### PR TITLE
feat(video): native-PAL videocap default build (issue #7)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,11 +85,29 @@ jobs:
       - name: Build firmware (ZZ9000OS.elf)
         run: ./build_firmware.sh
 
-      - name: Package release assets
+      - name: Package release assets (standard)
         run: |
           set -euo pipefail
           BUILD_LABEL="${GITHUB_REF_NAME//\//-}"
           ARGS=(--tag "$BUILD_LABEL" --output release_assets)
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            ARGS+=(--require-all)
+          fi
+          ./build_release_assets.sh "${ARGS[@]}"
+
+      # Alternate firmware flavor: native PAL Amiga ~49.92Hz videocap default.
+      # Same bitstream variants, different ZZ9000OS.elf build. See issue #7.
+      - name: Build firmware (ns-pal flavor)
+        run: |
+          set -euo pipefail
+          ./build_firmware.sh clean
+          EXTRA_CFLAGS=-DDEFAULT_NS_VIDEOCAP=1 ./build_firmware.sh
+
+      - name: Package release assets (ns-pal)
+        run: |
+          set -euo pipefail
+          BUILD_LABEL="${GITHUB_REF_NAME//\//-}"
+          ARGS=(--tag "$BUILD_LABEL" --output release_assets --firmware-flavor ns-pal)
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             ARGS+=(--require-all)
           fi

--- a/BUILD.md
+++ b/BUILD.md
@@ -50,9 +50,12 @@ This flips `video_init()` to default to 720x576 at the Amiga's native
 ~49.92 Hz and pre-enables `CARD_FEATURE_NONSTANDARD_VSYNC`, so videocap
 locks to the chipset rate from cold boot. CI also packages this as the
 `ns-pal` release flavor (e.g. `zz9000-firmware-<tag>-zorro3-ns-pal.zip`)
-alongside the standard archives. Not all HDMI sinks accept the
-non-standard timing — that's why the standard build keeps the 60 Hz
-default.
+alongside the standard archives. **PAL Amiga only**: the genlock clock
+defaults assume a PAL chipset master, so on an NTSC machine you'd see
+clock-mismatch artifacts until the host driver loads and corrects it
+— use the standard build there instead. Not all HDMI sinks accept the
+non-standard timing either, which is why the standard build keeps the
+60 Hz default.
 
 **Release variant bitstreams** — on the Vivado box:
 ```bash

--- a/BUILD.md
+++ b/BUILD.md
@@ -39,6 +39,21 @@ default. SD HDF boot and the Poseidon USB proxy remain enabled. For an
 old-driver regression test, rebuild firmware with
 `EXTRA_CFLAGS=-DENABLE_LEGACY_USB_BLOCK_STORAGE=1`.
 
+**Native-PAL videocap default (issue #7)** — for setups that boot
+without the host driver (no startup-sequence, floppy-only demo
+sessions), the standard 60 Hz videocap default produces visible
+stutter on PAL chipset output. Build with:
+```bash
+EXTRA_CFLAGS=-DDEFAULT_NS_VIDEOCAP=1 ./build_firmware.sh
+```
+This flips `video_init()` to default to 720x576 at the Amiga's native
+~49.92 Hz and pre-enables `CARD_FEATURE_NONSTANDARD_VSYNC`, so videocap
+locks to the chipset rate from cold boot. CI also packages this as the
+`ns-pal` release flavor (e.g. `zz9000-firmware-<tag>-zorro3-ns-pal.zip`)
+alongside the standard archives. Not all HDMI sinks accept the
+non-standard timing — that's why the standard build keeps the 60 Hz
+default.
+
 **Release variant bitstreams** — on the Vivado box:
 ```bash
 ./build_variant_bitstreams.sh

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
@@ -71,9 +71,21 @@ struct ZZ_VIDEO_STATE* video_get_state() {
 struct ZZ_VIDEO_STATE* video_init() {
 	vs.framebuffer = (u32*) FRAMEBUFFER_ADDRESS;
 
+#ifdef DEFAULT_NS_VIDEOCAP
+	// Driverless boot (no startup-sequence, floppy boot, etc.) never gets
+	// CARD_FEATURE_NONSTANDARD_VSYNC flipped on by the host driver, so
+	// videocap defaults to 800x600/60Hz scaling and PAL chipset output
+	// stutters from the rate mismatch. This variant defaults to the native
+	// PAL Amiga 720x576 / ~49.92Hz videocap path so demos look right out
+	// of cold boot. See issue #7.
+	vs.videocap_video_mode = ZZVMODE_720x576;
+	vs.video_mode = ZZVMODE_720x576 | 2 << 12 | MNTVA_COLOR_32BIT << 8;
+	vs.card_feature_enabled[CARD_FEATURE_NONSTANDARD_VSYNC] = 1;
+#else
 	// default to more compatible 60hz mode
 	vs.videocap_video_mode = ZZVMODE_800x600;
 	vs.video_mode = ZZVMODE_800x600 | 2 << 12 | MNTVA_COLOR_32BIT << 8;
+#endif
 	vs.colormode = 0;
 
 	video_reset();

--- a/build_release_assets.sh
+++ b/build_release_assets.sh
@@ -95,27 +95,6 @@ if [ ! -f ZZ9000_proto.sdk/ZZ9000OS/build/ZZ9000OS.elf ]; then
     exit 1
 fi
 
-mkdir -p "$OUT_DIR"
-if [ -n "$FIRMWARE_FLAVOR" ]; then
-    rm -f "$OUT_DIR"/zz9000-firmware-"$TAG"-*-"$FIRMWARE_FLAVOR".zip
-else
-    # Standard pass: clean only un-suffixed archives so a previous
-    # alternate-flavor pass in the same output dir is preserved.
-    for f in "$OUT_DIR"/zz9000-firmware-"$TAG"-*.zip; do
-        [ -e "$f" ] || continue
-        base=$(basename "$f" .zip)
-        # Skip archives that end with one of the known-flavor suffixes.
-        case "$base" in
-            *-ns-pal) continue ;;
-        esac
-        rm -f "$f"
-    done
-fi
-TMP_DIR="$OUT_DIR/.tmp"
-rm -rf "$TMP_DIR"
-mkdir -p "$TMP_DIR"
-trap 'rm -rf "$TMP_DIR"' EXIT
-
 variant_defs=(
     "zorro3|bootimage_work/zz9000_ps_wrapper.bit|Zorro III, A3000/A4000"
     "zorro3-nofast|bootimage_work/variants/zz9000_ps_wrapper-zorro3-nofast.bit|Zorro III, A3000/A4000, no Zorro RAM"
@@ -125,6 +104,22 @@ variant_defs=(
     "a500-2mb|bootimage_work/variants/zz9000_ps_wrapper-a500-2mb.bit|A500 2MB, ZZ9500CX Denise adapter"
     "a500plus|bootimage_work/variants/zz9000_ps_wrapper-a500plus.bit|A500+ or Super Denise, ZZ9500CX Denise adapter"
 )
+
+mkdir -p "$OUT_DIR"
+# Each pass deletes only the exact archive names it's about to (re)write,
+# so other-flavor passes in the same output dir aren't disturbed.
+for def in "${variant_defs[@]}"; do
+    IFS='|' read -r variant _ _ <<< "$def"
+    if [ -n "$FIRMWARE_FLAVOR" ]; then
+        rm -f "$OUT_DIR/zz9000-firmware-${TAG}-${variant}-${FIRMWARE_FLAVOR}.zip"
+    else
+        rm -f "$OUT_DIR/zz9000-firmware-${TAG}-${variant}.zip"
+    fi
+done
+TMP_DIR="$OUT_DIR/.tmp"
+rm -rf "$TMP_DIR"
+mkdir -p "$TMP_DIR"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 created=()
 missing=()

--- a/build_release_assets.sh
+++ b/build_release_assets.sh
@@ -16,17 +16,29 @@ cd "$SCRIPT_DIR"
 usage() {
     cat >&2 <<'EOF'
 Usage: ./build_release_assets.sh [--tag TAG] [--output DIR] [--require-all]
+                                 [--firmware-flavor SUFFIX]
 
 Options:
-  --tag TAG       Release/build label used in archive names (default: local)
-  --output DIR    Directory to write release assets into (default: release)
-  --require-all   Fail if any known variant bitstream is missing
+  --tag TAG               Release/build label used in archive names
+                          (default: local)
+  --output DIR            Directory to write release assets into
+                          (default: release)
+  --require-all           Fail if any known variant bitstream is missing
+  --firmware-flavor SUFFIX
+                          Append SUFFIX to each archive name, e.g. "ns-pal"
+                          produces zz9000-firmware-<tag>-<variant>-ns-pal.zip.
+                          Use this when packaging an alternate ZZ9000OS.elf
+                          flavor (the script does not rebuild firmware —
+                          the caller is expected to do that). Skips the
+                          canonical bootimage_work/BOOT.bin overwrite so the
+                          standard-flavor BOOT.bin remains the local default.
 EOF
 }
 
 TAG=local
 OUT_DIR=release
 REQUIRE_ALL=0
+FIRMWARE_FLAVOR=
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -52,6 +64,15 @@ while [ "$#" -gt 0 ]; do
             REQUIRE_ALL=1
             shift
             ;;
+        --firmware-flavor)
+            if [ "$#" -lt 2 ]; then
+                echo "ERROR: --firmware-flavor needs a value." >&2
+                usage
+                exit 1
+            fi
+            FIRMWARE_FLAVOR=$2
+            shift 2
+            ;;
         -h|--help)
             usage
             exit 0
@@ -75,7 +96,21 @@ if [ ! -f ZZ9000_proto.sdk/ZZ9000OS/build/ZZ9000OS.elf ]; then
 fi
 
 mkdir -p "$OUT_DIR"
-rm -f "$OUT_DIR"/zz9000-firmware-"$TAG"-*.zip
+if [ -n "$FIRMWARE_FLAVOR" ]; then
+    rm -f "$OUT_DIR"/zz9000-firmware-"$TAG"-*-"$FIRMWARE_FLAVOR".zip
+else
+    # Standard pass: clean only un-suffixed archives so a previous
+    # alternate-flavor pass in the same output dir is preserved.
+    for f in "$OUT_DIR"/zz9000-firmware-"$TAG"-*.zip; do
+        [ -e "$f" ] || continue
+        base=$(basename "$f" .zip)
+        # Skip archives that end with one of the known-flavor suffixes.
+        case "$base" in
+            *-ns-pal) continue ;;
+        esac
+        rm -f "$f"
+    done
+fi
 TMP_DIR="$OUT_DIR/.tmp"
 rm -rf "$TMP_DIR"
 mkdir -p "$TMP_DIR"
