### PR TITLE
fix(rtg): seed the line Bresenham accumulator so clipped segments resume

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/dma_rtg.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/dma_rtg.c
@@ -27,8 +27,14 @@ void handle_blitter_dma_op(struct ZZ_VIDEO_STATE* vs, uint16_t zdata)
                         data->user[0], (int16_t)data->user[3], data->rgb[0],
                         data->u8_user[GFXDATA_U8_COLORMODE]);
             else
+                /* The line pattern offset comes from the dedicated u8_user byte
+                 * (a single byte, so no byte order to reconcile). The driver
+                 * also packs it into user[2] for firmware that reads the word
+                 * form, but that field is deliberately NOT SWAP16'd here and is
+                 * unused on this path. */
                 draw_line(data->x[0], data->y[0], data->x[1], data->y[1],
-                        data->user[0], (int16_t)data->user[3], data->user[1], data->user[2], data->rgb[0], data->rgb[1],
+                        data->user[0], (int16_t)data->user[3], data->user[1],
+                        data->u8_user[GFXDATA_U8_LINE_PATTERN_OFFSET], data->rgb[0], data->rgb[1],
                         data->u8_user[GFXDATA_U8_COLORMODE], data->mask, data->u8_user[GFXDATA_U8_DRAWMODE]);
 
             break;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/dma_rtg.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/dma_rtg.c
@@ -14,6 +14,7 @@ void handle_blitter_dma_op(struct ZZ_VIDEO_STATE* vs, uint16_t zdata)
             SWAP16(data->x[0]);		SWAP16(data->x[1]);
             SWAP16(data->y[0]);		SWAP16(data->y[1]);
             SWAP16(data->user[0]);	SWAP16(data->user[1]);
+            SWAP16(data->user[3]);
 
             SWAP16(data->pitch[0]);
             SWAP32(data->offset[0]);
@@ -23,11 +24,11 @@ void handle_blitter_dma_op(struct ZZ_VIDEO_STATE* vs, uint16_t zdata)
 
             if (data->user[1] == 0xFFFF && data->mask == 0xFF)
                 draw_line_solid(data->x[0], data->y[0], data->x[1], data->y[1],
-                        data->user[0], data->rgb[0],
+                        data->user[0], (int16_t)data->user[3], data->rgb[0],
                         data->u8_user[GFXDATA_U8_COLORMODE]);
             else
                 draw_line(data->x[0], data->y[0], data->x[1], data->y[1],
-                        data->user[0], data->user[1], data->user[2], data->rgb[0], data->rgb[1],
+                        data->user[0], (int16_t)data->user[3], data->user[1], data->user[2], data->rgb[0], data->rgb[1],
                         data->u8_user[GFXDATA_U8_COLORMODE], data->mask, data->u8_user[GFXDATA_U8_DRAWMODE]);
 
             break;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.c
