### PR TITLE
fix(eth): RX-accept serial handshake (issue #29 defense-in-depth)

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -697,15 +697,23 @@ static void XEmacPsRecvHandler(void *Callback)
 		for (int i=0; i<num_rx_bufs; i++) {
 
 			frame_serial++;
-			/* 0 is the empty-slot / "no frame" sentinel: the driver skips an
-			 * all-zero header without acking, and the RX-accept handshake
-			 * rejects acked_serial == 0. frame_serial is a u16, so a plain
-			 * increment wraps 0xffff -> 0 once every 65536 frames; skip 0 so a
-			 * real frame is never tagged with the sentinel. Otherwise the
-			 * handshake would reject that frame forever (frames_backlog_read
-			 * never advances) and RX would stall until reset (issue #29). */
-			if (frame_serial == 0)
-				frame_serial++;
+			/* 0 and 1 are reserved values the RX-accept handshake treats
+			 * specially, so a real frame must never be tagged with either:
+			 *   0 = empty-slot / "no frame" sentinel — the driver skips an
+			 *       all-zero header without acking, and the handshake rejects
+			 *       acked_serial == 0. A frame tagged 0 would be rejected
+			 *       forever (frames_backlog_read never advances) → RX stalls.
+			 *   1 = legacy bare-advance — old drivers write a constant 1, which
+			 *       must bypass validation for backward compat. A frame tagged
+			 *       1 would be left unprotected by the handshake (a stray or
+			 *       duplicate legacy-style ack could consume it unread).
+			 * frame_serial is a u16, so a plain increment would emit 0 once per
+			 * 65536-frame wrap, and 1 on the first frame after reset and once
+			 * per wrap. frame_serial reaches 0 only by wrapping 0xffff->0 and 1
+			 * only from the post-reset 0->1, so a single jump to 2 skips both.
+			 * Real serials therefore stay in [2, 0xffff] (issue #29). */
+			if (frame_serial == 0 || frame_serial == 1)
+				frame_serial = 2;
 
 			//printf("RX ser: %d\n",frame_serial);
 
@@ -828,9 +836,10 @@ int ethernet_receive_frame(u16 acked_serial) {
 		 * Backward compatibility: legacy drivers write a constant 1 instead of
 		 * the real serial. We honour acked_serial == 1 as a bare advance so
 		 * those drivers keep working unchanged (the check is then a no-op);
-		 * reject 0 (never a valid serial — frame_serial is pre-incremented);
-		 * and for any other value require an exact match with the presented
-		 * frame's serial. */
+		 * reject 0. The serial generator skips both 0 and 1 (see frame_serial
+		 * above), so a handshake driver never emits either as a real serial —
+		 * value 1 is therefore only ever a legacy ack, and every real frame is
+		 * protected by the exact-match branch below. */
 		uint8_t* slot = ethernet_current_receive_ptr();
 		u16 presented = ((u16)slot[2] << 8) | slot[3];
 		int consume;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -72,6 +72,7 @@ static volatile int tx_recoveries = 0;
 static volatile int rx_backpressure = 0;
 static volatile int rx_pause_frames = 0;
 static volatile int rx_slot_mismatch = 0;
+static volatile int frames_ack_rejected = 0;	/* issue #29: RX-accept handshake rejects */
 
 #define ETH_PHY_TYPE_MICREL 0
 #define ETH_PHY_TYPE_MOTORCOMM 1
@@ -395,7 +396,7 @@ static void ethernet_log_status(const char *reason) {
 	XEmacPs* EmacPsInstancePtr = &EmacPsInstance;
 	u32 BaseAddress = EmacPsInstancePtr->Config.BaseAddress;
 
-	printf("EMAC[%s]: state=%d backlog=%u reserved=%u pending=%u read=%u write=%u reserve=%u serial=%u rx=%lu tx=%lu drops=%d full=%d bp=%d pause=%d mismatch=%d txrec=%d errors=%ld\n",
+	printf("EMAC[%s]: state=%d backlog=%u reserved=%u pending=%u read=%u write=%u reserve=%u serial=%u rx=%lu tx=%lu drops=%d full=%d bp=%d pause=%d mismatch=%d ackrej=%d txrec=%d errors=%ld\n",
 	       reason,
 	       ethernet_task_state,
 	       (unsigned int)frames_backlog,
@@ -412,6 +413,7 @@ static void ethernet_log_status(const char *reason) {
 	       rx_backpressure,
 	       rx_pause_frames,
 	       rx_slot_mismatch,
+	       frames_ack_rejected,
 	       tx_recoveries,
 	       (long)DeviceErrors);
 
@@ -797,17 +799,50 @@ u16 ethernet_get_rx_stats() {
 	return (dropped << 8) | pause;
 }
 
-int ethernet_receive_frame() {
+int ethernet_receive_frame(u16 acked_serial) {
 	//printf("[eth rx] backlog %d read %d write %d\n", frames_backlog, frames_backlog_read, frames_backlog_write);
 
 	int paused = ethernet_pause_rx_irq();
 	if (frames_backlog>0) {
-		uint16_t consumed_slot = frames_backlog_read;
-		frames_backlog_read = ethernet_next_backlog_slot(frames_backlog_read);
-		frames_backlog--;
-		ethernet_clear_backlog_slot(consumed_slot);
-		if (frames_backlog == 0) {
-			ethernet_clear_backlog_slot(frames_backlog_read);
+		/* Defense-in-depth (issue #29): only consume the presented frame when
+		 * the Amiga's ack actually corresponds to it. The Amiga writes the
+		 * serial of the frame it just read into the RX-accept register; we
+		 * compare it to the serial stored in the presented backlog slot.
+		 *
+		 * Why: a driver that acks an EMPTY (firmware-cleared) slot, or that
+		 * races a frame landing in the read slot between its read and its ack,
+		 * would otherwise make us advance past a frame the Amiga never read,
+		 * silently dropping it — the original issue #29 stall. An empty slot
+		 * carries serial 0; a mismatched ack carries a different serial. In
+		 * both cases we refuse to advance and leave the frame for the Amiga.
+		 *
+		 * Backward compatibility: legacy drivers write a constant 1 instead of
+		 * the real serial. We honour acked_serial == 1 as a bare advance so
+		 * those drivers keep working unchanged (the check is then a no-op);
+		 * reject 0 (never a valid serial — frame_serial is pre-incremented);
+		 * and for any other value require an exact match with the presented
+		 * frame's serial. */
+		uint8_t* slot = ethernet_current_receive_ptr();
+		u16 presented = ((u16)slot[2] << 8) | slot[3];
+		int consume;
+		if (acked_serial == 0) {
+			consume = 0;                            /* empty / invalid ack */
+		} else if (acked_serial == 1) {
+			consume = 1;                            /* legacy bare advance */
+		} else {
+			consume = (acked_serial == presented);  /* handshake: must match */
+		}
+
+		if (consume) {
+			uint16_t consumed_slot = frames_backlog_read;
+			frames_backlog_read = ethernet_next_backlog_slot(frames_backlog_read);
+			frames_backlog--;
+			ethernet_clear_backlog_slot(consumed_slot);
+			if (frames_backlog == 0) {
+				ethernet_clear_backlog_slot(frames_backlog_read);
+			}
+		} else {
+			frames_ack_rejected++;
 		}
 	} else {
 		// this is NOT an error, Amiga wants data and there is no data on RX buffers

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -697,6 +697,15 @@ static void XEmacPsRecvHandler(void *Callback)
 		for (int i=0; i<num_rx_bufs; i++) {
 
 			frame_serial++;
+			/* 0 is the empty-slot / "no frame" sentinel: the driver skips an
+			 * all-zero header without acking, and the RX-accept handshake
+			 * rejects acked_serial == 0. frame_serial is a u16, so a plain
+			 * increment wraps 0xffff -> 0 once every 65536 frames; skip 0 so a
+			 * real frame is never tagged with the sentinel. Otherwise the
+			 * handshake would reject that frame forever (frames_backlog_read
+			 * never advances) and RX would stall until reset (issue #29). */
+			if (frame_serial == 0)
+				frame_serial++;
 
 			//printf("RX ser: %d\n",frame_serial);
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
@@ -19,7 +19,7 @@
 
 int ethernet_init();
 u16 ethernet_send_frame(u16 frame_size);
-int ethernet_receive_frame();
+int ethernet_receive_frame(u16 acked_serial);
 u32 get_frames_received();
 uint8_t* ethernet_get_mac_address_ptr();
 void ethernet_update_mac_address();

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -944,7 +944,10 @@ int main() {
 					break;
 				case REG_ZZ_ETH_RX: {
 					//printf("RECV eth frame sz: %ld\n",zdata);
-					int frfb = ethernet_receive_frame();
+					/* zdata carries the serial of the frame the Amiga consumed
+					 * (legacy drivers write a constant 1). issue #29: the RX
+					 * handshake validates it before advancing. */
+					int frfb = ethernet_receive_frame((u16)zdata);
 					mntzorro_write(MNTZ_BASE_ADDR, MNTZORRO_REG4, frfb);
 					break;
 				}


### PR DESCRIPTION
## Summary

Defense-in-depth for the issue #29 large-transfer stall (BlitterStudio/zz9000-firmware#29). The primary fix is driver-side (don't ack empty RX slots — BlitterStudio/zz9000-drivers#31); this hardens the firmware so a stray ack can never consume an unread frame even if a future driver regresses.

## Background

`ethernet_receive_frame()` advanced and cleared the presented backlog slot on **any** ack from the Amiga, regardless of which frame the ack referred to. At the backlog drain boundary (`frames_backlog_read == frames_backlog_write`), an ack that was meant for an empty/cleared slot — but raced a real frame landing in that same slot — made the firmware consume a frame the Amiga never read. Silent inbound loss, invisible to the firmware (`frames_dropped` stays 0), and the mechanism behind the stall.

## Change

Turn the bare advance into a **serial handshake**. The Amiga writes the serial of the frame it consumed into the RX-accept register (`zdata`); the firmware compares it to the serial stored in the presented backlog slot and only advances on a match:

- `acked_serial == 0` → reject (0 is never a valid serial — `frame_serial` is pre-incremented).
- `acked_serial == 1` → honor as a legacy bare advance (see compatibility below).
- otherwise → consume only if `acked_serial == presented`.

Rejected acks are counted in `frames_ack_rejected` and surfaced on the `EMAC[...]` heartbeat as `ackrej=`.

## Backward compatibility — zero regression risk for the current fleet

Legacy drivers write a constant `1` to the RX-accept register. That hits the `acked_serial == 1` legacy path, which advances exactly as before — so **the check is a no-op for every existing driver**, and this firmware behaves identically to today until a driver opts in by writing real serials.

All four combinations work:

| | old driver (writes 1) | handshake driver (writes serial) |
|---|---|---|
| **old firmware** | advances (today) | advances — value ignored |
| **this firmware** | legacy advance (no-op) | validated |

## Pairing

Activated by the driver change BlitterStudio/zz9000-drivers#31-stacked branch (`fix/issue-29-rx-ack-handshake`), which writes the consumed serial instead of `1`. Until that ships, this firmware is dormant defense.

## Build / test

Builds clean via the standard Docker flow (`BOOT-issue29-handshake.bin`). Not yet bench-tested on hardware; in normal operation the heartbeat should show `ackrej=0`.