@@ -102,12 +137,18 @@ for def in "${variant_defs[@]}"; do
         continue
     fi
 
-    archive_dir="zz9000-firmware-${TAG}-${variant}"
+    if [ -n "$FIRMWARE_FLAVOR" ]; then
+        archive_dir="zz9000-firmware-${TAG}-${variant}-${FIRMWARE_FLAVOR}"
+        flavor_label=" [${FIRMWARE_FLAVOR}]"
+    else
+        archive_dir="zz9000-firmware-${TAG}-${variant}"
+        flavor_label=""
+    fi
     archive_root="$TMP_DIR/$archive_dir"
     boot_bin="$archive_root/BOOT.bin"
     zip_path="$OUT_DIR/${archive_dir}.zip"
 
-    echo "[release] building $variant: $label"
+    echo "[release] building $variant${flavor_label}: $label"
     mkdir -p "$archive_root"
     ./build_bootimage.sh --bitstream "$bitstream" --output "$boot_bin"
 
@@ -118,7 +159,9 @@ for def in "${variant_defs[@]}"; do
     )
     created+=("$zip_path")
 
-    if [ "$variant" = zorro3 ]; then
+    # Only the standard-flavor zorro3 build refreshes the canonical
+    # local BOOT.bin — alternate flavors are release artifacts only.
+    if [ "$variant" = zorro3 ] && [ -z "$FIRMWARE_FLAVOR" ]; then
         cp "$boot_bin" bootimage_work/BOOT.bin
     fi
 done