@@ -563,6 +563,7 @@ void copy_rect(uint16_t rect_x1, uint16_t rect_y1, uint16_t w, uint16_t h, uint1
 
 // Sneakily adapted version of the good old Bresenham algorithm
 void draw_line(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint16_t len,
+	int16_t err_seed,
 	uint16_t pattern, uint16_t pattern_offset,
 	uint32_t fg_color, uint32_t bg_color, uint32_t color_format,
 	uint8_t mask, uint8_t draw_mode)
@@ -577,10 +578,11 @@ void draw_line(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y
 	int32_t line_step = fb_pitch;
 	int8_t x_reverse = 0, inversion = 0;
 
-	uint16_t cur_bit = 0x8000;
+	/* PatternShift selects which pattern bit maps to the segment start. */
+	uint16_t cur_bit = (uint16_t)(0x8000u >> (pattern_offset & 15));
 
 	int32_t dx, dy, x = x1;
-	uint32_t dx_abs, dy_abs, ix, iy, draw_len = len;
+	uint32_t dx_abs, dy_abs, draw_len = len;
 
 	if (x2 < x1)
 		x_reverse = 1;
@@ -599,47 +601,45 @@ void draw_line(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y
 	dy = y2 - y1;
 	dx_abs = (dx < 0) ? (uint32_t)-dx : (uint32_t)dx;
 	dy_abs = (dy < 0) ? (uint32_t)-dy : (uint32_t)dy;
-	ix = dy_abs >> 1;
-	iy = dx_abs >> 1;
-
-	// This can't be used for now, as Flags from the current RastPort struct is not exposed by [ P96 2.4.2 ]
-	/*if ((pattern_offset >> 8) & 0x01) { // Is FRST_DOT set?
-		cur_bit = 0x8000;
-		fg_color = 0xFFFF0000;
-	}
-	else {
-		fg_color = 0xFF00FF00;
-		cur_bit >>= ((pattern_offset & 0xFF) % 16);
-	}
-	
-	if (cur_bit == 0)
-		cur_bit = 0x8000;*/
-
 
 	DRAW_LINE_PIXEL;
 
+	/* P96 round-half-up Bresenham, seeded with the accumulator at the segment
+	 * start (err_seed = S*k - L*m + L/2 == (S*k + L/2) mod L, in [0, L); L/2 for
+	 * an unclipped line). Each major step adds S to the accumulator; once it
+	 * reaches L it wraps (subtract L) and a minor step is taken. The L/2 seed
+	 * bias makes the staircase round-half-up (minor offset = floor((2*i*S+L) /
+	 * (2*L)), ties up), which matches DrawLineDefault pixel-for-pixel on ZZ9000
+	 * hardware (plain truncation, seed 0, was consistently 1px off). Seeding
+	 * from err_seed resumes a clipped line exactly where P96 left off. */
 	if (dx_abs >= dy_abs) {
-		if (!draw_len) draw_len = dx_abs;
+		int32_t s = (int32_t)dy_abs;
+		int32_t l = (int32_t)dx_abs;
+		int32_t e = err_seed;
 		for (uint32_t i = 0; i < draw_len; i++) {
-			iy += dy_abs;
-			if (iy >= dx_abs) {
-				iy -= dx_abs;
-				dp += line_step;
-			}
+			e += s;
+			int minor = (e >= l);
+			if (minor)
+				e -= l;
 			x += (x_reverse) ? -1 : 1;
+			if (minor)
+				dp += line_step;
 
 			DRAW_LINE_PIXEL;
 		}
 	}
 	else {
-		if (!draw_len) draw_len = dy_abs;
-		for(uint32_t i = 0; i < draw_len; i++) {
-			ix += dx_abs;
-			if (ix >= dy_abs) {
-				ix -= dy_abs;
-				x += (x_reverse) ? -1 : 1;
-			}
+		int32_t s = (int32_t)dx_abs;
+		int32_t l = (int32_t)dy_abs;
+		int32_t e = err_seed;
+		for (uint32_t i = 0; i < draw_len; i++) {
+			e += s;
+			int minor = (e >= l);
+			if (minor)
+				e -= l;
 			dp += line_step;
+			if (minor)
+				x += (x_reverse) ? -1 : 1;
 
 			DRAW_LINE_PIXEL;
 		}
@@ -647,7 +647,7 @@ void draw_line(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y
 }
 
 void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint16_t len,
-	uint32_t fg_color, uint32_t color_format)
+	int16_t err_seed, uint32_t fg_color, uint32_t color_format)
 {
 	int32_t x1 = rect_x1, y1 = rect_y1;
 	int32_t x2 = x1 + (int32_t)rect_x2, y2 = y1 + (int32_t)rect_y2;
@@ -659,7 +659,7 @@ void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t 
 	int8_t x_reverse = 0;
 
 	int32_t dx, dy, x = x1;
-	uint32_t dx_abs, dy_abs, ix, iy, draw_len = len;
+	uint32_t dx_abs, dy_abs, draw_len = len;
 
 	if (x2 < x1)
 		x_reverse = 1;
@@ -671,8 +671,6 @@ void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t 
 	dx_abs = (dx < 0) ? (uint32_t)-dx : (uint32_t)dx;
 	dy_abs = (dy < 0) ? (uint32_t)-dy : (uint32_t)dy;
 
-	if (!draw_len)
-		draw_len = (dx_abs >= dy_abs) ? dx_abs : dy_abs;
 	if (dx_abs == 0) {
 		draw_vertical_line_solid(dp, x, line_step, draw_len + 1,
 			fg_color, u8_fg, color_format);
@@ -684,23 +682,35 @@ void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t 
 		return;
 	}
 
-	ix = dy_abs >> 1;
-	iy = dx_abs >> 1;
+	/* Same seeded P96 round-half-up Bresenham as draw_line (see there): each
+	 * major step adds S; when the accumulator reaches L it wraps and a minor
+	 * step is taken; seeded from err_seed (which carries the L/2 round-half-up
+	 * bias) so clipped segments resume exactly. */
+	int32_t s, l;
+	if (dx_abs >= dy_abs) {
+		s = (int32_t)dy_abs;
+		l = (int32_t)dx_abs;
+	} else {
+		s = (int32_t)dx_abs;
+		l = (int32_t)dy_abs;
+	}
 
 	switch (color_format) {
 	case MNTVA_COLOR_8BIT:
 		((uint8_t *)dp)[x] = u8_fg;
 		if (dx_abs >= dy_abs) {
+			int32_t e = err_seed;
 			for (uint32_t i = 0; i < draw_len; i++) {
-				iy += dy_abs;
-				if (iy >= dx_abs) { iy -= dx_abs; dp += line_step; }
+				e += s;
+				if (e >= l) { e -= l; dp += line_step; }
 				x += (x_reverse) ? -1 : 1;
 				((uint8_t *)dp)[x] = u8_fg;
 			}
 		} else {
+			int32_t e = err_seed;
 			for (uint32_t i = 0; i < draw_len; i++) {
-				ix += dx_abs;
-				if (ix >= dy_abs) { ix -= dy_abs; x += (x_reverse) ? -1 : 1; }
+				e += s;
+				if (e >= l) { e -= l; x += (x_reverse) ? -1 : 1; }
 				dp += line_step;
 				((uint8_t *)dp)[x] = u8_fg;
 			}
@@ -710,16 +720,18 @@ void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t 
 	case MNTVA_COLOR_15BIT:
 		((uint16_t *)dp)[x] = fg_color;
 		if (dx_abs >= dy_abs) {
+			int32_t e = err_seed;
 			for (uint32_t i = 0; i < draw_len; i++) {
-				iy += dy_abs;
-				if (iy >= dx_abs) { iy -= dx_abs; dp += line_step; }
+				e += s;
+				if (e >= l) { e -= l; dp += line_step; }
 				x += (x_reverse) ? -1 : 1;
 				((uint16_t *)dp)[x] = fg_color;
 			}
 		} else {
+			int32_t e = err_seed;
 			for (uint32_t i = 0; i < draw_len; i++) {
-				ix += dx_abs;
-				if (ix >= dy_abs) { ix -= dy_abs; x += (x_reverse) ? -1 : 1; }
+				e += s;
+				if (e >= l) { e -= l; x += (x_reverse) ? -1 : 1; }
 				dp += line_step;
 				((uint16_t *)dp)[x] = fg_color;
 			}
@@ -728,16 +740,18 @@ void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t 
 	case MNTVA_COLOR_32BIT:
 		dp[x] = fg_color;
 		if (dx_abs >= dy_abs) {
+			int32_t e = err_seed;
 			for (uint32_t i = 0; i < draw_len; i++) {
-				iy += dy_abs;
-				if (iy >= dx_abs) { iy -= dx_abs; dp += line_step; }
+				e += s;
+				if (e >= l) { e -= l; dp += line_step; }
 				x += (x_reverse) ? -1 : 1;
 				dp[x] = fg_color;
 			}
 		} else {
+			int32_t e = err_seed;
 			for (uint32_t i = 0; i < draw_len; i++) {
-				ix += dx_abs;
-				if (ix >= dy_abs) { ix -= dy_abs; x += (x_reverse) ? -1 : 1; }
+				e += s;
+				if (e >= l) { e -= l; x += (x_reverse) ? -1 : 1; }
 				dp += line_step;
 				dp[x] = fg_color;
 			}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
@@ -59,8 +59,8 @@ void pattern_fill_rect(uint32_t color_format, uint16_t rect_x1, uint16_t rect_y1
 	uint16_t x_offset, uint16_t y_offset,
 	uint8_t *tmpl_data, uint16_t tmpl_pitch, uint16_t loop_rows);
 
-void draw_line(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint16_t len, uint16_t pattern, uint16_t pattern_offset, uint32_t fg_color, uint32_t bg_color, uint32_t color_format, uint8_t mask, uint8_t draw_mode);
-void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint16_t len, uint32_t fg_color, uint32_t color_format);
+void draw_line(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint16_t len, int16_t err_seed, uint16_t pattern, uint16_t pattern_offset, uint32_t fg_color, uint32_t bg_color, uint32_t color_format, uint8_t mask, uint8_t draw_mode);
+void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint16_t len, int16_t err_seed, uint32_t fg_color, uint32_t color_format);
 
 void p2c_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy, int16_t w, int16_t h, uint8_t draw_mode, uint8_t planes, uint8_t mask, uint8_t layer_mask, uint16_t src_line_pitch, uint8_t *bmp_data_src);
 void p2d_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy, int16_t w, int16_t h, uint8_t draw_mode, uint8_t planes, uint8_t mask, uint8_t layer_mask, uint32_t color_mask, uint16_t src_line_pitch, uint8_t *bmp_data_src, uint32_t color_format);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -362,6 +362,7 @@ int main() {
 	uint16_t blitter_src_pitch = 0;
 	uint16_t blitter_user1 = 0;
 	uint16_t blitter_user2 = 0;
+	int16_t blitter_user3 = 0;	// line Bresenham work-variable seed
 
 	// custom video mode
 	int custom_video_mode = ZZVMODE_CUSTOM;
@@ -685,7 +686,7 @@ int main() {
 					blitter_user2 = zdata;
 					break;
 				case REG_ZZ_USER3:
-					// FIXME unused
+					blitter_user3 = (int16_t)zdata;
 					break;
 				case REG_ZZ_USER4:
 					// FIXME unused
@@ -914,11 +915,11 @@ int main() {
 
 					if (rect_x3 == 0xFFFF && zdata == 0xFF)
 						draw_line_solid(rect_x1, rect_y1, rect_x2, rect_y2,
-								blitter_user1, rect_rgb,
+								blitter_user1, blitter_user3, rect_rgb,
 								blitter_colormode);
 					else
 						draw_line(rect_x1, rect_y1, rect_x2, rect_y2,
-								blitter_user1, rect_x3, rect_y3, rect_rgb,
+								blitter_user1, blitter_user3, rect_x3, rect_y3, rect_rgb,
 								rect_rgb2, blitter_colormode, zdata,
 								draw_mode);
 					break;

--- a/test/rtg/rtg_regression.c
+++ b/test/rtg/rtg_regression.c
@@ -356,6 +356,33 @@ static void ref_draw_line_oracle(int ox, int oy, int dx, int dy,
 	}
 }
 
+/* As ref_draw_line_oracle, but skips pixels outside the framebuffer so a line
+ * whose origin is off-screen (a negative Xorigin/Yorigin from top/left clipping)
+ * marks only its on-screen part. put_pixel itself does not bounds-check, so the
+ * clipping lives here rather than in the shared helper. */
+static void ref_draw_line_oracle_clipped(int ox, int oy, int dx, int dy,
+	uint32_t color, uint32_t color_format)
+{
+	int dxa = dx < 0 ? -dx : dx;
+	int dya = dy < 0 ? -dy : dy;
+	int horiz = dxa >= dya;
+	int L = horiz ? dxa : dya;
+	int S = horiz ? dya : dxa;
+	int sx = dx < 0 ? -1 : 1;
+	int sy = dy < 0 ? -1 : 1;
+	uint32_t pixel = color_to_pixel(color_format, color);
+	int Ldiv = L > 0 ? L : 1;
+
+	for (int i = 0; i <= L; i++) {
+		int minor = (2 * i * S + L) / (2 * Ldiv);
+		int x = horiz ? ox + sx * i : ox + sx * minor;
+		int y = horiz ? oy + sy * minor : oy + sy * i;
+		if (x < 0 || x >= FB_W || y < 0 || y >= FB_H)
+			continue;
+		put_pixel(expected_fb, FB_PITCH_WORDS, x, y, color_format, pixel);
+	}
+}
+
 /* Oracle pixel at major index i (0..L) of the line from (ox,oy), deltas (dx,dy). */
 static void oracle_point(int ox, int oy, int dx, int dy, int i, int *px, int *py)
 {
@@ -727,6 +754,40 @@ static void test_lines_clipped(void)
 	}
 }
 
+static void test_lines_negative_origin(void)
+{
+	/* A line clipped at the top/left has its true start above/left of the
+	 * RenderInfo, so P96 hands DrawLine a NEGATIVE Xorigin/Yorigin. err_seed is
+	 * computed from (segment_start - origin), so the origin must be treated as
+	 * signed (the driver's field is UWORD and has to be cast through WORD, or
+	 * -8 reads as 65528 and the seed is wrong). P96 clips segment A away and
+	 * only asks for the on-screen segment B, which must still match the
+	 * on-screen part of the whole line drawn from the negative origin. */
+	int ox = 20, oy = -10, dx = 14, dy = 28, L = 28;
+	int k = -oy;			/* major steps before the line reaches y = 0 */
+	int bx, by;
+
+	oracle_point(ox, oy, dx, dy, k, &bx, &by);
+
+	seed_frame(0x3500);
+	draw_line_solid(bx, by, dx, dy, L - k,
+		p96_err_seed(dx, dy, bx, by, ox, oy),
+		0xc4000000, MNTVA_COLOR_8BIT);
+	ref_draw_line_oracle_clipped(ox, oy, dx, dy, 0xc4000000, MNTVA_COLOR_8BIT);
+	check_frame("draw_line negative-origin clip resumes");
+
+	/* Guard the signedness directly: promoting the origin unsigned (the bug)
+	 * must change the seed, otherwise the WORD cast in the driver is moot. */
+	if (p96_err_seed(dx, dy, bx, by, ox, oy) ==
+	    p96_err_seed(dx, dy, bx, by, ox, (int)(uint16_t)oy)) {
+		printf("FAIL %-30s unsigned origin leaves the seed unchanged\n",
+			"negative-origin sign");
+		failures++;
+	} else {
+		printf("ok   negative-origin seed is sign-sensitive\n");
+	}
+}
+
 static void test_lines_pattern(void)
 {
 	/* A dotted (JAM2) line split at an interior point must reassemble exactly.
@@ -1091,6 +1152,7 @@ static void run_tests(void)
 	test_copy();
 	test_lines();
 	test_lines_clipped();
+	test_lines_negative_origin();
 	test_lines_pattern();
 	test_planar();
 	test_p2d();

--- a/test/rtg/rtg_regression.c
+++ b/test/rtg/rtg_regression.c
@@ -327,6 +327,108 @@ static void ref_draw_line_solid(int16_t x1, int16_t y1, int16_t x2_delta, int16_
 	}
 }
 
+/* Independent oracle for the P96 line contract (no shared code with the
+ * firmware recurrence): pixel i (i = 0..L) of a line from (ox,oy) with deltas
+ * (dx,dy) sits at minor offset floor((2*i*S + L) / (2*L)) == round(i*S/L) with
+ * ties going up. DrawLineDefault uses round-half-up: verified on ZZ9000
+ * hardware (the RoundCheck test drew DrawLineDefault beside both candidate
+ * staircases; round-half-up matched pixel-for-pixel, truncation was 1px off).
+ * The wiki's sExtend formula reduces to floor(i*S/L), but that describes the
+ * minor EXTENT used for clip rectangles, not the per-pixel stepping. */
+static void ref_draw_line_oracle(int ox, int oy, int dx, int dy,
+	uint32_t color, uint32_t color_format)
+{
+	int dxa = dx < 0 ? -dx : dx;
+	int dya = dy < 0 ? -dy : dy;
+	int horiz = dxa >= dya;
+	int L = horiz ? dxa : dya;
+	int S = horiz ? dya : dxa;
+	int sx = dx < 0 ? -1 : 1;
+	int sy = dy < 0 ? -1 : 1;
+	uint32_t pixel = color_to_pixel(color_format, color);
+	int Ldiv = L > 0 ? L : 1;
+
+	for (int i = 0; i <= L; i++) {
+		int minor = (2 * i * S + L) / (2 * Ldiv);
+		int x = horiz ? ox + sx * i : ox + sx * minor;
+		int y = horiz ? oy + sy * minor : oy + sy * i;
+		put_pixel(expected_fb, FB_PITCH_WORDS, x, y, color_format, pixel);
+	}
+}
+
+/* Oracle pixel at major index i (0..L) of the line from (ox,oy), deltas (dx,dy). */
+static void oracle_point(int ox, int oy, int dx, int dy, int i, int *px, int *py)
+{
+	int dxa = dx < 0 ? -dx : dx;
+	int dya = dy < 0 ? -dy : dy;
+	int horiz = dxa >= dya;
+	int L = horiz ? dxa : dya;
+	int S = horiz ? dya : dxa;
+	int sx = dx < 0 ? -1 : 1;
+	int sy = dy < 0 ? -1 : 1;
+	int Ldiv = L > 0 ? L : 1;
+	int minor = (2 * i * S + L) / (2 * Ldiv);
+
+	*px = horiz ? ox + sx * i : ox + sx * minor;
+	*py = horiz ? oy + sy * minor : oy + sy * i;
+}
+
+/* Compare actual vs expected without the per-case "ok" chatter; returns 1 on
+ * mismatch. */
+static int frames_differ(void)
+{
+	return memcmp(actual_fb, expected_fb, sizeof(actual_fb)) != 0;
+}
+
+/* Work-variable seed the driver computes for a line segment: the round-half-up
+ * Bresenham accumulator at the segment start, derived from geometry in
+ * magnitudes so it is octant-independent (the signed twoSDminusLD is not used).
+ * For a segment starting k major / m minor units from the origin, the
+ * accumulator is e = S*k - L*m + L/2 == (S*k + L/2) mod L, in [0, L); L/2 for
+ * an unclipped line. The L/2 bias is what makes the staircase round-half-up
+ * (matching DrawLineDefault). The firmware does e += S; if (e >= L) { e -= L;
+ * minor-step; }. */
+static int32_t p96_err_seed(int dx, int dy, int seg_x, int seg_y, int ox, int oy)
+{
+	int dxa = dx < 0 ? -dx : dx;
+	int dya = dy < 0 ? -dy : dy;
+	int horiz = dxa >= dya;
+	int L = horiz ? dxa : dya;
+	int S = horiz ? dya : dxa;
+	int dmajor = horiz ? seg_x - ox : seg_y - oy;
+	int dminor = horiz ? seg_y - oy : seg_x - ox;
+	int k = dmajor < 0 ? -dmajor : dmajor;
+	int m = dminor < 0 ? -dminor : dminor;
+	return S * k - L * m + L / 2;
+}
+
+/* Oracle for a patterned (JAM2) line: pixel i uses pattern bit
+ * 0x8000 >> ((pattern_shift + i) & 15); foreground where set, background where
+ * clear. The geometry is the same independent Bresenham oracle as above. */
+static void ref_draw_line_pattern_oracle(int ox, int oy, int dx, int dy,
+	uint16_t pattern, int pattern_shift, uint32_t fg, uint32_t bg,
+	uint32_t color_format)
+{
+	int dxa = dx < 0 ? -dx : dx;
+	int dya = dy < 0 ? -dy : dy;
+	int horiz = dxa >= dya;
+	int L = horiz ? dxa : dya;
+	int S = horiz ? dya : dxa;
+	int sx = dx < 0 ? -1 : 1;
+	int sy = dy < 0 ? -1 : 1;
+	int Ldiv = L > 0 ? L : 1;
+	uint32_t fgp = color_to_pixel(color_format, fg);
+	uint32_t bgp = color_to_pixel(color_format, bg);
+
+	for (int i = 0; i <= L; i++) {
+		int minor = (2 * i * S + L) / (2 * Ldiv);
+		int x = horiz ? ox + sx * i : ox + sx * minor;
+		int y = horiz ? oy + sy * minor : oy + sy * i;
+		int on = (pattern & (0x8000 >> ((pattern_shift + i) & 15))) != 0;
+		put_pixel(expected_fb, FB_PITCH_WORDS, x, y, color_format, on ? fgp : bgp);
+	}
+}
+
 static uint8_t ref_planar_pixel(const uint8_t *plane_data, uint8_t planes,
 	uint8_t layer_mask, uint16_t src_line_pitch, int h, int sx, int sy,
 	int x, int y, int invert)
@@ -536,19 +638,131 @@ static void test_copy(void)
 static void test_lines(void)
 {
 	seed_frame(0x3001);
-	draw_line_solid(4, 8, 42, 0, 0, 0xde000000, MNTVA_COLOR_8BIT);
-	ref_draw_line_solid(4, 8, 42, 0, 0, 0xde000000, MNTVA_COLOR_8BIT);
+	draw_line_solid(4, 8, 42, 0, 42, p96_err_seed(42, 0, 4, 8, 4, 8), 0xde000000, MNTVA_COLOR_8BIT);
+	ref_draw_line_solid(4, 8, 42, 0, 42, 0xde000000, MNTVA_COLOR_8BIT);
 	check_frame("draw_line_solid hline 8");
 
 	seed_frame(0x3002);
-	draw_line_solid(18, 3, 0, 31, 0, 0x00001234, MNTVA_COLOR_16BIT565);
-	ref_draw_line_solid(18, 3, 0, 31, 0, 0x00001234, MNTVA_COLOR_16BIT565);
+	draw_line_solid(18, 3, 0, 31, 31, p96_err_seed(0, 31, 18, 3, 18, 3), 0x00001234, MNTVA_COLOR_16BIT565);
+	ref_draw_line_solid(18, 3, 0, 31, 31, 0x00001234, MNTVA_COLOR_16BIT565);
 	check_frame("draw_line_solid vline 16");
 
 	seed_frame(0x3003);
-	draw_line_solid(9, 6, 25, 25, 0, 0xff884422, MNTVA_COLOR_32BIT);
-	ref_draw_line_solid(9, 6, 25, 25, 0, 0xff884422, MNTVA_COLOR_32BIT);
+	draw_line_solid(9, 6, 25, 25, 25, p96_err_seed(25, 25, 9, 6, 9, 6), 0xff884422, MNTVA_COLOR_32BIT);
+	ref_draw_line_solid(9, 6, 25, 25, 25, 0xff884422, MNTVA_COLOR_32BIT);
 	check_frame("draw_line_solid diag 32");
+
+	/* Steep (major-Y, dy_abs > dx_abs) solid lines exercise the otherwise
+	 * untested major-Y branch of draw_line_solid - the 45-degree "diag" case
+	 * above takes the major-X branch. Slope 2:1 makes the round-half-up staircase
+	 * unambiguous; both step directions are covered. */
+	seed_frame(0x3004);
+	draw_line_solid(20, 4, 14, 28, 28, p96_err_seed(14, 28, 20, 4, 20, 4), 0x000089ab, MNTVA_COLOR_16BIT565);
+	ref_draw_line_oracle(20, 4, 14, 28, 0x000089ab, MNTVA_COLOR_16BIT565);
+	check_frame("draw_line_solid steep 2:1 major-Y down");
+
+	seed_frame(0x3005);
+	draw_line_solid(60, 40, 14, -28, 28, p96_err_seed(14, -28, 60, 40, 60, 40), 0xaa113355, MNTVA_COLOR_32BIT);
+	ref_draw_line_oracle(60, 40, 14, -28, 0xaa113355, MNTVA_COLOR_32BIT);
+	check_frame("draw_line_solid steep 2:1 major-Y up");
+}
+
+static void test_lines_clipped(void)
+{
+	/* Full odd-major line must match the independent round-half-up oracle. An
+	 * odd L is where round-half-up and truncation diverge, so this pins the
+	 * firmware to DrawLineDefault's exact staircase (unclipped seed L/2) and
+	 * guards against a regression back to truncation (seed 0). */
+	{
+		int ox = 6, oy = 9, dx = 31, dy = 13;	/* L=31 (odd), S=13 */
+		seed_frame(0x3101);
+		draw_line_solid(ox, oy, dx, dy, 31,
+			p96_err_seed(dx, dy, ox, oy, ox, oy),
+			0xc4000000, MNTVA_COLOR_8BIT);
+		ref_draw_line_oracle(ox, oy, dx, dy, 0xc4000000, MNTVA_COLOR_8BIT);
+		check_frame("draw_line_solid full odd-L == oracle");
+	}
+
+	/* The P96 clipping contract: a line split into two segments at ANY interior
+	 * point must reassemble into exactly the same pixels as the whole line.
+	 * Segment B starts mid-line, so it only renders correctly if the firmware
+	 * resumes the staircase from err_seed rather than restarting at (X,Y). A
+	 * single clip point can accidentally land on an aligned phase, so sweep
+	 * every clip point of several octants. */
+	{
+		static const int dxs[] = { 31, 17, 40, -33, 25, 9, -40 };
+		static const int dys[] = { 13, 30, 9, 23, -25, -30, -7 };
+		int ox = 48, oy = 36;	/* center, so negative octants stay in-bounds */
+		unsigned bad = 0, total = 0;
+
+		for (size_t t = 0; t < sizeof(dxs) / sizeof(dxs[0]); t++) {
+			int dx = dxs[t], dy = dys[t];
+			int dxa = dx < 0 ? -dx : dx, dya = dy < 0 ? -dy : dy;
+			int L = dxa >= dya ? dxa : dya;
+
+			for (int k = 1; k < L; k++) {
+				int bx, by;
+				oracle_point(ox, oy, dx, dy, k, &bx, &by);
+				seed_frame(0x3200u + (uint32_t)(t * 64 + k));
+				draw_line_solid(ox, oy, dx, dy, k,
+					p96_err_seed(dx, dy, ox, oy, ox, oy),
+					0xc4000000, MNTVA_COLOR_8BIT);
+				draw_line_solid(bx, by, dx, dy, L - k,
+					p96_err_seed(dx, dy, bx, by, ox, oy),
+					0xc4000000, MNTVA_COLOR_8BIT);
+				ref_draw_line_oracle(ox, oy, dx, dy, 0xc4000000, MNTVA_COLOR_8BIT);
+				total++;
+				if (frames_differ())
+					bad++;
+			}
+		}
+
+		if (bad) {
+			printf("FAIL %-30s %u/%u clip points mismatch the whole line\n",
+				"draw_line split == whole", bad, total);
+			failures++;
+		} else {
+			printf("ok   draw_line split == whole (%u clip points)\n", total);
+		}
+	}
+}
+
+static void test_lines_pattern(void)
+{
+	/* A dotted (JAM2) line split at an interior point must reassemble exactly.
+	 * Beyond the staircase seed this also requires the firmware to resume the
+	 * dot pattern mid-line via cur_bit = 0x8000 >> PatternShift; segment B's
+	 * PatternShift advances by the major-step count of segment A. */
+	int ox = 20, oy = 30, dx = 37, dy = 15, L = 37, shift0 = 3;
+	uint16_t pat = 0xCCCC;
+	unsigned bad = 0, total = 0;
+
+	for (int k = 1; k < L; k++) {
+		int bx, by;
+		oracle_point(ox, oy, dx, dy, k, &bx, &by);
+		seed_frame(0x3400u + (uint32_t)k);
+		draw_line(ox, oy, dx, dy, k,
+			p96_err_seed(dx, dy, ox, oy, ox, oy),
+			pat, shift0, 0xaa000000, 0x55000000,
+			MNTVA_COLOR_8BIT, 0xFF, JAM2);
+		draw_line(bx, by, dx, dy, L - k,
+			p96_err_seed(dx, dy, bx, by, ox, oy),
+			pat, (shift0 + k) & 15, 0xaa000000, 0x55000000,
+			MNTVA_COLOR_8BIT, 0xFF, JAM2);
+		ref_draw_line_pattern_oracle(ox, oy, dx, dy, pat, shift0,
+			0xaa000000, 0x55000000, MNTVA_COLOR_8BIT);
+		total++;
+		if (frames_differ())
+			bad++;
+	}
+
+	if (bad) {
+		printf("FAIL %-30s %u/%u clip points mismatch the dotted line\n",
+			"draw_line pattern split", bad, total);
+		failures++;
+	} else {
+		printf("ok   draw_line pattern split == whole (%u clip points)\n", total);
+	}
 }
 
 static void test_planar(void)
@@ -876,6 +1090,8 @@ static void run_tests(void)
 	test_fill_and_invert();
 	test_copy();
 	test_lines();
+	test_lines_clipped();
+	test_lines_pattern();
 	test_planar();
 	test_p2d();
 	test_template();


### PR DESCRIPTION
## Summary

Makes the firmware line drawer resume a **clipped segment** of a larger line exactly, so the driver can hardware-accelerate clipped and patterned RTG lines instead of falling back to the CPU. Verified pixel-for-pixel against P96's `DrawLineDefault` on ZZ9000 hardware.

Driver side: `BlitterStudio/zz9000-drivers` branch `fix/rtg-line-clipping-hwaccel`.

## Background

P96 hands `DrawLine` a segment of a larger (possibly clipped) line: `X,Y` is the segment start, `Length` its major-axis extent, `dX,dY` the full line delta, `Xorigin,Yorigin` the whole line's start. To render a mid-line segment correctly the Bresenham accumulator (and the dot pattern) must resume from the segment-start state, not restart at `X,Y`.

## What changed

- **Seeded accumulator.** `draw_line` / `draw_line_solid` now seed the minor-axis accumulator from a new `err_seed` parameter (`e = err_seed; e += S; if (e >= L) { e -= L; minor-step; }`) instead of the fixed `iy = dx>>1`. The driver computes `err_seed` from segment geometry and seeds `L/2` at the line origin, making the staircase **round-half-up** — which matches `DrawLineDefault` pixel-for-pixel. (Truncation / seed-0 was consistently 1px off on steep lines.)
- **Honor `Length`.** Dropped the `len == 0 -> full extent` fallback that drew the whole line and overshot the window on fully-clipped lines.
- **Pattern.** Apply `PatternShift` to the dot pattern (`cur_bit = 0x8000 >> (offset & 15)`).
- **Plumbing.** Receive `err_seed` via `blitter_user3` (Z2) and `gfxdata->user[3]` (Z3, `SWAP16`).

## Testing

New host regression harness under `test/rtg` compiles the production `gfx.c` against an independent round-half-up oracle and sweeps every interior clip point:

- clipped split == whole line (222 clip points), patterned split (36), full odd-L, both step directions;
- plus rect fill/invert, copy, p2c, p2d, template, acc blit/clear, and fb-limit clamp coverage.

Run `make -C test/rtg test` — 35 cases, all green. Builds locally via the `gcc:13` Docker image.

The firmware binary is unchanged by the driver-side rounding/pattern fixes (those live entirely in the driver); this PR is the seed/pattern support the driver builds on, plus the corrected host oracle.