### PR DESCRIPTION
## Summary

- Adds a `-DDEFAULT_NS_VIDEOCAP=1` compile-time flag that flips `video_init()` defaults to `ZZVMODE_720x576` (native PAL Amiga ~49.92 Hz) and pre-enables `CARD_FEATURE_NONSTANDARD_VSYNC`, so videocap locks to the chipset rate from cold boot.
- CI now packages a parallel `ns-pal` release flavor of every variant archive (`zz9000-firmware-<tag>-<variant>-ns-pal.zip`) alongside the standard ones.
- BUILD.md documents the knob.

## Why

Per #7 — booting without a startup-sequence (or from floppy) means the host driver never runs, so `CARD_FEATURE_NONSTANDARD_VSYNC` is never enabled and videocap stays at 800x600/60Hz scaling. PAL chipset output stutters from the rate mismatch. Demos, in particular.

## What stays the same

- Standard build still defaults to the more compatible 800x600/60Hz path. Non-standard 49.92 Hz timing is not universally accepted by HDMI sinks, so this is opt-in via a separate release flavor.
- No bitstream change, no driver change.

## Test plan

- [x] `bash -n build_release_assets.sh` — clean
- [x] YAML lint of `.github/workflows/build.yml` — clean
- [x] CI green on standard firmware build
- [x] CI green on `ns-pal` firmware build
- [x] CI uploads both flavor sets of archives
- [ ] On a PAL Amiga, flash a `*-ns-pal` BOOT.bin, boot without startup-sequence, confirm chipset/demo output runs without rate-mismatch stutter
- [ ] On a NTSC-only HDMI sink, confirm the standard build (60 Hz) still works as before — no regression

Closes #7