### PR TITLE
Dual-core task scheduler: run LONG ops (crypto) on core 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
         run: make -C test/rtg test
       - name: Firmware-file restore suite
         run: make -C test/fwupdate test
+      - name: Scheduler host tests
+        run: make -C test/scheduler test
 
   build:
     name: Build & package firmware

--- a/ZZ9000_proto.sdk/ZZ9000OS/Makefile
+++ b/ZZ9000_proto.sdk/ZZ9000OS/Makefile
@@ -102,6 +102,8 @@ C_SRCS = \
 	$(SRC_DIR)/codec47.c \
 	$(SRC_DIR)/compression.c \
 	$(SRC_DIR)/core2.c \
+	$(SRC_DIR)/scheduler.c \
+	$(SRC_DIR)/scheduler_arm.c \
 	$(SRC_DIR)/dma_acc.c \
 	$(SRC_DIR)/dma_rtg.c \
 	$(SRC_DIR)/usb.c \

--- a/ZZ9000_proto.sdk/ZZ9000OS/Makefile
+++ b/ZZ9000_proto.sdk/ZZ9000OS/Makefile
@@ -104,6 +104,7 @@ C_SRCS = \
 	$(SRC_DIR)/core2.c \
 	$(SRC_DIR)/scheduler.c \
 	$(SRC_DIR)/scheduler_arm.c \
+	$(SRC_DIR)/scheduler_stress.c \
 	$(SRC_DIR)/dma_acc.c \
 	$(SRC_DIR)/dma_rtg.c \
 	$(SRC_DIR)/usb.c \

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -201,15 +201,20 @@ __attribute__((naked, used)) void core1_entry(void)
 }
 
 /*
- * Core-1 exception-mode stacks. core1_entry set only the current (Supervisor)
- * SP; it bypasses the BSP boot.S that would set up the banked IRQ/FIQ/Abort/
- * Undefined stack pointers. The BSP fault vectors (asm_vectors.S) save state
- * with `stmdb sp!` on the *faulting mode's* banked stack and run the C handler
- * (arm_exception_handler_* -> record_fault -> printf) in that mode, so without
- * these a data/prefetch/undefined fault on core 1 would push to a garbage SP
- * and die before record_fault() could fail the task and request a restart --
- * defeating the scheduler's fault recovery. 8 KiB each covers the vpushed FP
- * context plus printf.
+ * Core-1 exception state (VBAR + banked stacks). core1_entry set only the
+ * current (Supervisor) SP and bypassed the BSP boot.S, which programs VBAR to
+ * _vector_table (boot.S: mcr p15,0,rX,c12,c0,0) and sets up the banked IRQ/FIQ/
+ * Abort/Undefined stacks. Two things are therefore missing on core 1:
+ *   - VBAR: without it, a core-1 data/prefetch/undefined fault vectors through
+ *     inherited reset state instead of _vector_table, so the registered
+ *     handlers (arm_exception_handler_*) never run.
+ *   - the banked exception stacks: the BSP vectors (asm_vectors.S) save state
+ *     with `stmdb sp!` on the *faulting mode's* stack and run the C handler
+ *     (record_fault -> printf) in that mode, so a garbage banked SP crashes the
+ *     handler itself.
+ * Either gap means record_fault() never fails the task / requests a restart, so
+ * a faulting offloaded request hangs. Program both before core 1 runs any task.
+ * 8 KiB per mode covers the vpushed FP context plus printf.
  */
 #define CORE1_EXC_STACK_SZ 0x2000
 static uint8_t core1_irq_stack[CORE1_EXC_STACK_SZ]   __attribute__((aligned(8), used));
@@ -218,17 +223,18 @@ static uint8_t core1_abort_stack[CORE1_EXC_STACK_SZ] __attribute__((aligned(8), 
 static uint8_t core1_undef_stack[CORE1_EXC_STACK_SZ] __attribute__((aligned(8), used));
 
 /*
- * Point each exception mode's banked SP at its own stack, then return to the
- * entry mode. Naked with PC-relative `ldr sp, =(stack + size)` literals so no
- * value is carried across a mode switch -- FIQ banks r8-r12, which would
- * corrupt register operands. I+F are masked while switching; the original CPSR
- * is restored at the end (the SP-writes touch no memory, so this is valid even
- * before the fault stacks are ever used). Set up on core 1 before it runs any
- * scheduler task.
+ * Program VBAR = _vector_table, then point each exception mode's banked SP at
+ * its own stack and return to the entry mode. Naked with PC-relative literals
+ * (`ldr ..., =sym`) so no value is carried across a mode switch -- FIQ banks
+ * r8-r12, which would corrupt register operands. I+F are masked while switching;
+ * the original CPSR is restored at the end. SCTLR.V is left at its reset default
+ * (0 = normal vectors, same as the boot core), so VBAR is the vector base.
  */
-__attribute__((naked, used)) static void core1_init_exception_stacks(void)
+__attribute__((naked, used)) static void core1_init_exception_state(void)
 {
 	__asm__ volatile(
+		"ldr	r0, =_vector_table\n\t"            /* VBAR = BSP vector table */
+		"mcr	p15, 0, r0, c12, c0, 0\n\t"
 		"mrs	r0, cpsr\n\t"
 		"bic	r1, r0, #0x1f\n\t"
 		"orr	r1, r1, #0xc0\n\t"                 /* mask I+F during switches */
@@ -301,11 +307,12 @@ void core1_loop() {
 	scheduler_coherency_init_core1();
 	C1_TRACE("[c1] R2 coherency-ok (mmu on)\r\n");  /* survived MMU/cache/SMP bring-up */
 
-	// Give the exception modes valid banked stacks before running any task, so a
-	// data/prefetch/undefined fault reaches record_fault() (which fails the task
-	// and requests a cold restart) instead of dying on a garbage SP.
-	core1_init_exception_stacks();
-	C1_TRACE("[c1] R2b exc-stacks-ok\r\n");
+	// Program VBAR + banked exception stacks before running any task, so a
+	// data/prefetch/undefined fault vectors to the registered handlers and
+	// reaches record_fault() (which fails the task and requests a cold restart)
+	// instead of vectoring through stale state or dying on a garbage SP.
+	core1_init_exception_state();
+	C1_TRACE("[c1] R2b exc-state-ok\r\n");
 
 #ifdef SCHED_STRESS_TEST
 	scheduler_stress_core1();  // Phase 0 two-core coherency torture; never returns

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -78,15 +78,77 @@ int __attribute__ ((visibility ("default"))) _putchar(char c) {
 volatile void (*core1_trampoline)(volatile struct ZZ9K_ENV* env);
 volatile int core2_execute = 0;
 
+void core1_loop();  /* forward decl: core1_cold_restart re-points 0xFFFFFFF0 at it */
+
 struct core_fault_slot core1_fault __attribute__((aligned(32))) = { CORE_FAULT_NONE, {0} };
 
 static void record_fault(uint32_t code, const char *name)
 {
+	taskq_shared_t *sh = scheduler_shared();
+	int slot = sh->core1_current_slot;
+
 	core1_fault.code = code;
 	Xil_DCacheFlushRange((INTPTR)&core1_fault, sizeof(core1_fault));
 	printf("%s: arm_exception_handler()!\n", name);
+
+	if (slot >= 0) {
+		/*
+		 * Core 1 faulted while running a dual-core scheduler task. Don't hang
+		 * the card: mark the in-flight slot FAILED so core 0 posts an error
+		 * completion (the Amiga falls back to software crypto), record the
+		 * fault code, and request a cold restart. core 0's harvest maps every
+		 * FAILED task to SDK_STATUS_INTERNAL_ERROR, so the status passed here
+		 * is unused. Then park on WFE until core 0 resets us back into
+		 * core1_loop (core1_cold_restart).
+		 */
+		taskq_fail(&sh->queue, slot, 0);
+		sh->core1_current_slot = -1;
+		sh->core1_fault_code = code;
+		sh->core1_restart_request = 1;
+		Xil_DCacheFlushRange((INTPTR)sh, sizeof(*sh));
+		__asm__ __volatile__("dsb" ::: "memory");
+		for (;;) {
+			__asm__ __volatile__("wfe" ::: "memory");
+		}
+	}
+
+	/*
+	 * Legacy surface-coprocessor path (no scheduler task in flight): hang until
+	 * core 0 notices core1_fault.code and resets the core.
+	 */
 	while (1) {
 	}
+}
+
+/*
+ * Cold-restart core 1 by re-running the CPU1 reset sequence (XAPP1079), so it
+ * re-enters core1_loop from its reset vector. Used by the dual-core scheduler
+ * (scheduler_core0_poll) to recover a worker that faulted and parked. 0xFFFFFFF0
+ * is re-pointed at core1_loop first in case the OCM word was disturbed.
+ */
+void core1_cold_restart(void)
+{
+	volatile uint32_t *core1_addr = (volatile uint32_t *) 0xFFFFFFF0;
+	uint32_t RegVal;
+
+	*core1_addr = (uint32_t) core1_loop;
+
+	Xil_Out32(XSLCR_UNLOCK_ADDR, XSLCR_UNLOCK_CODE);
+	RegVal = Xil_In32(A9_CPU_RST_CTRL);
+	RegVal |= A9_RST1_MASK;
+	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
+	RegVal |= A9_CLKSTOP1_MASK;
+	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
+	RegVal &= ~A9_RST1_MASK;
+	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
+	RegVal &= ~A9_CLKSTOP1_MASK;
+	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
+	Xil_Out32(XSLCR_LOCK_ADDR, XSLCR_LOCK_CODE);
+
+	dmb();
+	dsb();
+	isb();
+	asm("sev");
 }
 
 #pragma GCC push_options

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -385,6 +385,15 @@ void arm_app_run(uint32_t arm_run_address) {
 	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
 	Xil_Out32(XSLCR_LOCK_ADDR, XSLCR_LOCK_CODE);
 
+	// Core 1 has been reset away from the scheduler worker and re-enters as the
+	// trampoline, so it will never poll the task queue again. Take the scheduler
+	// offline and reclaim any in-flight/queued crypto tasks inline on core 0 --
+	// otherwise crypto_dispatch would keep enqueueing to a dead worker and a
+	// task in flight at the reset would leak CLAIMED. Safe here: the worker died
+	// at the reset above and this runs on core 0's main loop, so core 0 now owns
+	// the task queue exclusively.
+	scheduler_core1_divert_reclaim();
+
 	dmb();
 	dsb();
 	isb();

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -200,6 +200,55 @@ __attribute__((naked, used)) void core1_entry(void)
 		"b	core1_loop\n\t");
 }
 
+/*
+ * Core-1 exception-mode stacks. core1_entry set only the current (Supervisor)
+ * SP; it bypasses the BSP boot.S that would set up the banked IRQ/FIQ/Abort/
+ * Undefined stack pointers. The BSP fault vectors (asm_vectors.S) save state
+ * with `stmdb sp!` on the *faulting mode's* banked stack and run the C handler
+ * (arm_exception_handler_* -> record_fault -> printf) in that mode, so without
+ * these a data/prefetch/undefined fault on core 1 would push to a garbage SP
+ * and die before record_fault() could fail the task and request a restart --
+ * defeating the scheduler's fault recovery. 8 KiB each covers the vpushed FP
+ * context plus printf.
+ */
+#define CORE1_EXC_STACK_SZ 0x2000
+static uint8_t core1_irq_stack[CORE1_EXC_STACK_SZ]   __attribute__((aligned(8), used));
+static uint8_t core1_fiq_stack[CORE1_EXC_STACK_SZ]   __attribute__((aligned(8), used));
+static uint8_t core1_abort_stack[CORE1_EXC_STACK_SZ] __attribute__((aligned(8), used));
+static uint8_t core1_undef_stack[CORE1_EXC_STACK_SZ] __attribute__((aligned(8), used));
+
+/*
+ * Point each exception mode's banked SP at its own stack, then return to the
+ * entry mode. Naked with PC-relative `ldr sp, =(stack + size)` literals so no
+ * value is carried across a mode switch -- FIQ banks r8-r12, which would
+ * corrupt register operands. I+F are masked while switching; the original CPSR
+ * is restored at the end (the SP-writes touch no memory, so this is valid even
+ * before the fault stacks are ever used). Set up on core 1 before it runs any
+ * scheduler task.
+ */
+__attribute__((naked, used)) static void core1_init_exception_stacks(void)
+{
+	__asm__ volatile(
+		"mrs	r0, cpsr\n\t"
+		"bic	r1, r0, #0x1f\n\t"
+		"orr	r1, r1, #0xc0\n\t"                 /* mask I+F during switches */
+		"orr	r2, r1, #0x12\n\t"                 /* IRQ mode  (0x12) */
+		"msr	cpsr_c, r2\n\t"
+		"ldr	sp, =(core1_irq_stack + "   CORE1_STR(CORE1_EXC_STACK_SZ) ")\n\t"
+		"orr	r2, r1, #0x11\n\t"                 /* FIQ mode  (0x11) */
+		"msr	cpsr_c, r2\n\t"
+		"ldr	sp, =(core1_fiq_stack + "   CORE1_STR(CORE1_EXC_STACK_SZ) ")\n\t"
+		"orr	r2, r1, #0x17\n\t"                 /* Abort mode (0x17) */
+		"msr	cpsr_c, r2\n\t"
+		"ldr	sp, =(core1_abort_stack + " CORE1_STR(CORE1_EXC_STACK_SZ) ")\n\t"
+		"orr	r2, r1, #0x1b\n\t"                 /* Undefined  (0x1b) */
+		"msr	cpsr_c, r2\n\t"
+		"ldr	sp, =(core1_undef_stack + " CORE1_STR(CORE1_EXC_STACK_SZ) ")\n\t"
+		"msr	cpsr_c, r0\n\t"                    /* back to entry mode */
+		"bx	lr\n\t"
+		".ltorg\n\t");
+}
+
 #pragma GCC push_options
 #pragma GCC optimize ("O1")
 // core1_loop is executed on core1 (vs core0), entered via core1_entry
@@ -251,6 +300,12 @@ void core1_loop() {
 	// task-queue region shareable at boot, before this core started).
 	scheduler_coherency_init_core1();
 	C1_TRACE("[c1] R2 coherency-ok (mmu on)\r\n");  /* survived MMU/cache/SMP bring-up */
+
+	// Give the exception modes valid banked stacks before running any task, so a
+	// data/prefetch/undefined fault reaches record_fault() (which fails the task
+	// and requests a cold restart) instead of dying on a garbage SP.
+	core1_init_exception_stacks();
+	C1_TRACE("[c1] R2b exc-stacks-ok\r\n");
 
 #ifdef SCHED_STRESS_TEST
 	scheduler_stress_core1();  // Phase 0 two-core coherency torture; never returns

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -141,6 +141,18 @@ void core1_loop() {
 	scheduler_stress_core1();  // Phase 0 two-core coherency torture; never returns
 #endif
 
+	// Default core 1 to the dual-core task-scheduler worker (crypto offload).
+	// The legacy REG_ZZ_ARM_RUN trampoline -- the Amiga uploading a native ARM
+	// app to run on core 1 -- is preserved without a compile flag: arm_app_run()
+	// sets core2_execute *and* cold-resets core 1, so on the post-reset re-entry
+	// core2_execute is already 1 here and we fall through to the trampoline
+	// dispatch below instead of the worker. At cold boot core2_execute is 0, so
+	// core 1 becomes the worker and never returns. (Folding the trampoline into
+	// the scheduler is a later phase.)
+	if (!core2_execute) {
+		scheduler_core1_worker();  // dual-core crypto worker; never returns
+	}
+
 	while (1) {
 		while (!core2_execute) {
 			usleep(1);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -256,43 +256,15 @@ void core1_loop() {
 	scheduler_stress_core1();  // Phase 0 two-core coherency torture; never returns
 #endif
 
-	// Default core 1 to the dual-core task-scheduler worker (crypto offload).
-	// The legacy REG_ZZ_ARM_RUN trampoline -- the Amiga uploading a native ARM
-	// app to run on core 1 -- is preserved without a compile flag: arm_app_run()
-	// sets core2_execute *and* cold-resets core 1, so on the post-reset re-entry
-	// core2_execute is already 1 here and we fall through to the trampoline
-	// dispatch below instead of the worker. At cold boot core2_execute is 0, so
-	// core 1 becomes the worker and never returns. (Folding the trampoline into
-	// the scheduler is a later phase.)
-	if (!core2_execute) {
-		C1_TRACE("[c1] R3 worker-start (core2_execute=0)\r\n");
-		scheduler_core1_worker();  // dual-core crypto worker; never returns
-	} else {
-		C1_TRACE("[c1] R3 trampoline (core2_execute=1)\r\n");
-	}
-
-	while (1) {
-		while (!core2_execute) {
-			usleep(1);
-		}
-		core2_execute = 0;
-		printf("[core2] executing at %p.\n", core1_trampoline);
-		Xil_DCacheFlush();
-		Xil_ICacheInvalidate();
-
-		if (core1_trampoline) {
-			asm("push {r0-r12}");
-			// FIXME HACK save our stack pointer in 0x10000
-			asm("mov r0, #0x00010000");
-			asm("str sp, [r0]");
-
-			core1_trampoline(&arm_run_env);
-
-			asm("mov r0, #0x00010000");
-			asm("ldr sp, [r0]");
-			asm("pop {r0-r12}");
-		}
-	}
+	// Core 1 runs the dual-core task-scheduler worker and never returns. It
+	// executes work offloaded from the OS -- crypto today, with datatypes,
+	// audio decode (MP3/Ogg/FLAC) and full app modules to follow -- and, in a
+	// later phase, hosted ARM apps, all through the same scheduler. The pre-v2.x
+	// REG_ZZ_ARM_RUN trampoline (upload a raw ARM blob and run it on core 1 in
+	// an uncached environment) has been removed; the v2 ARM-hosted app platform
+	// launches apps through the scheduler instead.
+	C1_TRACE("[c1] R3 worker-start\r\n");
+	scheduler_core1_worker();  // dual-core task worker; never returns
 }
 #pragma GCC pop_options
 
@@ -337,67 +309,6 @@ void arm_app_init() {
 	dsb();
 	asm("sev");
 	printf("[core2] now idling.\n");
-}
-
-void arm_app_run(uint32_t arm_run_address) {
-	volatile uint32_t* core1_addr = (volatile uint32_t*) 0xFFFFFFF0;
-	volatile uint32_t* core1_addr2 = (volatile uint32_t*) 0x100; // catch 2
-
-	*core1_addr = (uint32_t) core1_entry;
-	core1_addr2[0] = 0xe3e0000f; // mvn	r0, #15  -- loads 0xfffffff0
-	core1_addr2[1] = 0xe590f000; // ldr	pc, [r0] -- jumps to the address in that address
-
-	printf("[ARM_RUN] %lx\n", arm_run_address);
-	if (arm_run_address > 0) {
-		core1_trampoline = (volatile void (*)(
-				volatile struct ZZ9K_ENV*)) arm_run_address;
-		printf("[ARM_RUN] signaling second core.\n");
-		// publish the trampoline (and app code/env) before the execute flag
-		// becomes visible to core1
-		Xil_DCacheFlush();
-		Xil_ICacheInvalidate();
-		dmb();
-		dsb();
-		core2_execute = 1;
-		Xil_DCacheFlush();
-		Xil_ICacheInvalidate();
-	} else {
-		core1_trampoline = 0;
-		Xil_DCacheFlush();
-		dmb();
-		dsb();
-		core2_execute = 0;
-		Xil_DCacheFlush();
-	}
-
-	// FIXME move this out of here
-	// sequence to reset cpu1 taken from https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842504/XAPP1079+Latest+Information
-
-	Xil_Out32(XSLCR_UNLOCK_ADDR, XSLCR_UNLOCK_CODE);
-	uint32_t RegVal = Xil_In32(A9_CPU_RST_CTRL);
-	RegVal |= A9_RST1_MASK;
-	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
-	RegVal |= A9_CLKSTOP1_MASK;
-	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
-	RegVal &= ~A9_RST1_MASK;
-	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
-	RegVal &= ~A9_CLKSTOP1_MASK;
-	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
-	Xil_Out32(XSLCR_LOCK_ADDR, XSLCR_LOCK_CODE);
-
-	// Core 1 has been reset away from the scheduler worker and re-enters as the
-	// trampoline, so it will never poll the task queue again. Take the scheduler
-	// offline and reclaim any in-flight/queued crypto tasks inline on core 0 --
-	// otherwise crypto_dispatch would keep enqueueing to a dead worker and a
-	// task in flight at the reset would leak CLAIMED. Safe here: the worker died
-	// at the reset above and this runs on core 0's main loop, so core 0 now owns
-	// the task queue exclusively.
-	scheduler_core1_divert_reclaim();
-
-	dmb();
-	dsb();
-	isb();
-	asm("sev");
 }
 
 void arm_app_input_event(uint32_t evt) {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -6,6 +6,7 @@
 #include "xil_misc_psreset_api.h"
 #include "core2.h"
 #include "sleep.h"
+#include "scheduler.h"
 
 #define A9_CPU_RST_CTRL		(XSLCR_BASEADDR + 0x244)
 #define A9_RST1_MASK 		0x00000002
@@ -130,6 +131,11 @@ void core1_loop() {
 	volatile uint32_t* addr = 0;
 	addr[0] = 0xe3e0000f; // mvn	r0, #15  -- loads 0xfffffff0
 	addr[1] = 0xe590f000; // ldr	pc, [r0] -- jumps to the address in that address
+
+	// Bring core 1 up to MMU + D-cache + SMP so the dual-core task scheduler's
+	// cross-core LDREX/STREX and SCU coherency work (core 0 marked the
+	// task-queue region shareable at boot, before this core started).
+	scheduler_coherency_init_core1();
 
 	while (1) {
 		while (!core2_execute) {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -137,6 +137,10 @@ void core1_loop() {
 	// task-queue region shareable at boot, before this core started).
 	scheduler_coherency_init_core1();
 
+#ifdef SCHED_STRESS_TEST
+	scheduler_stress_core1();  // Phase 0 two-core coherency torture; never returns
+#endif
+
 	while (1) {
 		while (!core2_execute) {
 			usleep(1);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -7,6 +7,7 @@
 #include "core2.h"
 #include "sleep.h"
 #include "scheduler.h"
+#include "memorymap.h"
 
 #define A9_CPU_RST_CTRL		(XSLCR_BASEADDR + 0x244)
 #define A9_RST1_MASK 		0x00000002
@@ -78,7 +79,8 @@ int __attribute__ ((visibility ("default"))) _putchar(char c) {
 volatile void (*core1_trampoline)(volatile struct ZZ9K_ENV* env);
 volatile int core2_execute = 0;
 
-void core1_loop();  /* forward decl: core1_cold_restart re-points 0xFFFFFFF0 at it */
+void core1_loop();  /* forward decl: core1_entry branches into this C body */
+void core1_entry(void);  /* naked reset stub: 0xFFFFFFF0 points here; sets SP then branches to core1_loop */
 
 struct core_fault_slot core1_fault __attribute__((aligned(32))) = { CORE_FAULT_NONE, {0} };
 
@@ -122,16 +124,17 @@ static void record_fault(uint32_t code, const char *name)
 
 /*
  * Cold-restart core 1 by re-running the CPU1 reset sequence (XAPP1079), so it
- * re-enters core1_loop from its reset vector. Used by the dual-core scheduler
+ * re-enters core1_entry from its reset vector. Used by the dual-core scheduler
  * (scheduler_core0_poll) to recover a worker that faulted and parked. 0xFFFFFFF0
- * is re-pointed at core1_loop first in case the OCM word was disturbed.
+ * is re-pointed at core1_entry first in case the OCM word was disturbed.
  */
 void core1_cold_restart(void)
 {
 	volatile uint32_t *core1_addr = (volatile uint32_t *) 0xFFFFFFF0;
 	uint32_t RegVal;
 
-	*core1_addr = (uint32_t) core1_loop;
+	*core1_addr = (uint32_t) core1_entry;
+	Xil_DCacheFlush();  /* the reset vector write must reach OCM before CPU1 reads it */
 
 	Xil_Out32(XSLCR_UNLOCK_ADDR, XSLCR_UNLOCK_CODE);
 	RegVal = Xil_In32(A9_CPU_RST_CTRL);
@@ -151,10 +154,57 @@ void core1_cold_restart(void)
 	asm("sev");
 }
 
+/*
+ * SCHED_CORE1_TRACE (opt-in, off by default): raw UART1 (STDOUT_BASEADDRESS
+ * 0xE0001000) byte output for core-1 bring-up diagnostics. Deliberately uses NO
+ * libc, NO malloc, NO MMU and a trivial leaf-function stack frame, so it is
+ * valid on core 1 before the MMU/D-cache are up and regardless of any heap/stack
+ * corruption. SR @ 0x2C (TXFULL = 0x10), TX FIFO @ 0x30. Define SCHED_CORE1_TRACE
+ * to re-enable the staged [c1] R0..R3 markers when diagnosing bring-up; the
+ * production boot signal is the single "[sched] core 1 worker online" line.
+ */
+#ifdef SCHED_CORE1_TRACE
+static void c1_trace(const char *s)
+{
+	volatile uint32_t *sr   = (volatile uint32_t *)(0xE0001000u + 0x2Cu);
+	volatile uint32_t *fifo = (volatile uint32_t *)(0xE0001000u + 0x30u);
+	while (*s) {
+		while (*sr & 0x10u) { }          /* wait while TX FIFO full */
+		*fifo = (uint32_t)(unsigned char)*s++;
+	}
+}
+#define C1_TRACE(s) c1_trace(s)
+#else
+#define C1_TRACE(s) ((void)0)
+#endif
+
+/*
+ * Core-1 reset entry. The CPU1 reset vector (0xFFFFFFF0) points here. This must
+ * be NAKED: on Cortex-A9 reset the stack pointer is UNPREDICTABLE, so any
+ * compiler-generated prologue would push registers to a garbage SP and fault
+ * before a single instruction of C ran -- which is exactly what killed core 1
+ * (no markers at all, even the raw-UART one). We set SP to the reserved core-1
+ * stack in asm FIRST, with nothing on the stack yet, then branch into the C
+ * body. `b` (not `bl`): core1_loop never returns.
+ *
+ * Basic asm only (naked functions do not reliably support extended asm); the
+ * stack-top constant is single-sourced from memorymap.h via stringification.
+ * SDK_CORE1_STACK_TOP must be a valid ARM `mov` immediate for this one insn.
+ */
+#define CORE1_STR2(x) #x
+#define CORE1_STR(x)  CORE1_STR2(x)
+__attribute__((naked, used)) void core1_entry(void)
+{
+	__asm__ volatile(
+		"mov	sp, #" CORE1_STR(SDK_CORE1_STACK_TOP) "\n\t"
+		"b	core1_loop\n\t");
+}
+
 #pragma GCC push_options
 #pragma GCC optimize ("O1")
-// core1_loop is executed on core1 (vs core0)
+// core1_loop is executed on core1 (vs core0), entered via core1_entry
 void core1_loop() {
+	C1_TRACE("[c1] R0 entry (stub set SP)\r\n");  /* proof: CPU1 reached the C body */
 	asm("mov	r0, r0");
 	asm("mrc	p15, 0, r1, c1, c0, 2");
 	/* read cp access control register (CACR) into r1 */
@@ -187,17 +237,20 @@ void core1_loop() {
 	asm("mcr	p15,0,r0,c1,c0,1");
 	/* write Auxiliary Control Register */
 
-	// stack
-	asm("mov sp, #0x06000000");
+	// SP was established by the core1_entry reset stub (SDK_CORE1_STACK_TOP),
+	// before any C ran -- do NOT reset it here.
 
 	volatile uint32_t* addr = 0;
 	addr[0] = 0xe3e0000f; // mvn	r0, #15  -- loads 0xfffffff0
 	addr[1] = 0xe590f000; // ldr	pc, [r0] -- jumps to the address in that address
 
+	C1_TRACE("[c1] R1 loop-entry (mmu off)\r\n");  /* core 1 is executing core1_loop */
+
 	// Bring core 1 up to MMU + D-cache + SMP so the dual-core task scheduler's
 	// cross-core LDREX/STREX and SCU coherency work (core 0 marked the
 	// task-queue region shareable at boot, before this core started).
 	scheduler_coherency_init_core1();
+	C1_TRACE("[c1] R2 coherency-ok (mmu on)\r\n");  /* survived MMU/cache/SMP bring-up */
 
 #ifdef SCHED_STRESS_TEST
 	scheduler_stress_core1();  // Phase 0 two-core coherency torture; never returns
@@ -212,7 +265,10 @@ void core1_loop() {
 	// core 1 becomes the worker and never returns. (Folding the trampoline into
 	// the scheduler is a later phase.)
 	if (!core2_execute) {
+		C1_TRACE("[c1] R3 worker-start (core2_execute=0)\r\n");
 		scheduler_core1_worker();  // dual-core crypto worker; never returns
+	} else {
+		C1_TRACE("[c1] R3 trampoline (core2_execute=1)\r\n");
 	}
 
 	while (1) {
@@ -264,7 +320,7 @@ void arm_app_init() {
 
 	printf("[core2] launch...\n");
 	volatile uint32_t* core1_addr = (volatile uint32_t*) 0xFFFFFFF0;
-	*core1_addr = (uint32_t) core1_loop;
+	*core1_addr = (uint32_t) core1_entry;
 	// Place some machine code in strategic positions that will catch core1 if it crashes
 	// FIXME: clean this up and turn into a debug handler / monitor
 	volatile uint32_t* core1_addr2 = (volatile uint32_t*) 0x140; // catch 1
@@ -275,6 +331,10 @@ void arm_app_init() {
 	core1_addr2[0] = 0xe3e0000f; // mvn	r0, #15  -- loads 0xfffffff0
 	core1_addr2[1] = 0xe590f000; // ldr	pc, [r0] -- jumps to the address in that address
 
+	// The reset-vector word and catch stubs live in memory CPU1 reads with its
+	// caches off; flush core 0's D-cache so they are visible before we wake it.
+	Xil_DCacheFlush();
+	dsb();
 	asm("sev");
 	printf("[core2] now idling.\n");
 }
@@ -283,7 +343,7 @@ void arm_app_run(uint32_t arm_run_address) {
 	volatile uint32_t* core1_addr = (volatile uint32_t*) 0xFFFFFFF0;
 	volatile uint32_t* core1_addr2 = (volatile uint32_t*) 0x100; // catch 2
 
-	*core1_addr = (uint32_t) core1_loop;
+	*core1_addr = (uint32_t) core1_entry;
 	core1_addr2[0] = 0xe3e0000f; // mvn	r0, #15  -- loads 0xfffffff0
 	core1_addr2[1] = 0xe590f000; // ldr	pc, [r0] -- jumps to the address in that address
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.h
@@ -15,7 +15,6 @@ struct ZZ9K_ENV {
 
 void arm_app_init();
 volatile struct ZZ9K_ENV* arm_app_get_run_env();
-void arm_app_run(uint32_t arm_run_address);
 void core1_cold_restart(void);  /* re-reset core 1 into core1_loop (scheduler fault recovery) */
 void arm_app_input_event(uint32_t evt);
 uint32_t arm_app_output_event();

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.h
@@ -16,6 +16,7 @@ struct ZZ9K_ENV {
 void arm_app_init();
 volatile struct ZZ9K_ENV* arm_app_get_run_env();
 void arm_app_run(uint32_t arm_run_address);
+void core1_cold_restart(void);  /* re-reset core 1 into core1_loop (scheduler fault recovery) */
 void arm_app_input_event(uint32_t evt);
 uint32_t arm_app_output_event();
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -869,13 +869,19 @@ static void XEmacPsErrorHandler(void *Callback, u8 Direction, u32 ErrorWord)
 			printf("EMAC: Receive over run\n");
 		}
 		if (ErrorWord & XEMACPS_RXSR_BUFFNA_MASK) {
-			printf("EMAC: Receive buffer not available\n");
+			// RX descriptors exhausted: frames keep arriving but nothing on the
+			// Amiga side is draining them (no TCP stack / driver up). Expected and
+			// self-healing once RX is consumed. Keep the recovery attempt on the
+			// same cadence, but rate-limit the console line so an idle board with
+			// no stack doesn't flood the UART with a per-frame message.
 			// signal to host that frames are available
 			frames_dropped++;
 			frames_received++;
 			if (frames_dropped%10 == 0) {
-				printf("ETHDROP: %d\n",frames_dropped);
 				ethernet_alloc_rx_frames();
+			}
+			if (frames_dropped%1000 == 0) {
+				printf("ETHDROP: %d\n",frames_dropped);
 			}
 		}
 		break;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -361,6 +361,11 @@ int main() {
 	// Confirm core 1's scheduler worker checked in before trusting the async
 	// offload path; if it never does, stay in single-core mode (all inline).
 	scheduler_confirm_core1_boot();
+	if (scheduler_core1_available()) {
+		print("[sched] core 1 worker online\r\n");
+	} else {
+		print("[sched] core 1 offline - single-core fallback\r\n");
+	}
 #endif
 	volatile struct ZZ9K_ENV* arm_run_env = arm_app_get_run_env();
 	uint32_t arm_run_address = 0;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -347,9 +347,15 @@ int main() {
 	// before core 1 starts, so the SCU keeps it coherent once core 1 brings up
 	// its own MMU/D-cache. Must precede arm_app_init() (which launches core 1).
 	scheduler_coherency_init_core0();
+#ifdef SCHED_STRESS_TEST
+	scheduler_stress_init();   // init the shared block before core 1 starts
+#endif
 
 	// ARM app run environment
 	arm_app_init();
+#ifdef SCHED_STRESS_TEST
+	scheduler_stress_core0();  // Phase 0 two-core coherency torture; never returns
+#endif
 	volatile struct ZZ9K_ENV* arm_run_env = arm_app_get_run_env();
 	uint32_t arm_run_address = 0;
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -1706,13 +1706,14 @@ int main() {
 		}
 
 		/*
-		 * Dual-core scheduler service. Harvest crypto tasks core 1 finished and
-		 * post their deferred completions EVERY iteration -- so results reach
-		 * the Amiga promptly even while display-load Zorro traffic keeps core 0
-		 * in the write/read branches (exactly the contention case we offload
-		 * for). The opportunistic inline SHORT-drain is gated on no Zorro
-		 * request having been serviced this iteration. Dormant (a cheap
-		 * empty-queue scan) until core 1 is enabled.
+		 * Dual-core scheduler service. Harvest tasks core 1 finished and post
+		 * their deferred completions EVERY iteration -- so results reach the
+		 * Amiga promptly even while display-load Zorro traffic keeps core 0 in
+		 * the write/read branches (exactly the contention case we offload for).
+		 * The queue is opcode-agnostic; Phase 1 feeds it the crypto service,
+		 * later phases add image/compression and MP3. The opportunistic inline
+		 * SHORT-drain is gated on no Zorro request having been serviced this
+		 * iteration. Dormant (a cheap empty-queue scan) until core 1 is enabled.
 		 */
 		scheduler_core0_poll((writereq || readreq) ? 1 : 0, 0);
 	}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -51,6 +51,7 @@ void Xil_AssertNonVoid() {}
 #include "interrupt.h"
 #include "bootrom.h"
 #include "core2.h"
+#include "scheduler.h"
 #include "adc.h"
 #include "ax.h"
 #include "watchdog.h"
@@ -341,6 +342,11 @@ int main() {
 #else
 	handle_amiga_reset(AMIGA_RESET_INIT_MEDIA);
 #endif
+
+	// Mark the task-queue region shareable-cacheable in the shared MMU table
+	// before core 1 starts, so the SCU keeps it coherent once core 1 brings up
+	// its own MMU/D-cache. Must precede arm_app_init() (which launches core 1).
+	scheduler_coherency_init_core0();
 
 	// ARM app run environment
 	arm_app_init();

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -1704,6 +1704,17 @@ int main() {
 			mntzorro_write(MNTZ_BASE_ADDR, MNTZORRO_REG0, 0);
 			need_req_ack = 0;
 		}
+
+		/*
+		 * Dual-core scheduler service. Harvest crypto tasks core 1 finished and
+		 * post their deferred completions EVERY iteration -- so results reach
+		 * the Amiga promptly even while display-load Zorro traffic keeps core 0
+		 * in the write/read branches (exactly the contention case we offload
+		 * for). The opportunistic inline SHORT-drain is gated on no Zorro
+		 * request having been serviced this iteration. Dormant (a cheap
+		 * empty-queue scan) until core 1 is enabled.
+		 */
+		scheduler_core0_poll((writereq || readreq) ? 1 : 0, 0);
 	}
 
 	cleanup_platform();

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -368,7 +368,6 @@ int main() {
 	}
 #endif
 	volatile struct ZZ9K_ENV* arm_run_env = arm_app_get_run_env();
-	uint32_t arm_run_address = 0;
 
 	// graphics temporary registers
 	uint16_t rect_x1 = 0;
@@ -1197,14 +1196,10 @@ int main() {
 					}
 					break;
 
-				// ARM core 2 execution
-				case REG_ZZ_ARM_RUN_HI:
-					arm_run_address = ((u32) zdata) << 16;
-					break;
-				case REG_ZZ_ARM_RUN_LO:
-					arm_run_address |= zdata;
-					arm_app_run(arm_run_address);
-					break;
+				// ARM core 1 execution: the pre-v2.x REG_ZZ_ARM_RUN "upload a
+				// raw ARM blob and run it on core 1" launch has been removed
+				// (core 1 is the dual-core scheduler worker). The argv/event
+				// registers below are inert with no app to launch.
 				case REG_ZZ_ARM_ARGC:
 					arm_run_env->argc = zdata;
 					break;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -349,6 +349,8 @@ int main() {
 	scheduler_coherency_init_core0();
 #ifdef SCHED_STRESS_TEST
 	scheduler_stress_init();   // init the shared block before core 1 starts
+#else
+	scheduler_boot_init();     // init the task queue + watchdog before core 1 starts
 #endif
 
 	// ARM app run environment

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -357,6 +357,10 @@ int main() {
 	arm_app_init();
 #ifdef SCHED_STRESS_TEST
 	scheduler_stress_core0();  // Phase 0 two-core coherency torture; never returns
+#else
+	// Confirm core 1's scheduler worker checked in before trusting the async
+	// offload path; if it never does, stay in single-core mode (all inline).
+	scheduler_confirm_core1_boot();
 #endif
 	volatile struct ZZ9K_ENV* arm_run_env = arm_app_get_run_env();
 	uint32_t arm_run_address = 0;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
@@ -86,6 +86,25 @@
 #error "task-queue region overlaps codec scratch at 0x30000000"
 #endif
 
+// Dedicated core-1 stack (dual-core scheduler). The Cortex-A9 stack is
+// full-descending, so the CPU is given the TOP. Reserved in the unclaimed
+// 0x18000000..0x30000000 hole, immediately above the task-queue region and
+// clear of every heap/framebuffer/DMA buffer below 0x08000000 -- the previous
+// hardcoded 0x06000000 core-1 SP sat on the seam of the surface heaps and
+// descended into the legacy accelerator heap. SDK_CORE1_STACK_TOP is chosen as
+// a valid ARM data-processing immediate (0x1C = 8-bit value, rotated) so the
+// reset stub can load SP in a single `mov` with no literal pool.
+#define SDK_CORE1_STACK_TOP     0x1C000000
+#define SDK_CORE1_STACK_SIZE    0x00100000     // 1 MB
+#define SDK_CORE1_STACK_BASE    (SDK_CORE1_STACK_TOP - SDK_CORE1_STACK_SIZE)
+
+#if SDK_CORE1_STACK_BASE < SDK_TASKQ_REGION_END
+#error "core-1 stack overlaps the task-queue region"
+#endif
+#if SDK_CORE1_STACK_TOP > 0x30000000
+#error "core-1 stack overlaps codec scratch at 0x30000000"
+#endif
+
 // SDK v2 bootstrap mailbox. The Amiga side reaches this through the existing
 // board window at 0xd000, inside the legacy 0xa000..0xffff shared I/O buffer.
 #define SDK_MAILBOX_WINDOW_OFFSET   0x0000D000

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
@@ -64,6 +64,28 @@
 #error "SDK ARM-local heap exceeds low DDR reservation"
 #endif
 
+// Dual-core scheduler task-queue control region. A small SCU-coherent slab in
+// the otherwise-unclaimed 0x18000000..0x30000000 hole -- above the
+// linker-managed DDR (ps7_ddr_hi ends at 0x18000000) and below the codec
+// scratch buffers at 0x30000000. Holds the taskq_shared_t control block only;
+// crypto data buffers stay in SDK_SHARED_HEAP with core-0 cache management.
+#define SDK_TASKQ_REGION_ADDRESS    0x18000000
+#define SDK_TASKQ_REGION_SIZE       0x00100000     // 1 MB (one MMU section)
+#define SDK_TASKQ_REGION_END \
+    (SDK_TASKQ_REGION_ADDRESS + SDK_TASKQ_REGION_SIZE)
+
+#if SDK_TASKQ_REGION_ADDRESS < 0x18000000
+#error "task-queue region must sit above the linker-managed DDR (ends 0x18000000)"
+#endif
+#if defined(SDK_JEDI_REGION_ADDRESS)
+#if SDK_TASKQ_REGION_ADDRESS < (SDK_JEDI_REGION_ADDRESS + SDK_JEDI_REGION_SIZE)
+#error "task-queue region overlaps the JEDI region"
+#endif
+#endif
+#if SDK_TASKQ_REGION_END > 0x30000000
+#error "task-queue region overlaps codec scratch at 0x30000000"
+#endif
+
 // SDK v2 bootstrap mailbox. The Amiga side reaches this through the existing
 // board window at 0xd000, inside the legacy 0xa000..0xffff shared I/O buffer.
 #define SDK_MAILBOX_WINDOW_OFFSET   0x0000D000

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -100,7 +100,7 @@ int taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
                   uint32_t in_addr, uint32_t in_len,
                   uint32_t out_addr, uint32_t out_cap,
                   uint32_t request_id, uint32_t user_cookie,
-                  const void *op_params)
+                  const void *op_params, uint32_t param_len)
 {
   uint32_t i, idx;
   for (i = 0; i < TASKQ_CAPACITY; i++) {
@@ -108,6 +108,12 @@ int taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
     if (q->descs[idx].state == TASK_FREE) {
       taskq_desc_t *d = &q->descs[idx];
       uint32_t k;
+      /* Callers pass structs smaller than the 48-byte op_params field, so copy
+       * only param_len source bytes and zero-fill the rest -- reading a full
+       * TASKQ_OP_PARAM_BYTES from the caller's struct would be an out-of-bounds
+       * read that leaks unrelated stack into the shared queue. */
+      uint32_t n = (param_len < TASKQ_OP_PARAM_BYTES) ? param_len
+                                                      : TASKQ_OP_PARAM_BYTES;
       d->cls = (uint32_t)cls;
       d->opcode = opcode;
       d->in_addr = in_addr;
@@ -121,7 +127,8 @@ int taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
       /* Copy the opaque input params before publishing, so a consumer that
        * claims the QUEUED slot always sees complete params. */
       for (k = 0; k < TASKQ_OP_PARAM_BYTES; k++) {
-        d->op_params[k] = op_params ? ((const uint8_t *)op_params)[k] : 0;
+        d->op_params[k] = (op_params && k < n) ? ((const uint8_t *)op_params)[k]
+                                               : 0;
       }
       taskq_store_release(&d->state, TASK_QUEUED);  /* publish last */
       q->enqueue_cursor = (idx + 1) % TASKQ_CAPACITY;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -1,0 +1,67 @@
+/*
+ * ZZ9000 dual-core task scheduler -- portable core.
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Host-testable: contains NO xil_ or firmware includes. The ARM build gets the
+ * real LDREX/STREX compare-swap and a dmb-release store from the #else branch;
+ * the host test build (-DTASKQ_HOST_TEST) gets an injectable single-threaded
+ * model so the claim-race path is exercisable deterministically.
+ */
+#include "scheduler.h"
+
+/* ---- atomic primitive seam ---- */
+#ifdef TASKQ_HOST_TEST
+int taskq_test_force_cas_fail = 0;
+
+int taskq_cas_u32(volatile uint32_t *p, uint32_t expected, uint32_t desired)
+{
+  if (taskq_test_force_cas_fail > 0) {
+    taskq_test_force_cas_fail--;
+    return 0;                       /* simulate losing the exclusive access */
+  }
+  if (*p == expected) {
+    *p = desired;
+    return 1;
+  }
+  return 0;
+}
+#else
+int taskq_cas_u32(volatile uint32_t *p, uint32_t expected, uint32_t desired)
+{
+  uint32_t old, ok;
+  __asm__ __volatile__(
+    "1: ldrex %0, [%2]\n"
+    "   cmp   %0, %3\n"
+    "   bne   2f\n"
+    "   strex %1, %4, [%2]\n"
+    "   cmp   %1, #0\n"
+    "   bne   1b\n"
+    "   dmb   ish\n"
+    "   mov   %1, #1\n"
+    "   b     3f\n"
+    "2: clrex\n"
+    "   mov   %1, #0\n"
+    "3:\n"
+    : "=&r"(old), "=&r"(ok)
+    : "r"(p), "r"(expected), "r"(desired)
+    : "cc", "memory");
+  (void)old;
+  return (int)ok;
+}
+#endif
+
+/* ---- coherency stress model (used by the Phase 0 two-core torture harness) ---- */
+uint32_t taskq_stress_fill(uint32_t seed, uint32_t index)
+{
+  uint32_t x = seed ^ (index * 2654435761u);
+  x ^= x >> 15;
+  x *= 2246822519u;
+  x ^= x >> 13;
+  return x;
+}
+
+int taskq_stress_check(uint32_t seed, uint32_t index, uint32_t value)
+{
+  return taskq_stress_fill(seed, index) == value ? 1 : 0;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -183,3 +183,27 @@ void taskq_release(taskq_t *q, int slot)
 {
   taskq_store_release(&q->descs[slot].state, TASK_FREE);
 }
+
+/* ---- dispatch policy ---- */
+taskq_class_t taskq_class_for_opcode(uint32_t opcode, uint32_t in_len)
+{
+  switch (opcode) {
+  case TASKQ_OP_CRYPTO_KX:
+  case TASKQ_OP_CRYPTO_VERIFY:
+    return TASK_SHORT;              /* asymmetric ops: always small/fast */
+  case TASKQ_OP_CRYPTO_HASH:
+  case TASKQ_OP_CRYPTO_STREAM:
+  case TASKQ_OP_CRYPTO_AEAD:
+    return (in_len <= TASKQ_SHORT_MAX_BYTES) ? TASK_SHORT : TASK_LONG;
+  default:
+    return TASK_LONG;              /* unknown/heavy: never drained on core 0 */
+  }
+}
+
+int taskq_should_drain(int zorro_pending, int display_pending, int core1_enabled)
+{
+  if (!core1_enabled) {
+    return 0;                      /* fallback path drains all inline elsewhere */
+  }
+  return (!zorro_pending && !display_pending) ? 1 : 0;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -205,6 +205,21 @@ void taskq_release(taskq_t *q, int slot)
   taskq_store_release(&q->descs[slot].state, TASK_FREE);
 }
 
+/* True while any slot is QUEUED or CLAIMED -- i.e. the worker may still be about
+ * to run it or is mid-execution (still writing the task's resolved data
+ * buffers). The mailbox-reset quiesce waits on this before freeing buffers. */
+int taskq_has_active(taskq_t *q)
+{
+  uint32_t i;
+  for (i = 0; i < TASKQ_CAPACITY; i++) {
+    uint32_t st = q->descs[i].state;
+    if (st == TASK_QUEUED || st == TASK_CLAIMED) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
 /* ---- dispatch policy ---- */
 taskq_class_t taskq_class_for_opcode(uint32_t opcode, uint32_t in_len)
 {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -142,3 +142,44 @@ int taskq_claim_short(taskq_t *q)
   }
   return -1;
 }
+
+/* ---- completion transitions ---- */
+void taskq_complete(taskq_t *q, int slot, uint16_t status,
+                    const uint8_t *payload, uint16_t payload_len)
+{
+  taskq_desc_t *d = &q->descs[slot];
+  uint16_t n = payload_len > TASKQ_RESULT_PAYLOAD ? TASKQ_RESULT_PAYLOAD
+                                                  : payload_len;
+  uint16_t k;
+  d->result_status = status;
+  d->result_len = n;
+  for (k = 0; k < n; k++) {
+    d->result_payload[k] = payload ? payload[k] : 0;
+  }
+  taskq_store_release(&d->state, TASK_DONE);
+}
+
+void taskq_fail(taskq_t *q, int slot, uint16_t status)
+{
+  taskq_desc_t *d = &q->descs[slot];
+  d->result_status = status;
+  d->result_len = 0;
+  taskq_store_release(&d->state, TASK_FAILED);
+}
+
+int taskq_harvest(taskq_t *q)
+{
+  uint32_t i;
+  for (i = 0; i < TASKQ_CAPACITY; i++) {
+    uint32_t st = q->descs[i].state;
+    if (st == TASK_DONE || st == TASK_FAILED) {
+      return (int)i;
+    }
+  }
+  return -1;
+}
+
+void taskq_release(taskq_t *q, int slot)
+{
+  taskq_store_release(&q->descs[slot].state, TASK_FREE);
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -207,3 +207,29 @@ int taskq_should_drain(int zorro_pending, int display_pending, int core1_enabled
   }
   return (!zorro_pending && !display_pending) ? 1 : 0;
 }
+
+/* ---- fault watchdog: trips core 1 off after too many consecutive faults ---- */
+void taskq_watchdog_init(taskq_watchdog_t *w, uint32_t threshold)
+{
+  w->consecutive_faults = 0;
+  w->fault_threshold = threshold;
+  w->core1_enabled = 1;
+}
+
+void taskq_watchdog_on_fault(taskq_watchdog_t *w)
+{
+  w->consecutive_faults++;
+  if (w->fault_threshold != 0 && w->consecutive_faults >= w->fault_threshold) {
+    w->core1_enabled = 0;
+  }
+}
+
+void taskq_watchdog_on_success(taskq_watchdog_t *w)
+{
+  w->consecutive_faults = 0;
+}
+
+int taskq_watchdog_core1_enabled(const taskq_watchdog_t *w)
+{
+  return w->core1_enabled;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -114,3 +114,31 @@ int taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
   }
   return -1;
 }
+
+/* ---- atomic claim (consumer): CAS QUEUED -> CLAIMED ---- */
+int taskq_claim_any(taskq_t *q)
+{
+  uint32_t i;
+  for (i = 0; i < TASKQ_CAPACITY; i++) {
+    volatile uint32_t *s = &q->descs[i].state;
+    if (*s == TASK_QUEUED && taskq_cas_u32(s, TASK_QUEUED, TASK_CLAIMED)) {
+      return (int)i;
+    }
+  }
+  return -1;
+}
+
+int taskq_claim_short(taskq_t *q)
+{
+  uint32_t i;
+  for (i = 0; i < TASKQ_CAPACITY; i++) {
+    if (q->descs[i].state == TASK_QUEUED &&
+        q->descs[i].cls == (uint32_t)TASK_SHORT) {
+      volatile uint32_t *s = &q->descs[i].state;
+      if (taskq_cas_u32(s, TASK_QUEUED, TASK_CLAIMED)) {
+        return (int)i;
+      }
+    }
+  }
+  return -1;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -148,8 +148,16 @@ int taskq_claim_short(taskq_t *q)
 {
   uint32_t i;
   for (i = 0; i < TASKQ_CAPACITY; i++) {
-    if (q->descs[i].state == TASK_QUEUED &&
-        q->descs[i].cls == (uint32_t)TASK_SHORT) {
+    if (q->descs[i].state != TASK_QUEUED) {
+      continue;
+    }
+    /* Acquire: order the cls load after observing TASK_QUEUED, pairing with the
+     * dmb-release store of state in taskq_enqueue. Without it the weakly-ordered
+     * A9 could pair a freshly published QUEUED state with a stale cls left over
+     * from this slot's previous task -- a SHORT->LONG reuse would then read
+     * cls == TASK_SHORT and run a LONG crypto op inline on core 0. */
+    taskq_acquire_barrier();
+    if (q->descs[i].cls == (uint32_t)TASK_SHORT) {
       volatile uint32_t *s = &q->descs[i].state;
       if (taskq_cas_u32(s, TASK_QUEUED, TASK_CLAIMED)) {
         return (int)i;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -90,13 +90,15 @@ void taskq_init(taskq_t *q)
 int taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
                   uint32_t in_addr, uint32_t in_len,
                   uint32_t out_addr, uint32_t out_cap,
-                  uint32_t request_id, uint32_t user_cookie)
+                  uint32_t request_id, uint32_t user_cookie,
+                  const void *op_params)
 {
   uint32_t i, idx;
   for (i = 0; i < TASKQ_CAPACITY; i++) {
     idx = (q->enqueue_cursor + i) % TASKQ_CAPACITY;
     if (q->descs[idx].state == TASK_FREE) {
       taskq_desc_t *d = &q->descs[idx];
+      uint32_t k;
       d->cls = (uint32_t)cls;
       d->opcode = opcode;
       d->in_addr = in_addr;
@@ -107,6 +109,11 @@ int taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
       d->user_cookie = user_cookie;
       d->result_status = 0;
       d->result_len = 0;
+      /* Copy the opaque input params before publishing, so a consumer that
+       * claims the QUEUED slot always sees complete params. */
+      for (k = 0; k < TASKQ_OP_PARAM_BYTES; k++) {
+        d->op_params[k] = op_params ? ((const uint8_t *)op_params)[k] : 0;
+      }
       taskq_store_release(&d->state, TASK_QUEUED);  /* publish last */
       q->enqueue_cursor = (idx + 1) % TASKQ_CAPACITY;
       return (int)idx;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -26,6 +26,11 @@ int taskq_cas_u32(volatile uint32_t *p, uint32_t expected, uint32_t desired)
   }
   return 0;
 }
+
+static void taskq_store_release(volatile uint32_t *p, uint32_t v)
+{
+  *p = v;
+}
 #else
 int taskq_cas_u32(volatile uint32_t *p, uint32_t expected, uint32_t desired)
 {
@@ -49,6 +54,12 @@ int taskq_cas_u32(volatile uint32_t *p, uint32_t expected, uint32_t desired)
   (void)old;
   return (int)ok;
 }
+
+static void taskq_store_release(volatile uint32_t *p, uint32_t v)
+{
+  __asm__ __volatile__("dmb ish" ::: "memory");
+  *p = v;
+}
 #endif
 
 /* ---- coherency stress model (used by the Phase 0 two-core torture harness) ---- */
@@ -64,4 +75,42 @@ uint32_t taskq_stress_fill(uint32_t seed, uint32_t index)
 int taskq_stress_check(uint32_t seed, uint32_t index, uint32_t value)
 {
   return taskq_stress_fill(seed, index) == value ? 1 : 0;
+}
+
+/* ---- queue lifecycle: init + single-producer enqueue ---- */
+void taskq_init(taskq_t *q)
+{
+  uint32_t i;
+  for (i = 0; i < TASKQ_CAPACITY; i++) {
+    q->descs[i].state = TASK_FREE;
+  }
+  q->enqueue_cursor = 0;
+}
+
+int taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
+                  uint32_t in_addr, uint32_t in_len,
+                  uint32_t out_addr, uint32_t out_cap,
+                  uint32_t request_id, uint32_t user_cookie)
+{
+  uint32_t i, idx;
+  for (i = 0; i < TASKQ_CAPACITY; i++) {
+    idx = (q->enqueue_cursor + i) % TASKQ_CAPACITY;
+    if (q->descs[idx].state == TASK_FREE) {
+      taskq_desc_t *d = &q->descs[idx];
+      d->cls = (uint32_t)cls;
+      d->opcode = opcode;
+      d->in_addr = in_addr;
+      d->in_len = in_len;
+      d->out_addr = out_addr;
+      d->out_cap = out_cap;
+      d->request_id = request_id;
+      d->user_cookie = user_cookie;
+      d->result_status = 0;
+      d->result_len = 0;
+      taskq_store_release(&d->state, TASK_QUEUED);  /* publish last */
+      q->enqueue_cursor = (idx + 1) % TASKQ_CAPACITY;
+      return (int)idx;
+    }
+  }
+  return -1;
 }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -31,6 +31,10 @@ static void taskq_store_release(volatile uint32_t *p, uint32_t v)
 {
   *p = v;
 }
+
+static void taskq_acquire_barrier(void)
+{
+}
 #else
 int taskq_cas_u32(volatile uint32_t *p, uint32_t expected, uint32_t desired)
 {
@@ -59,6 +63,11 @@ static void taskq_store_release(volatile uint32_t *p, uint32_t v)
 {
   __asm__ __volatile__("dmb ish" ::: "memory");
   *p = v;
+}
+
+static void taskq_acquire_barrier(void)
+{
+  __asm__ __volatile__("dmb ish" ::: "memory");
 }
 #endif
 
@@ -180,6 +189,11 @@ int taskq_harvest(taskq_t *q)
   for (i = 0; i < TASKQ_CAPACITY; i++) {
     uint32_t st = q->descs[i].state;
     if (st == TASK_DONE || st == TASK_FAILED) {
+      /* Acquire: order the consumer's later result_status/result_payload reads
+       * after this terminal-state load. Pairs with the dmb-release store in
+       * taskq_complete()/taskq_fail(); without it the weakly-ordered A9 may
+       * observe TASK_DONE yet read stale/zero result fields. */
+      taskq_acquire_barrier();
       return (int)i;
     }
   }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -121,7 +121,6 @@ int  scheduler_core1_available(void);      /* core 1 started and not watchdog-di
 void scheduler_confirm_core1_boot(void);   /* core 0: bounded wait for worker liveness at boot */
 void scheduler_core1_worker(void);         /* core 1: dedicated task worker; never returns */
 void scheduler_core0_poll(int zorro_pending, int display_pending); /* core 0: harvest+post+drain */
-void scheduler_core1_divert_reclaim(void); /* core 0: take scheduler offline + reclaim tasks when core 1 is diverted (must be called with core 1 halted) */
 #endif
 
 #if defined(SCHED_STRESS_TEST) && !defined(TASKQ_HOST_TEST)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -117,6 +117,7 @@ taskq_shared_t *scheduler_shared(void);    /* the coherent control block */
 void scheduler_boot_init(void);            /* core 0: init queue + watchdog at boot */
 int  scheduler_core1_available(void);      /* core 1 started and not watchdog-disabled */
 void scheduler_core1_worker(void);         /* core 1: dedicated task worker; never returns */
+void scheduler_core0_poll(int zorro_pending, int display_pending); /* core 0: harvest+post+drain */
 #endif
 
 #if defined(SCHED_STRESS_TEST) && !defined(TASKQ_HOST_TEST)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -121,6 +121,7 @@ int  scheduler_core1_available(void);      /* core 1 started and not watchdog-di
 void scheduler_confirm_core1_boot(void);   /* core 0: bounded wait for worker liveness at boot */
 void scheduler_core1_worker(void);         /* core 1: dedicated task worker; never returns */
 void scheduler_core0_poll(int zorro_pending, int display_pending); /* core 0: harvest+post+drain */
+void scheduler_core1_divert_reclaim(void); /* core 0: take scheduler offline + reclaim tasks when core 1 is diverted (must be called with core 1 halted) */
 #endif
 
 #if defined(SCHED_STRESS_TEST) && !defined(TASKQ_HOST_TEST)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -90,6 +90,7 @@ void taskq_complete(taskq_t *q, int slot, uint16_t status,
 void taskq_fail(taskq_t *q, int slot, uint16_t status);
 int  taskq_harvest(taskq_t *q);
 void taskq_release(taskq_t *q, int slot);
+int  taskq_has_active(taskq_t *q);         /* any slot still QUEUED or CLAIMED */
 
 /* ---- dispatch policy (portable) ---- */
 taskq_class_t taskq_class_for_opcode(uint32_t opcode, uint32_t in_len);
@@ -121,6 +122,7 @@ int  scheduler_core1_available(void);      /* core 1 started and not watchdog-di
 void scheduler_confirm_core1_boot(void);   /* core 0: bounded wait for worker liveness at boot */
 void scheduler_core1_worker(void);         /* core 1: dedicated task worker; never returns */
 void scheduler_core0_poll(int zorro_pending, int display_pending); /* core 0: harvest+post+drain */
+void scheduler_quiesce_for_reset(void);    /* core 0: drain in-flight core-1 tasks + reset queue before a mailbox teardown */
 #endif
 
 #if defined(SCHED_STRESS_TEST) && !defined(TASKQ_HOST_TEST)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -106,4 +106,10 @@ int taskq_cas_u32(volatile uint32_t *p, uint32_t expected, uint32_t desired);
 extern int taskq_test_force_cas_fail;  /* >0: force the next N CAS calls to fail */
 #endif
 
+#ifndef TASKQ_HOST_TEST
+/* ARM-only glue (scheduler_arm.c). Not visible to the host test build. */
+void scheduler_coherency_init_core0(void); /* core 0: mark region shareable */
+void scheduler_coherency_init_core1(void); /* core 1: full MMU/cache/SMP bring-up */
+#endif
+
 #endif /* ZZ9K_SCHEDULER_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -116,6 +116,7 @@ void scheduler_coherency_init_core1(void); /* core 1: full MMU/cache/SMP bring-u
 taskq_shared_t *scheduler_shared(void);    /* the coherent control block */
 void scheduler_boot_init(void);            /* core 0: init queue + watchdog at boot */
 int  scheduler_core1_available(void);      /* core 1 started and not watchdog-disabled */
+void scheduler_core1_worker(void);         /* core 1: dedicated task worker; never returns */
 #endif
 
 #if defined(SCHED_STRESS_TEST) && !defined(TASKQ_HOST_TEST)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -112,4 +112,12 @@ void scheduler_coherency_init_core0(void); /* core 0: mark region shareable */
 void scheduler_coherency_init_core1(void); /* core 1: full MMU/cache/SMP bring-up */
 #endif
 
+#if defined(SCHED_STRESS_TEST) && !defined(TASKQ_HOST_TEST)
+/* Phase 0 coherency torture harness (scheduler_stress.c). Turns the whole
+ * firmware into a two-core stress test; none of these return. */
+void scheduler_stress_init(void);   /* core 0: init the shared block (pre core-1) */
+void scheduler_stress_core0(void);  /* core 0: producer + drain + verify + report */
+void scheduler_stress_core1(void);  /* core 1: dedicated consumer */
+#endif
+
 #endif /* ZZ9K_SCHEDULER_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -116,6 +116,7 @@ void scheduler_coherency_init_core1(void); /* core 1: full MMU/cache/SMP bring-u
 taskq_shared_t *scheduler_shared(void);    /* the coherent control block */
 void scheduler_boot_init(void);            /* core 0: init queue + watchdog at boot */
 int  scheduler_core1_available(void);      /* core 1 started and not watchdog-disabled */
+void scheduler_confirm_core1_boot(void);   /* core 0: bounded wait for worker liveness at boot */
 void scheduler_core1_worker(void);         /* core 1: dedicated task worker; never returns */
 void scheduler_core0_poll(int zorro_pending, int display_pending); /* core 0: harvest+post+drain */
 #endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -82,7 +82,7 @@ int  taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
                    uint32_t in_addr, uint32_t in_len,
                    uint32_t out_addr, uint32_t out_cap,
                    uint32_t request_id, uint32_t user_cookie,
-                   const void *op_params);
+                   const void *op_params, uint32_t param_len);
 int  taskq_claim_any(taskq_t *q);
 int  taskq_claim_short(taskq_t *q);
 void taskq_complete(taskq_t *q, int slot, uint16_t status,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -1,0 +1,109 @@
+/*
+ * ZZ9000 dual-core task scheduler -- portable core interface.
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This header and scheduler.c are deliberately free of xil_ and firmware
+ * includes so the queue/claim/harvest/policy/watchdog state machine is unit-tested
+ * off-target (system cc, -DTASKQ_HOST_TEST). ARM-only glue lives in
+ * scheduler_arm.c / scheduler_stress.c.
+ */
+#ifndef ZZ9K_SCHEDULER_H
+#define ZZ9K_SCHEDULER_H
+
+#include <stdint.h>
+
+#define TASKQ_CAPACITY         16u
+#define TASKQ_SHORT_MAX_BYTES  4096u
+#define TASKQ_RESULT_PAYLOAD   48u
+
+/* Crypto opcodes mirrored from sdk_mailbox.h. scheduler_arm.c carries
+ * _Static_assert drift guards proving these match the firmware definitions. */
+#define TASKQ_OP_CRYPTO_HASH   0x0800u
+#define TASKQ_OP_CRYPTO_STREAM 0x0801u
+#define TASKQ_OP_CRYPTO_AEAD   0x0802u
+#define TASKQ_OP_CRYPTO_KX     0x0803u
+#define TASKQ_OP_CRYPTO_VERIFY 0x0804u
+
+typedef enum {
+  TASK_FREE    = 0,
+  TASK_QUEUED  = 1,
+  TASK_CLAIMED = 2,
+  TASK_DONE    = 3,
+  TASK_FAILED  = 4
+} taskq_state_t;
+
+typedef enum {
+  TASK_SHORT = 0,
+  TASK_LONG  = 1
+} taskq_class_t;
+
+typedef struct {
+  volatile uint32_t state;      /* taskq_state_t; CAS target */
+  uint32_t cls;                 /* taskq_class_t */
+  uint32_t opcode;
+  uint32_t in_addr;             /* card DDR address of input buffer */
+  uint32_t in_len;
+  uint32_t out_addr;            /* card DDR address of output buffer */
+  uint32_t out_cap;
+  uint32_t request_id;
+  uint32_t user_cookie;
+  uint16_t result_status;       /* SDK_STATUS_* to post on completion */
+  uint16_t result_len;          /* completion payload length */
+  uint8_t  result_payload[TASKQ_RESULT_PAYLOAD];
+} taskq_desc_t;
+
+typedef struct {
+  taskq_desc_t descs[TASKQ_CAPACITY];
+  uint32_t     enqueue_cursor;  /* single-producer hint (core 0 only) */
+} taskq_t;
+
+typedef struct {                /* coherent control block at the queue region */
+  taskq_t          queue;
+  volatile int32_t  core1_current_slot;     /* slot core 1 is running; -1 idle */
+  volatile uint32_t core1_restart_request;  /* core 1 sets on fault; core 0 clears */
+  volatile uint32_t core1_fault_code;       /* last fault code */
+  volatile uint32_t core1_alive;            /* worker sets 1 on entry */
+} taskq_shared_t;
+
+typedef struct {
+  uint32_t consecutive_faults;
+  uint32_t fault_threshold;
+  int      core1_enabled;
+} taskq_watchdog_t;
+
+/* ---- queue lifecycle (portable) ---- */
+void taskq_init(taskq_t *q);
+int  taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
+                   uint32_t in_addr, uint32_t in_len,
+                   uint32_t out_addr, uint32_t out_cap,
+                   uint32_t request_id, uint32_t user_cookie);
+int  taskq_claim_any(taskq_t *q);
+int  taskq_claim_short(taskq_t *q);
+void taskq_complete(taskq_t *q, int slot, uint16_t status,
+                    const uint8_t *payload, uint16_t payload_len);
+void taskq_fail(taskq_t *q, int slot, uint16_t status);
+int  taskq_harvest(taskq_t *q);
+void taskq_release(taskq_t *q, int slot);
+
+/* ---- dispatch policy (portable) ---- */
+taskq_class_t taskq_class_for_opcode(uint32_t opcode, uint32_t in_len);
+int  taskq_should_drain(int zorro_pending, int display_pending, int core1_enabled);
+
+/* ---- fault watchdog (portable) ---- */
+void taskq_watchdog_init(taskq_watchdog_t *w, uint32_t threshold);
+void taskq_watchdog_on_fault(taskq_watchdog_t *w);
+void taskq_watchdog_on_success(taskq_watchdog_t *w);
+int  taskq_watchdog_core1_enabled(const taskq_watchdog_t *w);
+
+/* ---- coherency stress model (portable; Phase 0 harness uses these) ---- */
+uint32_t taskq_stress_fill(uint32_t seed, uint32_t index);
+int      taskq_stress_check(uint32_t seed, uint32_t index, uint32_t value);
+
+/* ---- atomic primitive seam ---- */
+int taskq_cas_u32(volatile uint32_t *p, uint32_t expected, uint32_t desired);
+#ifdef TASKQ_HOST_TEST
+extern int taskq_test_force_cas_fail;  /* >0: force the next N CAS calls to fail */
+#endif
+
+#endif /* ZZ9K_SCHEDULER_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -16,6 +16,7 @@
 #define TASKQ_CAPACITY         16u
 #define TASKQ_SHORT_MAX_BYTES  4096u
 #define TASKQ_RESULT_PAYLOAD   48u
+#define TASKQ_OP_PARAM_BYTES   48u   /* opaque per-task input params (firmware) */
 
 /* Crypto opcodes mirrored from sdk_mailbox.h. scheduler_arm.c carries
  * _Static_assert drift guards proving these match the firmware definitions. */
@@ -51,6 +52,7 @@ typedef struct {
   uint16_t result_status;       /* SDK_STATUS_* to post on completion */
   uint16_t result_len;          /* completion payload length */
   uint8_t  result_payload[TASKQ_RESULT_PAYLOAD];
+  uint8_t  op_params[TASKQ_OP_PARAM_BYTES]; /* producer-filled input params */
 } taskq_desc_t;
 
 typedef struct {
@@ -77,7 +79,8 @@ void taskq_init(taskq_t *q);
 int  taskq_enqueue(taskq_t *q, uint32_t opcode, taskq_class_t cls,
                    uint32_t in_addr, uint32_t in_len,
                    uint32_t out_addr, uint32_t out_cap,
-                   uint32_t request_id, uint32_t user_cookie);
+                   uint32_t request_id, uint32_t user_cookie,
+                   const void *op_params);
 int  taskq_claim_any(taskq_t *q);
 int  taskq_claim_short(taskq_t *q);
 void taskq_complete(taskq_t *q, int slot, uint16_t status,
@@ -110,6 +113,9 @@ extern int taskq_test_force_cas_fail;  /* >0: force the next N CAS calls to fail
 /* ARM-only glue (scheduler_arm.c). Not visible to the host test build. */
 void scheduler_coherency_init_core0(void); /* core 0: mark region shareable */
 void scheduler_coherency_init_core1(void); /* core 1: full MMU/cache/SMP bring-up */
+taskq_shared_t *scheduler_shared(void);    /* the coherent control block */
+void scheduler_boot_init(void);            /* core 0: init queue + watchdog at boot */
+int  scheduler_core1_available(void);      /* core 1 started and not watchdog-disabled */
 #endif
 
 #if defined(SCHED_STRESS_TEST) && !defined(TASKQ_HOST_TEST)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -66,6 +66,8 @@ typedef struct {                /* coherent control block at the queue region */
   volatile uint32_t core1_restart_request;  /* core 1 sets on fault; core 0 clears */
   volatile uint32_t core1_fault_code;       /* last fault code */
   volatile uint32_t core1_alive;            /* worker sets 1 on entry */
+  volatile uint32_t tasks_on_core1;         /* core-1 worker: tasks it executed */
+  volatile uint32_t tasks_on_core0;         /* core-0: inline dispatch + drains  */
 } taskq_shared_t;
 
 typedef struct {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -228,6 +228,13 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
 
   while ((slot = taskq_harvest(&sh->queue)) >= 0) {
     taskq_desc_t *d = &sh->queue.descs[slot];
+    if (!sdk_mailbox_task_gen_ok(slot)) {
+      /* Task submitted under a previous mailbox lifetime (the mailbox was
+       * re-initialised while it was in flight). Drop it without posting so its
+       * stale request_id/user_cookie never lands in the new completion ring. */
+      taskq_release(&sh->queue, slot);
+      continue;
+    }
     int failed = (d->state == TASK_FAILED);
     uint16_t status = failed ? SDK_STATUS_INTERNAL_ERROR : d->result_status;
     if (!sdk_mailbox_post_deferred(d->request_id, d->user_cookie,
@@ -271,6 +278,41 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
       (void)scheduler_run_slot(&sh->queue.descs[slot]);
       sh->tasks_on_core0++;
     }
+  }
+}
+
+/*
+ * Core 0 is diverting core 1 away from the scheduler worker -- e.g. the legacy
+ * REG_ZZ_ARM_RUN trampoline uploads a native ARM app that takes over core 1.
+ * The caller MUST have already halted/reset core 1 (so it can no longer touch
+ * the queue); core 0 then owns the queue exclusively here. Mark the scheduler
+ * offline so crypto_dispatch stops enqueueing to a worker that will never run
+ * again (new requests compute inline on core 0), and reclaim every outstanding
+ * task so nothing a caller already submitted is lost:
+ *   - the slot the worker had in flight (core1_current_slot) was abandoned
+ *     CLAIMED at the reset -> recompute it inline;
+ *   - anything still QUEUED -> drain inline.
+ * DONE/FAILED slots are left for the next scheduler_core0_poll to post.
+ */
+void scheduler_core1_divert_reclaim(void)
+{
+  taskq_shared_t *sh = scheduler_shared();
+  int slot;
+
+  g_core1_started = 0;   /* scheduler_core1_available() -> 0 from now on */
+
+  if (sh->core1_current_slot >= 0) {
+    taskq_desc_t *d = &sh->queue.descs[sh->core1_current_slot];
+    if (d->state == TASK_CLAIMED) {
+      (void)scheduler_run_slot(d);
+      sh->tasks_on_core0++;
+    }
+    sh->core1_current_slot = -1;
+  }
+
+  while ((slot = taskq_claim_any(&sh->queue)) >= 0) {
+    (void)scheduler_run_slot(&sh->queue.descs[slot]);
+    sh->tasks_on_core0++;
   }
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -13,6 +13,7 @@
 #include "scheduler.h"
 #include "memorymap.h"
 #include "sdk_mailbox.h"
+#include "core2.h"
 #include "xil_types.h"
 #include "xil_mmu.h"
 #include "xil_cache.h"
@@ -110,17 +111,21 @@ void scheduler_coherency_init_core1(void)
 }
 
 /*
- * Run one claimed task's compute on the calling core and mark it DONE.
+ * Run one claimed task's compute on the calling core and mark it DONE. This is
+ * the scheduler's compute-dispatch seam: the queue/worker/harvest machinery is
+ * opcode-agnostic, and this function routes a task to its service handler.
+ * Phase 1 wires only the crypto service (sdk_mailbox_run_crypto_task); later
+ * phases extend the dispatch to image/compression and MP3 offload here.
  *
- * The compute (sdk_mailbox_run_crypto_task) owns all data-buffer cache
- * maintenance, so this runs correctly on whichever core executes it: core 1 in
- * the normal async path, or core 0 on the inline/fallback and SHORT-drain paths
- * (scheduler_core0_poll). A crypto op that ran to completion -- including a
- * legitimate failure such as an AEAD auth mismatch -- is a DONE task carrying
- * its exact SDK_STATUS_*; only a core-1 hardware fault (handled in core2.c)
- * marks a slot FAILED. The completion payload is always one
- * SDKCryptoResultPayload (== TASKQ_RESULT_PAYLOAD bytes) on success, none on
- * error, matching the pre-scheduler handlers byte-for-byte.
+ * The service handler owns all data-buffer cache maintenance, so this runs
+ * correctly on whichever core executes it: core 1 in the normal async path, or
+ * core 0 on the inline/fallback and SHORT-drain paths (scheduler_core0_poll). A
+ * task that ran to completion -- including a legitimate failure such as an AEAD
+ * auth mismatch -- is a DONE task carrying its exact SDK_STATUS_*; only a
+ * core-1 hardware fault (handled in core2.c) marks a slot FAILED. For crypto the
+ * completion payload is always one SDKCryptoResultPayload (== TASKQ_RESULT_PAYLOAD
+ * bytes) on success, none on error, matching the pre-scheduler handlers
+ * byte-for-byte.
  */
 static uint16_t scheduler_run_slot(taskq_desc_t *d)
 {
@@ -164,18 +169,26 @@ void scheduler_core1_worker(void)
 }
 
 /*
- * Core-0 poll, called once per main-loop iteration. Two jobs:
+ * Core-0 poll, called once per main-loop iteration. The queue, worker, harvest,
+ * and completion posting here are opcode-agnostic -- they carry whatever task
+ * the worker ran. Phase 1 wires only the crypto service to the queue (see
+ * scheduler_run_slot); later phases add image/compression and MP3 offload
+ * without changing this machinery. Three jobs:
  *   1. Harvest tasks the worker finished (DONE/FAILED) and post their deferred
  *      completions to the Amiga via sdk_mailbox_post_deferred. A DONE task
- *      carries its exact crypto status; a FAILED task (core-1 fault) posts the
+ *      carries its exact result status; a FAILED task (core-1 fault) posts the
  *      generic SDK_STATUS_INTERNAL_ERROR so the Amiga falls back to software.
  *      Each successful DONE clears the fault watchdog. If the completion ring
  *      is full the task stays harvested and is retried on the next poll.
- *   2. Opportunistically drain one SHORT task inline in idle windows -- only
+ *   2. Service a core-1 fault: if the worker faulted it marked its in-flight
+ *      slot FAILED (harvested above) and set core1_restart_request. Trip the
+ *      watchdog; while it still has core 1 enabled, cold-restart the core. Once
+ *      the watchdog trips (too many consecutive faults) leave core 1 down and
+ *      fall to single-core mode.
+ *   3. Opportunistically drain one SHORT task inline in idle windows -- only
  *      when core 1 is enabled and neither a Zorro register request nor display
  *      work is pending this iteration (taskq_should_drain). This soaks up
- *      latency-sensitive work (KX/VERIFY) without stealing cycles from
- *      Amiga-facing I/O.
+ *      latency-sensitive work without stealing cycles from Amiga-facing I/O.
  */
 void scheduler_core0_poll(int zorro_pending, int display_pending)
 {
@@ -195,6 +208,17 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
       taskq_watchdog_on_success(&g_sched_watchdog);
     }
     taskq_release(&sh->queue, slot);
+  }
+
+  if (sh->core1_restart_request) {
+    sh->core1_restart_request = 0;
+    dmb();  /* publish the clear before the reset re-enters the worker */
+    taskq_watchdog_on_fault(&g_sched_watchdog);
+    if (taskq_watchdog_core1_enabled(&g_sched_watchdog)) {
+      core1_cold_restart();
+    } else {
+      g_core1_started = 0;  /* give up on core 1 -> single-core fallback */
+    }
   }
 
   if (taskq_should_drain(zorro_pending, display_pending,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -193,6 +193,7 @@ void scheduler_core1_worker(void)
     sh->core1_current_slot = slot;
     (void)scheduler_run_slot(&sh->queue.descs[slot]);
     sh->core1_current_slot = -1;
+    sh->tasks_on_core1++;   /* proof: this core executed a crypto task */
   }
 }
 
@@ -259,12 +260,14 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
      */
     while ((slot = taskq_claim_any(&sh->queue)) >= 0) {
       (void)scheduler_run_slot(&sh->queue.descs[slot]);
+      sh->tasks_on_core0++;
     }
   } else if (taskq_should_drain(zorro_pending, display_pending, 1)) {
     /* Opportunistic SHORT drain in idle windows while core 1 is healthy. */
     slot = taskq_claim_short(&sh->queue);
     if (slot >= 0) {
       (void)scheduler_run_slot(&sh->queue.descs[slot]);
+      sh->tasks_on_core0++;
     }
   }
 }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -282,8 +282,9 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
 }
 
 /* Bounded quiesce wait: crypto tasks are sub-millisecond, so 5000 * 10us = 50ms
- * is far beyond a normal drain; the cap only bounds a wedged worker (which the
- * fault watchdog handles separately). */
+ * is far beyond a normal drain. If a task is still active when the cap expires
+ * it is either wedged or a legitimately long op mid-write -- either way core 1
+ * is force-reset (see below) rather than left to race the mailbox teardown. */
 #define SCHED_QUIESCE_SPINS  5000u
 #define SCHED_QUIESCE_US       10u
 
@@ -295,6 +296,14 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
  * owner even though the stale completion is dropped by the generation tag. Wait
  * for every queued/in-flight task to finish, then re-init the queue so no task
  * survives into the next mailbox lifetime.
+ *
+ * If a task outlives the bounded wait (a wedged worker, or a genuinely long
+ * hash/stream/AEAD), we must NOT just reinit and free its buffers -- the worker
+ * still owns those addresses and would write into memory the mailbox is about
+ * to reuse. Cold-reset core 1 first: that halts the worker mid-op, guaranteeing
+ * no write survives into the next lifetime. The worker re-enters core1_loop and
+ * parks on the now-empty queue; core 0's next scheduler_boot path / poll brings
+ * it back. Draining is the fast path; the reset is the safety net.
  *
  * Race-free without a worker handshake: this runs on core 0's main loop, the
  * sole task producer, so once the queue reads empty no new task can appear.
@@ -311,6 +320,13 @@ void scheduler_quiesce_for_reset(void)
     if (!taskq_has_active(&sh->queue))
       break;
     usleep(SCHED_QUIESCE_US);
+  }
+
+  if (taskq_has_active(&sh->queue)) {
+    /* Task still running after the cap -> halt core 1 before we free its
+     * buffers, so no in-flight write reaches the reused memory. */
+    core1_cold_restart();
+    sh->core1_restart_request = 0;   /* consumed here; don't double-restart */
   }
 
   taskq_init(&sh->queue);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -1,0 +1,74 @@
+/*
+ * ZZ9000 dual-core task scheduler -- ARM-only glue.
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * This file carries the Cortex-A9 / Xilinx-BSP integration that cannot be
+ * host-tested: SCU/SMP coherency bring-up, the coherent shared control block,
+ * the core-1 worker, and the core-0 poll. The portable state machine it drives
+ * lives in scheduler.c (host-tested). Compiled out of the host test build.
+ */
+#ifndef TASKQ_HOST_TEST
+
+#include "scheduler.h"
+#include "memorymap.h"
+#include "xil_types.h"
+#include "xil_mmu.h"
+#include "xil_cache.h"
+#include "xpseudo_asm.h"
+#include "xreg_cortexa9.h"
+
+/* BSP flat 1 MB-section translation table (translation_table.S). */
+extern u32 MMUTable;
+
+/* TTBR0 page-table-walk attributes: outer cacheable write-back, matching the
+ * value boot.S programs on core 0 (0x5B). */
+#define TASKQ_TTBR0_ATTR 0x5BU
+
+static void taskq_set_smp_bit(void)
+{
+  /* ACTLR (CP15 c1,c0,1): bit 6 = SMP (participate in SCU coherency),
+   * bit 0 = cache/TLB maintenance broadcast. Set before enabling the D-cache. */
+  u32 actlr = mfcp(XREG_CP15_AUX_CONTROL);
+  actlr |= (1U << 6) | (1U << 0);
+  mtcp(XREG_CP15_AUX_CONTROL, actlr);
+  dsb();
+  isb();
+}
+
+void scheduler_coherency_init_core0(void)
+{
+  /* Core 0 already runs with MMU + D-cache + SMP (BSP boot.S). Only mark the
+   * task-queue region Normal, Inner-Shareable, cacheable write-back in the
+   * shared translation table so the SCU keeps it coherent with core 1. This
+   * runs at boot before core 1 is started. */
+  Xil_SetTlbAttributes(SDK_TASKQ_REGION_ADDRESS, NORM_WB_CACHE);
+}
+
+void scheduler_coherency_init_core1(void)
+{
+  /* Core 1 is entered straight from the CPU1 reset vector (core1_loop),
+   * bypassing boot.S, so it starts with MMU + caches + SMP OFF. Bring it up to
+   * match core 0 so cross-core LDREX/STREX and SCU coherency work:
+   *   1. point TTBR0 at the shared translation table (same table as core 0),
+   *   2. set the domain access control (all domains manager),
+   *   3. set ACTLR.SMP before enabling the D-cache,
+   *   4. enable MMU + D-cache (Xil_EnableMMU invalidates I/D caches first),
+   *   5. refresh the shareable attribute so this core's TLB reflects it.
+   * The region was already marked shareable by scheduler_coherency_init_core0()
+   * at boot, before this core started. */
+  u32 ttbr0 = (u32)(UINTPTR)&MMUTable | TASKQ_TTBR0_ATTR;
+
+  mtcp(XREG_CP15_TTBR0, ttbr0);
+  mtcp(XREG_CP15_DOMAIN_ACCESS_CTRL, 0xFFFFFFFFU); /* all domains: manager */
+  dsb();
+  isb();
+
+  taskq_set_smp_bit();
+
+  Xil_EnableMMU();                                 /* enable MMU + D-cache */
+
+  Xil_SetTlbAttributes(SDK_TASKQ_REGION_ADDRESS, NORM_WB_CACHE);
+}
+
+#endif /* TASKQ_HOST_TEST */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -51,6 +51,8 @@ void scheduler_boot_init(void)
   sh->core1_restart_request = 0;
   sh->core1_fault_code = 0;
   sh->core1_alive = 0;
+  sh->tasks_on_core1 = 0;   /* observability counters live in uninitialised DDR */
+  sh->tasks_on_core0 = 0;   /* until zeroed here -- must not read back as garbage */
   taskq_watchdog_init(&g_sched_watchdog, 3u);
   g_core1_started = 0;
 }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -312,6 +312,7 @@ void scheduler_quiesce_for_reset(void)
 {
   taskq_shared_t *sh = scheduler_shared();
   uint32_t spins;
+  int timed_out;
 
   if (!scheduler_core1_available())
     return;   /* no core-1 worker -> no in-flight writes to drain */
@@ -322,15 +323,23 @@ void scheduler_quiesce_for_reset(void)
     usleep(SCHED_QUIESCE_US);
   }
 
-  if (taskq_has_active(&sh->queue)) {
-    /* Task still running after the cap -> halt core 1 before we free its
-     * buffers, so no in-flight write reaches the reused memory. */
+  /* Clear the queue BEFORE any restart, so a restarted worker finds no QUEUED
+   * descriptor to claim. Capture the timeout first -- taskq_init would mask it.
+   * taskq_init leaves zero QUEUED slots, and the worker only ever claims QUEUED,
+   * so it cannot pick up a stale task and write into buffers the mailbox is
+   * about to reuse. */
+  timed_out = taskq_has_active(&sh->queue);
+  taskq_init(&sh->queue);
+  sh->core1_current_slot = -1;
+
+  if (timed_out) {
+    /* A task outlived the wait and is still writing its buffers. Cold-reset
+     * core 1 to halt it before those buffers are freed. The queue is already
+     * cleared above and core1_cold_restart flushes the whole D-cache before
+     * releasing CPU1, so the restarted worker re-enters onto the empty queue. */
     core1_cold_restart();
     sh->core1_restart_request = 0;   /* consumed here; don't double-restart */
   }
-
-  taskq_init(&sh->queue);
-  sh->core1_current_slot = -1;
 }
 
 #endif /* TASKQ_HOST_TEST */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -281,39 +281,4 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
   }
 }
 
-/*
- * Core 0 is diverting core 1 away from the scheduler worker -- e.g. the legacy
- * REG_ZZ_ARM_RUN trampoline uploads a native ARM app that takes over core 1.
- * The caller MUST have already halted/reset core 1 (so it can no longer touch
- * the queue); core 0 then owns the queue exclusively here. Mark the scheduler
- * offline so crypto_dispatch stops enqueueing to a worker that will never run
- * again (new requests compute inline on core 0), and reclaim every outstanding
- * task so nothing a caller already submitted is lost:
- *   - the slot the worker had in flight (core1_current_slot) was abandoned
- *     CLAIMED at the reset -> recompute it inline;
- *   - anything still QUEUED -> drain inline.
- * DONE/FAILED slots are left for the next scheduler_core0_poll to post.
- */
-void scheduler_core1_divert_reclaim(void)
-{
-  taskq_shared_t *sh = scheduler_shared();
-  int slot;
-
-  g_core1_started = 0;   /* scheduler_core1_available() -> 0 from now on */
-
-  if (sh->core1_current_slot >= 0) {
-    taskq_desc_t *d = &sh->queue.descs[sh->core1_current_slot];
-    if (d->state == TASK_CLAIMED) {
-      (void)scheduler_run_slot(d);
-      sh->tasks_on_core0++;
-    }
-    sh->core1_current_slot = -1;
-  }
-
-  while ((slot = taskq_claim_any(&sh->queue)) >= 0) {
-    (void)scheduler_run_slot(&sh->queue.descs[slot]);
-    sh->tasks_on_core0++;
-  }
-}
-
 #endif /* TASKQ_HOST_TEST */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -14,6 +14,7 @@
 #include "memorymap.h"
 #include "sdk_mailbox.h"
 #include "core2.h"
+#include "sleep.h"
 #include "xil_types.h"
 #include "xil_mmu.h"
 #include "xil_cache.h"
@@ -58,6 +59,33 @@ int scheduler_core1_available(void)
 {
   return (g_core1_started != 0 &&
           taskq_watchdog_core1_enabled(&g_sched_watchdog)) ? 1 : 0;
+}
+
+/* Bounded wait for core 1's worker to come up, ~100 ms total. */
+#define SCHED_CORE1_BOOT_SPINS   1000u
+#define SCHED_CORE1_BOOT_US       100u
+
+void scheduler_confirm_core1_boot(void)
+{
+  taskq_shared_t *sh = scheduler_shared();
+  uint32_t spins;
+
+  /*
+   * Core 0 calls this once, after arm_app_init() has launched core 1. The
+   * worker publishes core1_alive in the coherent shared block on entry
+   * (scheduler_core1_worker); wait a bounded time for it. Only once seen do we
+   * set g_core1_started, which gates scheduler_core1_available() and hence the
+   * whole async offload path. If core 1 never checks in (absent, or wedged
+   * before the worker), we stay in single-core mode and every task runs inline.
+   */
+  for (spins = 0; spins < SCHED_CORE1_BOOT_SPINS; spins++) {
+    if (sh->core1_alive != 0) {
+      g_core1_started = 1;
+      return;
+    }
+    usleep(SCHED_CORE1_BOOT_US);
+  }
+  /* timeout: leave g_core1_started = 0 -> single-core fallback */
 }
 
 /* TTBR0 page-table-walk attributes: outer cacheable write-back, matching the
@@ -221,8 +249,19 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
     }
   }
 
-  if (taskq_should_drain(zorro_pending, display_pending,
-                         scheduler_core1_available())) {
+  if (!scheduler_core1_available()) {
+    /*
+     * Single-core fallback: core 1 is absent or the watchdog disabled it. New
+     * crypto requests already compute inline in the front (crypto_dispatch), so
+     * the queue only holds tasks stranded when core 1 died mid-flight. Drain
+     * them ALL inline (claim_any, not claim_short) so nothing is lost; they are
+     * posted on the next poll's harvest.
+     */
+    while ((slot = taskq_claim_any(&sh->queue)) >= 0) {
+      (void)scheduler_run_slot(&sh->queue.descs[slot]);
+    }
+  } else if (taskq_should_drain(zorro_pending, display_pending, 1)) {
+    /* Opportunistic SHORT drain in idle windows while core 1 is healthy. */
     slot = taskq_claim_short(&sh->queue);
     if (slot >= 0) {
       (void)scheduler_run_slot(&sh->queue.descs[slot]);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -281,4 +281,40 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
   }
 }
 
+/* Bounded quiesce wait: crypto tasks are sub-millisecond, so 5000 * 10us = 50ms
+ * is far beyond a normal drain; the cap only bounds a wedged worker (which the
+ * fault watchdog handles separately). */
+#define SCHED_QUIESCE_SPINS  5000u
+#define SCHED_QUIESCE_US       10u
+
+/*
+ * Quiesce the scheduler before a mailbox teardown (sdk_mailbox_init on Amiga
+ * reset / firmware-update). Core 1's worker writes each task's result into the
+ * task's resolved data buffers; if the mailbox frees and re-hands-out those
+ * buffers while a task is still in flight, the late write corrupts the new
+ * owner even though the stale completion is dropped by the generation tag. Wait
+ * for every queued/in-flight task to finish, then re-init the queue so no task
+ * survives into the next mailbox lifetime.
+ *
+ * Race-free without a worker handshake: this runs on core 0's main loop, the
+ * sole task producer, so once the queue reads empty no new task can appear.
+ */
+void scheduler_quiesce_for_reset(void)
+{
+  taskq_shared_t *sh = scheduler_shared();
+  uint32_t spins;
+
+  if (!scheduler_core1_available())
+    return;   /* no core-1 worker -> no in-flight writes to drain */
+
+  for (spins = 0; spins < SCHED_QUIESCE_SPINS; spins++) {
+    if (!taskq_has_active(&sh->queue))
+      break;
+    usleep(SCHED_QUIESCE_US);
+  }
+
+  taskq_init(&sh->queue);
+  sh->core1_current_slot = -1;
+}
+
 #endif /* TASKQ_HOST_TEST */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -109,4 +109,58 @@ void scheduler_coherency_init_core1(void)
   Xil_SetTlbAttributes(SDK_TASKQ_REGION_ADDRESS, NORM_WB_CACHE);
 }
 
+/*
+ * Run one claimed task's compute on the calling core and mark it DONE.
+ *
+ * The compute (sdk_mailbox_run_crypto_task) owns all data-buffer cache
+ * maintenance, so this runs correctly on whichever core executes it: core 1 in
+ * the normal async path, or core 0 on the inline/fallback and SHORT-drain paths
+ * (scheduler_core0_poll). A crypto op that ran to completion -- including a
+ * legitimate failure such as an AEAD auth mismatch -- is a DONE task carrying
+ * its exact SDK_STATUS_*; only a core-1 hardware fault (handled in core2.c)
+ * marks a slot FAILED. The completion payload is always one
+ * SDKCryptoResultPayload (== TASKQ_RESULT_PAYLOAD bytes) on success, none on
+ * error, matching the pre-scheduler handlers byte-for-byte.
+ */
+static uint16_t scheduler_run_slot(taskq_desc_t *d)
+{
+  taskq_shared_t *sh = scheduler_shared();
+  uint8_t payload[TASKQ_RESULT_PAYLOAD];
+  int slot = (int)(d - sh->queue.descs);
+  uint16_t status = sdk_mailbox_run_crypto_task((uint16_t)d->opcode,
+                                                d->op_params, payload);
+  uint16_t len = (status == SDK_STATUS_OK) ? (uint16_t)TASKQ_RESULT_PAYLOAD : 0u;
+  taskq_complete(&sh->queue, slot, status, payload, len);
+  return status;
+}
+
+/*
+ * Core-1 dedicated worker. Entered from core1_loop (core2.c) after coherency
+ * bring-up; never returns. Publishes core1_alive in the coherent shared block
+ * as the boot-start confirmation core 0 waits on (scheduler_core1_available),
+ * then claims and runs tasks. Idles on WFE; the core-0 enqueue path issues SEV
+ * after a release-store so a sleeping worker wakes promptly. core1_current_slot
+ * is set around execution so a fault on core 1 can attribute the in-flight slot
+ * (core2.c fault path). The worker touches only the task queue and the task's
+ * resolved data buffers -- never Zorro, the mailbox, the doorbell, or display.
+ */
+void scheduler_core1_worker(void)
+{
+  taskq_shared_t *sh = scheduler_shared();
+
+  sh->core1_alive = 1;
+  dmb();  /* make the alive flag observable to core 0 before we sleep on WFE */
+
+  for (;;) {
+    int slot = taskq_claim_any(&sh->queue);
+    if (slot < 0) {
+      __asm__ __volatile__("wfe" ::: "memory");
+      continue;
+    }
+    sh->core1_current_slot = slot;
+    (void)scheduler_run_slot(&sh->queue.descs[slot]);
+    sh->core1_current_slot = -1;
+  }
+}
+
 #endif /* TASKQ_HOST_TEST */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -163,4 +163,47 @@ void scheduler_core1_worker(void)
   }
 }
 
+/*
+ * Core-0 poll, called once per main-loop iteration. Two jobs:
+ *   1. Harvest tasks the worker finished (DONE/FAILED) and post their deferred
+ *      completions to the Amiga via sdk_mailbox_post_deferred. A DONE task
+ *      carries its exact crypto status; a FAILED task (core-1 fault) posts the
+ *      generic SDK_STATUS_INTERNAL_ERROR so the Amiga falls back to software.
+ *      Each successful DONE clears the fault watchdog. If the completion ring
+ *      is full the task stays harvested and is retried on the next poll.
+ *   2. Opportunistically drain one SHORT task inline in idle windows -- only
+ *      when core 1 is enabled and neither a Zorro register request nor display
+ *      work is pending this iteration (taskq_should_drain). This soaks up
+ *      latency-sensitive work (KX/VERIFY) without stealing cycles from
+ *      Amiga-facing I/O.
+ */
+void scheduler_core0_poll(int zorro_pending, int display_pending)
+{
+  taskq_shared_t *sh = scheduler_shared();
+  int slot;
+
+  while ((slot = taskq_harvest(&sh->queue)) >= 0) {
+    taskq_desc_t *d = &sh->queue.descs[slot];
+    int failed = (d->state == TASK_FAILED);
+    uint16_t status = failed ? SDK_STATUS_INTERNAL_ERROR : d->result_status;
+    if (!sdk_mailbox_post_deferred(d->request_id, d->user_cookie,
+                                   (uint16_t)d->opcode, status,
+                                   d->result_payload, d->result_len)) {
+      break;  /* completion ring full -> retry next poll */
+    }
+    if (!failed) {
+      taskq_watchdog_on_success(&g_sched_watchdog);
+    }
+    taskq_release(&sh->queue, slot);
+  }
+
+  if (taskq_should_drain(zorro_pending, display_pending,
+                         scheduler_core1_available())) {
+    slot = taskq_claim_short(&sh->queue);
+    if (slot >= 0) {
+      (void)scheduler_run_slot(&sh->queue.descs[slot]);
+    }
+  }
+}
+
 #endif /* TASKQ_HOST_TEST */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -12,6 +12,7 @@
 
 #include "scheduler.h"
 #include "memorymap.h"
+#include "sdk_mailbox.h"
 #include "xil_types.h"
 #include "xil_mmu.h"
 #include "xil_cache.h"
@@ -20,6 +21,43 @@
 
 /* BSP flat 1 MB-section translation table (translation_table.S). */
 extern u32 MMUTable;
+
+/* Compile-time guard: the crypto opcodes the scheduler policy mirrors in
+ * scheduler.h must match the firmware's authoritative definitions. */
+typedef char sched_opcode_drift_check[
+    (TASKQ_OP_CRYPTO_HASH   == SDK_OP_CRYPTO_HASH   &&
+     TASKQ_OP_CRYPTO_STREAM == SDK_OP_CRYPTO_STREAM &&
+     TASKQ_OP_CRYPTO_AEAD   == SDK_OP_CRYPTO_AEAD   &&
+     TASKQ_OP_CRYPTO_KX     == SDK_OP_CRYPTO_KX     &&
+     TASKQ_OP_CRYPTO_VERIFY == SDK_OP_CRYPTO_VERIFY) ? 1 : -1];
+
+/* Core-0 view of scheduler run state. The taskq watchdog trips core 1 off
+ * after repeated faults; g_core1_started is set by the worker on entry. */
+static taskq_watchdog_t g_sched_watchdog;
+static volatile uint32_t g_core1_started;
+
+taskq_shared_t *scheduler_shared(void)
+{
+  return (taskq_shared_t *)SDK_TASKQ_REGION_ADDRESS;
+}
+
+void scheduler_boot_init(void)
+{
+  taskq_shared_t *sh = scheduler_shared();
+  taskq_init(&sh->queue);
+  sh->core1_current_slot = -1;
+  sh->core1_restart_request = 0;
+  sh->core1_fault_code = 0;
+  sh->core1_alive = 0;
+  taskq_watchdog_init(&g_sched_watchdog, 3u);
+  g_core1_started = 0;
+}
+
+int scheduler_core1_available(void)
+{
+  return (g_core1_started != 0 &&
+          taskq_watchdog_core1_enabled(&g_sched_watchdog)) ? 1 : 0;
+}
 
 /* TTBR0 page-table-walk attributes: outer cacheable write-back, matching the
  * value boot.S programs on core 0 (0x5B). */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_stress.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_stress.c
@@ -24,6 +24,7 @@
 
 #include "scheduler.h"
 #include "memorymap.h"
+#include "watchdog.h"
 #include <stdio.h>
 #include <stdint.h>
 
@@ -97,6 +98,11 @@ void scheduler_stress_core0(void)
   for (;;) {
     int slot;
     int budget;
+
+    /* This harness owns core 0 and never returns to the main loop, so it must
+     * service the private watchdog itself or the board resets every ~12.9 s.
+     * If core 0 itself ever wedges, the watchdog still fires (intended). */
+    watchdog_kick();
 
     /* Fill every currently-free slot with a fresh stamped pattern. */
     for (;;) {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_stress.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_stress.c
@@ -1,0 +1,145 @@
+/*
+ * ZZ9000 dual-core task scheduler -- Phase 0 coherency stress harness.
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Built only when SCHED_STRESS_TEST is defined. Turns the whole firmware into a
+ * two-core torture test that proves, on real silicon, that:
+ *   - the SCU keeps the task-queue region coherent between the two cores,
+ *   - the LDREX/STREX claim (taskq_cas_u32) works cross-core, including under
+ *     contention (core 0 and core 1 both claim), and
+ *   - the release/acquire ordering (taskq_store_release) is honoured.
+ *
+ * Protocol: core 0 stamps each descriptor with a pattern P
+ * (in_addr = request_id = user_cookie = P) and enqueues it. A consumer (core 1
+ * always, core 0 opportunistically) claims the slot, checks the three stamped
+ * words agree (a coherency read check), writes P ^ 0xFFFFFFFF into the result
+ * payload, and completes. Core 0 harvests and verifies the transform. Any
+ * disagreement increments a mismatch counter reported over serial.
+ *
+ * GATE: zero mismatches over a long run (target: millions of claims).
+ */
+#ifndef TASKQ_HOST_TEST
+#ifdef SCHED_STRESS_TEST
+
+#include "scheduler.h"
+#include "memorymap.h"
+#include <stdio.h>
+#include <stdint.h>
+
+#define STRESS_SHARED        ((taskq_shared_t *)SDK_TASKQ_REGION_ADDRESS)
+#define STRESS_XFORM         0xFFFFFFFFU
+#define STRESS_REPORT_CLAIMS 1000000UL
+#define STRESS_HEARTBEAT_ROUNDS 50000000UL
+#define STRESS_CORE0_DRAIN_BUDGET 4
+
+static void stress_put_u32(volatile uint8_t *p, uint32_t v)
+{
+  p[0] = (uint8_t)v;
+  p[1] = (uint8_t)(v >> 8);
+  p[2] = (uint8_t)(v >> 16);
+  p[3] = (uint8_t)(v >> 24);
+}
+
+static uint32_t stress_get_u32(const volatile uint8_t *p)
+{
+  return (uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+         ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+/* A consumer runs one claimed slot: verify core 0's stamp, write the transform. */
+static void stress_run_slot(taskq_shared_t *sh, int slot)
+{
+  taskq_desc_t *d = &sh->queue.descs[slot];
+  uint8_t payload[4];
+  uint32_t in = d->in_addr;
+  uint16_t st = (d->request_id == in && d->user_cookie == in) ? 0 : 1;
+  stress_put_u32(payload, in ^ STRESS_XFORM);
+  taskq_complete(&sh->queue, slot, st, payload, 4);
+}
+
+void scheduler_stress_init(void)
+{
+  taskq_shared_t *sh = STRESS_SHARED;
+  taskq_init(&sh->queue);
+  sh->core1_current_slot = -1;
+  sh->core1_restart_request = 0;
+  sh->core1_fault_code = 0;
+  sh->core1_alive = 0;
+}
+
+/* Core 1: sole dedicated consumer -- claim, verify, transform, complete. */
+void scheduler_stress_core1(void)
+{
+  taskq_shared_t *sh = STRESS_SHARED;
+  sh->core1_alive = 1;
+  for (;;) {
+    int slot = taskq_claim_any(&sh->queue);
+    if (slot < 0) {
+      continue;
+    }
+    stress_run_slot(sh, slot);
+  }
+}
+
+/* Core 0: producer + opportunistic consumer + verifier + serial reporter. */
+void scheduler_stress_core0(void)
+{
+  taskq_shared_t *sh = STRESS_SHARED;
+  uint32_t round = 0, seq = 0;
+  uint32_t claims = 0, mismatches = 0;
+  uint32_t next_report = STRESS_REPORT_CLAIMS;
+  uint32_t next_heartbeat = STRESS_HEARTBEAT_ROUNDS;
+
+  printf("[stress] core0 producer starting; region=%p cap=%u\n",
+         (void *)sh, (unsigned)TASKQ_CAPACITY);
+
+  for (;;) {
+    int slot;
+    int budget;
+
+    /* Fill every currently-free slot with a fresh stamped pattern. */
+    for (;;) {
+      uint32_t p = taskq_stress_fill(round, seq);
+      int s = taskq_enqueue(&sh->queue, 0u, TASK_SHORT, p, 0u, 0u, 0u, p, p);
+      if (s < 0) {
+        break;              /* queue full */
+      }
+      seq++;
+    }
+
+    /* Opportunistic core-0 drain: contend with core 1 on the CAS. */
+    budget = STRESS_CORE0_DRAIN_BUDGET;
+    while (budget-- > 0 && (slot = taskq_claim_short(&sh->queue)) >= 0) {
+      stress_run_slot(sh, slot);
+    }
+
+    /* Harvest + verify everything a consumer finished. */
+    while ((slot = taskq_harvest(&sh->queue)) >= 0) {
+      taskq_desc_t *d = &sh->queue.descs[slot];
+      uint32_t want = d->in_addr ^ STRESS_XFORM;
+      uint32_t got = stress_get_u32(d->result_payload);
+      if (d->result_status != 0 || got != want) {
+        mismatches++;
+      }
+      claims++;
+      taskq_release(&sh->queue, slot);
+    }
+
+    round++;
+    if (claims >= next_report) {
+      printf("[stress] rounds=%lu claims=%lu mismatches=%lu\n",
+             (unsigned long)round, (unsigned long)claims,
+             (unsigned long)mismatches);
+      next_report += STRESS_REPORT_CLAIMS;
+    } else if (round >= next_heartbeat) {
+      printf("[stress] heartbeat rounds=%lu claims=%lu mismatches=%lu\n",
+             (unsigned long)round, (unsigned long)claims,
+             (unsigned long)mismatches);
+      next_heartbeat += STRESS_HEARTBEAT_ROUNDS;
+    }
+  }
+}
+
+#endif /* SCHED_STRESS_TEST */
+#endif /* TASKQ_HOST_TEST */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_stress.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_stress.c
@@ -107,7 +107,7 @@ void scheduler_stress_core0(void)
     /* Fill every currently-free slot with a fresh stamped pattern. */
     for (;;) {
       uint32_t p = taskq_stress_fill(round, seq);
-      int s = taskq_enqueue(&sh->queue, 0u, TASK_SHORT, p, 0u, 0u, 0u, p, p);
+      int s = taskq_enqueue(&sh->queue, 0u, TASK_SHORT, p, 0u, 0u, 0u, p, p, NULL);
       if (s < 0) {
         break;              /* queue full */
       }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_stress.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_stress.c
@@ -107,7 +107,7 @@ void scheduler_stress_core0(void)
     /* Fill every currently-free slot with a fresh stamped pattern. */
     for (;;) {
       uint32_t p = taskq_stress_fill(round, seq);
-      int s = taskq_enqueue(&sh->queue, 0u, TASK_SHORT, p, 0u, 0u, 0u, p, p, NULL);
+      int s = taskq_enqueue(&sh->queue, 0u, TASK_SHORT, p, 0u, 0u, 0u, p, p, NULL, 0u);
       if (s < 0) {
         break;              /* queue full */
       }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_crypto.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_crypto.c
@@ -888,6 +888,37 @@ int sdk_p256_ecdh(const uint8_t scalar[32], const uint8_t peer_point[65],
 	return ok != 0;
 }
 
+int sdk_p256_keygen(const uint8_t scalar[32], uint8_t pub[65])
+{
+	const br_ec_impl *ec = &br_ec_p256_m31;
+	const unsigned char *order;
+	size_t order_len;
+	size_t len;
+	unsigned i;
+	int nonzero = 0;
+	int lt = 0, decided = 0;
+
+	/* BearSSL mulgen requires the multiplier be non-zero and < the group
+	 * order; enforce that here (mirrors zz9k_soft_p256_keygen) so a bad
+	 * scalar is rejected instead of producing an undefined point. */
+	order = ec->order(BR_EC_secp256r1, &order_len);
+	if (order_len != SDK_P256_KEY_SIZE)
+		return 0;
+	for (i = 0; i < SDK_P256_KEY_SIZE; i++) {
+		nonzero |= scalar[i];
+		if (!decided) {
+			if (scalar[i] < order[i]) { lt = 1; decided = 1; }
+			else if (scalar[i] > order[i]) { lt = 0; decided = 1; }
+		}
+	}
+	if (!nonzero || !lt)          /* zero, or scalar >= order */
+		return 0;
+
+	/* scalar*G -> full uncompressed point (0x04 || X || Y). */
+	len = ec->mulgen(pub, scalar, SDK_P256_KEY_SIZE, BR_EC_secp256r1);
+	return len == SDK_P256_POINT_SIZE;
+}
+
 int sdk_ecdsa_verify_p256(const uint8_t pubkey[SDK_P256_ECDSA_POINT_SIZE],
                            const uint8_t signature[SDK_P256_ECDSA_SIG_SIZE],
                            const uint8_t hash[SDK_SHA256_DIGEST_SIZE])

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_crypto.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_crypto.h
@@ -123,6 +123,12 @@ int sdk_p256_ecdh(const uint8_t scalar[SDK_P256_KEY_SIZE],
                    const uint8_t peer_point[SDK_P256_POINT_SIZE],
                    uint8_t shared[SDK_P256_SHARED_SIZE]);
 
+/* P-256 keygen. scalar = private key (32 bytes BE, in [1, n-1]),
+   pub = output uncompressed public point scalar*G (65 bytes: 0x04 || X || Y).
+   Returns 1 on success, 0 if the scalar is out of range or on other error. */
+int sdk_p256_keygen(const uint8_t scalar[SDK_P256_KEY_SIZE],
+                    uint8_t pub[SDK_P256_POINT_SIZE]);
+
 /* P-256 ECDSA verification with SHA-256 (raw r||s format, 64 bytes).
    pubkey = uncompressed public key point (65 bytes: 0x04 || X || Y),
    signature = raw ECDSA signature (r||s, 64 bytes),

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -180,6 +180,13 @@ struct SDKDiagTimingPayload {
 	uint8_t max_us[4];
 };
 
+struct SDKDiagSchedPayload {
+	uint8_t version[4];
+	uint8_t core1_online[4];
+	uint8_t tasks_on_core1[4];
+	uint8_t tasks_on_core0[4];
+};
+
 struct SDKSurfaceInfoPayload {
 	uint8_t handle[4];
 	uint8_t arm_addr[4];
@@ -632,6 +639,9 @@ typedef char SDKDiagPayload_must_be_48_bytes[
 typedef char SDKDiagTimingPayload_must_be_48_bytes[
 	(sizeof(struct SDKDiagTimingPayload) == 48U) ? 1 : -1
 ];
+typedef char SDKDiagSchedPayload_must_be_16_bytes[
+	(sizeof(struct SDKDiagSchedPayload) == 16U) ? 1 : -1
+];
 typedef char SDKSurfaceInfoPayload_must_be_48_bytes[
 	(sizeof(struct SDKSurfaceInfoPayload) == 48U) ? 1 : -1
 ];
@@ -852,7 +862,7 @@ static const struct SDKServiceDescriptor sdk_services[] = {
 		SDK_CAP_DIAGNOSTICS,
 		SDK_SERVICE_FLAG_FIRMWARE,
 		SDK_SERVICE_DIAG,
-		2,
+		3,
 		"diag"
 	}
 };
@@ -3408,6 +3418,7 @@ static uint16_t crypto_dispatch(uint16_t opcode, uint32_t in_len,
 	}
 
 	status = sdk_mailbox_run_crypto_task(opcode, params, result_payload);
+	scheduler_shared()->tasks_on_core0++;   /* executed inline on core 0 */
 	if (status != SDK_STATUS_OK)
 		return complete_status(req, comp, status);
 	write_completion(comp, req, SDK_STATUS_OK,
@@ -4170,6 +4181,22 @@ static uint16_t handle_diag_timing(volatile struct SDKMailboxEntry *req,
 	return SDK_STATUS_OK;
 }
 
+static uint16_t handle_diag_sched(volatile struct SDKMailboxEntry *req,
+                                  volatile struct SDKMailboxEntry *comp)
+{
+	volatile struct SDKDiagSchedPayload *sched;
+	taskq_shared_t *sh = scheduler_shared();
+
+	write_completion(comp, req, SDK_STATUS_OK, sizeof(*sched));
+	memset((void *)comp->payload, 0, sizeof(comp->payload));
+	sched = (volatile struct SDKDiagSchedPayload *)comp->payload;
+	put_be32(sched->version, 1U);
+	put_be32(sched->core1_online, scheduler_core1_available() ? 1U : 0U);
+	put_be32(sched->tasks_on_core1, sh->tasks_on_core1);
+	put_be32(sched->tasks_on_core0, sh->tasks_on_core0);
+	return SDK_STATUS_OK;
+}
+
 static uint16_t handle_query_service(volatile struct SDKMailboxEntry *req,
                                      volatile struct SDKMailboxEntry *comp,
                                      uint16_t payload_len)
@@ -4308,6 +4335,8 @@ static uint16_t handle_request(volatile struct SDKMailboxEntry *req,
 		return handle_diag_read(req, comp, pending_requests);
 	case SDK_OP_DIAG_TIMING:
 		return handle_diag_timing(req, comp);
+	case SDK_OP_DIAG_SCHED:
+		return handle_diag_sched(req, comp);
 	default:
 		write_completion(comp, req, SDK_STATUS_UNSUPPORTED, 0);
 		return SDK_STATUS_UNSUPPORTED;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -4470,6 +4470,75 @@ void sdk_mailbox_task(void)
 		amiga_interrupt_set(AMIGA_INTERRUPT_SDK);
 }
 
+/*
+ * Post a deferred completion for a task the core-1 scheduler finished. Reuses
+ * the exact completion machinery of sdk_mailbox_task -- grab the next slot,
+ * fill request_id/opcode/status/user_cookie/payload, flush the entry, advance
+ * completion_tail, flush the descriptor, and raise the completion IRQ. Both
+ * this and sdk_mailbox_task run only on core 0's main loop (never concurrently),
+ * so they share completion_tail safely. Returns 1 if posted, 0 if the
+ * completion ring is full (caller leaves the task harvested and retries) or the
+ * mailbox is inactive/invalid. Deferred completions carry entry flags = 0;
+ * crypto requests never set the entry flags word, so this matches the
+ * synchronous path (which echoes the request's zero flags) byte-for-byte.
+ */
+int sdk_mailbox_post_deferred(uint32_t request_id, uint32_t user_cookie,
+                              uint16_t opcode, uint16_t status,
+                              const uint8_t *payload, uint16_t payload_len)
+{
+	volatile struct SDKMailboxDescriptor *desc = descriptor();
+	volatile struct SDKMailboxEntry *comp_ring = completion_ring();
+	volatile struct SDKMailboxEntry *comp;
+	uint32_t comp_head;
+	uint32_t comp_tail;
+	uint32_t next_comp_tail;
+
+	if (!sdk_mailbox_active)
+		return 0;
+
+	/* Refresh the Amiga-owned completion_head before checking for room. */
+	Xil_DCacheInvalidateRange((INTPTR)desc, sizeof(*desc));
+	__asm__ __volatile__("dsb" ::: "memory");
+
+	if (!descriptor_valid(desc))
+		return 0;
+
+	comp_head = get_be32(desc->completion_head);
+	comp_tail = get_be32(desc->completion_tail);
+	next_comp_tail = next_index(comp_tail);
+	if (next_comp_tail == comp_head)
+		return 0;                    /* ring full -> caller retries next poll */
+
+	comp = &comp_ring[comp_tail];
+	put_be32(comp->request_id, request_id);
+	put_be16(comp->opcode, opcode);
+	put_be16(comp->status, status);
+	put_be16(comp->flags, 0);
+	put_be16(comp->payload_len, payload_len);
+	put_be32(comp->user_cookie, user_cookie);
+	if (payload_len > 0U && payload != 0) {
+		uint16_t n = payload_len > sizeof(comp->payload)
+		                 ? (uint16_t)sizeof(comp->payload) : payload_len;
+		memset((void *)comp->payload, 0, sizeof(comp->payload));
+		memcpy((void *)comp->payload, payload, n);
+	}
+	Xil_DCacheFlushRange((INTPTR)comp, sizeof(*comp));
+
+	comp_tail = next_comp_tail;
+	put_be32(desc->completion_tail, comp_tail);
+	Xil_DCacheFlushRange((INTPTR)desc, sizeof(*desc));
+	__asm__ __volatile__("dsb" ::: "memory");
+
+	requests_completed++;
+	if (status != SDK_STATUS_OK)
+		requests_failed++;
+
+	if (sdk_completion_irq_enabled)
+		amiga_interrupt_set(AMIGA_INTERRUPT_SDK);
+
+	return 1;
+}
+
 uint16_t sdk_mailbox_status(void)
 {
 	return sdk_status;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -4366,6 +4366,15 @@ void sdk_mailbox_init(void)
 {
 	volatile struct SDKMailboxDescriptor *desc = descriptor();
 
+	/* Drain any in-flight core-1 task before we tear the mailbox down. A task
+	 * still executing on core 1 is mid-write into its resolved data buffers;
+	 * the shared-buffer allocator reset below (next_shared_handle = 1 +
+	 * memset(shared_buffers)) re-hands those DDR ranges to the next lifetime's
+	 * requests, so a late write would corrupt a freshly allocated buffer. The
+	 * generation tag stops the stale completion from posting, but only the
+	 * quiesce stops the write itself. No-op at cold boot (core 1 not yet up). */
+	scheduler_quiesce_for_reset();
+
 	memset((void *)SDK_MAILBOX_ADDRESS, 0, SDK_MAILBOX_TOTAL_SIZE);
 	put_be32(desc->magic, SDK_MAILBOX_MAGIC);
 	put_be16(desc->abi_major, SDK_MAILBOX_ABI_MAJOR);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3118,6 +3118,11 @@ struct crypto_verify_params {
 typedef char crypto_params_fit_op_params[
     (sizeof(struct crypto_aead_params) <= TASKQ_OP_PARAM_BYTES) ? 1 : -1];
 
+/* The core-1 worker (scheduler_arm.c) posts TASKQ_RESULT_PAYLOAD bytes for a
+ * successful crypto completion; that must equal one full result payload. */
+typedef char crypto_result_fits_payload[
+    (sizeof(struct SDKCryptoResultPayload) == TASKQ_RESULT_PAYLOAD) ? 1 : -1];
+
 static void crypto_result(uint8_t *result_payload, uint32_t bytes_written,
                           uint32_t algorithm, uint32_t flags)
 {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -17,6 +17,7 @@
 #include "sdk_jpeg.h"
 #include "sdk_surface.h"
 #include "memorymap.h"
+#include "scheduler.h"
 #include "interrupt.h"
 #include "video.h"
 #include "mp3/mp3.h"
@@ -3047,15 +3048,339 @@ static uint16_t crypto_digest_length(uint32_t algorithm)
 	}
 }
 
+/*
+ * Crypto compute cores (Phase 1 dual-core scheduler).
+ *
+ * The core-0 fronts (handle_crypto_*) resolve shared-buffer handles to card DDR
+ * addresses and validate them, then pack the resolved addresses into one of the
+ * param structs below and hand the task to a consumer via crypto_dispatch(). A
+ * compute core runs on whichever core claims the task (core 1 normally, core 0
+ * inline on fallback). It owns ALL data-buffer cache maintenance: invalidate
+ * inputs before reading (pull the Amiga's DDR writes / drop stale lines) and
+ * flush outputs after writing (push to DDR for the Amiga). The generic queue
+ * region is SCU-coherent; these per-op data buffers are not, so the compute
+ * core manages them explicitly exactly as the original single-core handlers did.
+ *
+ * These structs live in the task descriptor's opaque op_params[48]; both cores
+ * are Cortex-A9 with identical ABI, so a plain struct overlay is safe.
+ */
+struct crypto_hash_params {
+	uint32_t algorithm;
+	uint32_t flags;
+	uint32_t src_addr;
+	uint32_t src_length;
+	uint32_t key_addr;      /* 0 = no key (plain hash) */
+	uint32_t key_length;
+	uint32_t dst_addr;
+	uint32_t digest_length;
+};
+
+struct crypto_stream_params {
+	uint32_t algorithm;
+	uint32_t src_addr;
+	uint32_t src_length;
+	uint32_t key_addr;
+	uint32_t nonce_addr;
+	uint32_t counter;
+	uint32_t dst_addr;
+};
+
+struct crypto_aead_params {
+	uint32_t algorithm;
+	uint32_t flags;         /* carries SDK_CRYPTO_AEAD_FLAG_DECRYPT */
+	uint32_t src_addr;
+	uint32_t src_length;
+	uint32_t src_total;
+	uint32_t dst_addr;
+	uint32_t key_addr;
+	uint32_t key_size;
+	uint32_t nonce_addr;
+	uint32_t aad_addr;      /* 0 = no AAD */
+	uint32_t aad_length;
+};
+
+struct crypto_kx_params {
+	uint32_t algorithm;
+	uint32_t scalar_addr;
+	uint32_t point_addr;
+	uint32_t dst_addr;
+};
+
+struct crypto_verify_params {
+	uint32_t algorithm;
+	uint32_t hash_addr;
+	uint32_t key_addr;
+	uint32_t key_length;
+	uint32_t sig_addr;
+	uint32_t sig_length;
+};
+
+typedef char crypto_params_fit_op_params[
+    (sizeof(struct crypto_aead_params) <= TASKQ_OP_PARAM_BYTES) ? 1 : -1];
+
+static void crypto_result(uint8_t *result_payload, uint32_t bytes_written,
+                          uint32_t algorithm, uint32_t flags)
+{
+	volatile struct SDKCryptoResultPayload *r =
+	    (volatile struct SDKCryptoResultPayload *)result_payload;
+	put_be32(r->bytes_written, bytes_written);
+	put_be32(r->algorithm, algorithm);
+	put_be32(r->flags, flags);
+}
+
+static uint16_t crypto_hash_compute(const struct crypto_hash_params *p,
+                                    uint8_t *result_payload)
+{
+	const uint8_t *src_data = (const uint8_t *)(uintptr_t)p->src_addr;
+	uint8_t digest[SDK_SHA256_DIGEST_SIZE];
+
+	Xil_DCacheInvalidateRange((INTPTR)src_data, p->src_length);
+	if (p->key_addr != 0U) {
+		const uint8_t *key_data = (const uint8_t *)(uintptr_t)p->key_addr;
+		Xil_DCacheInvalidateRange((INTPTR)key_data, p->key_length);
+		if (p->algorithm == SDK_CRYPTO_HASH_POLY1305)
+			sdk_poly1305(key_data, src_data, p->src_length, digest);
+		else if (p->algorithm == SDK_CRYPTO_HASH_SHA1)
+			sdk_hmac_sha1(key_data, p->key_length, src_data,
+			              p->src_length, digest);
+		else
+			sdk_hmac_sha256(key_data, p->key_length, src_data,
+			                p->src_length, digest);
+	} else {
+		if (p->algorithm == SDK_CRYPTO_HASH_SHA1)
+			sdk_sha1(src_data, p->src_length, digest);
+		else
+			sdk_sha256(src_data, p->src_length, digest);
+	}
+
+	memcpy((void *)(uintptr_t)p->dst_addr, digest, p->digest_length);
+	Xil_DCacheFlushRange((INTPTR)(uintptr_t)p->dst_addr, p->digest_length);
+	crypto_result(result_payload, p->digest_length, p->algorithm, p->flags);
+	memset(digest, 0, sizeof(digest));
+	return SDK_STATUS_OK;
+}
+
+static uint16_t crypto_stream_compute(const struct crypto_stream_params *p,
+                                      uint8_t *result_payload)
+{
+	const uint8_t *src_data = (const uint8_t *)(uintptr_t)p->src_addr;
+	const uint8_t *key_data = (const uint8_t *)(uintptr_t)p->key_addr;
+	const uint8_t *nonce_data = (const uint8_t *)(uintptr_t)p->nonce_addr;
+	uint8_t *dst_data = (uint8_t *)(uintptr_t)p->dst_addr;
+
+	Xil_DCacheInvalidateRange((INTPTR)src_data, p->src_length);
+	Xil_DCacheInvalidateRange((INTPTR)key_data, SDK_CHACHA20_KEY_SIZE);
+	Xil_DCacheInvalidateRange((INTPTR)nonce_data, SDK_CHACHA20_NONCE_SIZE);
+	sdk_chacha20_xor(key_data, nonce_data, p->counter, src_data, dst_data,
+	                 p->src_length);
+	Xil_DCacheFlushRange((INTPTR)dst_data, p->src_length);
+	crypto_result(result_payload, p->src_length, p->algorithm, 0U);
+	return SDK_STATUS_OK;
+}
+
+static uint16_t crypto_aead_compute(const struct crypto_aead_params *p,
+                                    uint8_t *result_payload)
+{
+	const uint8_t *src_data = (const uint8_t *)(uintptr_t)p->src_addr;
+	const uint8_t *aad_data = p->aad_length ?
+	    (const uint8_t *)(uintptr_t)p->aad_addr : 0;
+	const uint8_t *key_data = (const uint8_t *)(uintptr_t)p->key_addr;
+	const uint8_t *nonce_data = (const uint8_t *)(uintptr_t)p->nonce_addr;
+	uint8_t *dst_data = (uint8_t *)(uintptr_t)p->dst_addr;
+	uint32_t decrypt = (p->flags & SDK_CRYPTO_AEAD_FLAG_DECRYPT) != 0;
+	uint8_t tag[SDK_POLY1305_TAG_SIZE];
+
+	Xil_DCacheInvalidateRange((INTPTR)src_data, p->src_total);
+	if (p->aad_length != 0U)
+		Xil_DCacheInvalidateRange((INTPTR)aad_data, p->aad_length);
+	Xil_DCacheInvalidateRange((INTPTR)key_data, p->key_size);
+	Xil_DCacheInvalidateRange((INTPTR)nonce_data, SDK_AES_GCM_NONCE_SIZE);
+
+	if (decrypt) {
+		int ok;
+		if (p->algorithm == SDK_CRYPTO_AEAD_CHACHA20_POLY1305)
+			ok = sdk_chacha20_poly1305_decrypt(
+			    key_data, nonce_data, aad_data, p->aad_length,
+			    src_data, p->src_length,
+			    src_data + p->src_length, dst_data);
+		else
+			ok = sdk_aes_gcm_decrypt(
+			    key_data, p->key_size, nonce_data, aad_data,
+			    p->aad_length, src_data, p->src_length,
+			    src_data + p->src_length, dst_data);
+		if (!ok)
+			return SDK_STATUS_IO_ERROR;
+		Xil_DCacheFlushRange((INTPTR)dst_data, p->src_length);
+	} else {
+		if (p->algorithm == SDK_CRYPTO_AEAD_CHACHA20_POLY1305)
+			sdk_chacha20_poly1305_encrypt(key_data, nonce_data,
+			                              aad_data, p->aad_length,
+			                              src_data, p->src_length,
+			                              dst_data, tag);
+		else
+			sdk_aes_gcm_encrypt(key_data, p->key_size, nonce_data,
+			                    aad_data, p->aad_length,
+			                    src_data, p->src_length,
+			                    dst_data, tag);
+		memcpy(dst_data + p->src_length, tag, sizeof(tag));
+		Xil_DCacheFlushRange((INTPTR)dst_data,
+		                     p->src_length + SDK_AES_GCM_TAG_SIZE);
+	}
+
+	crypto_result(result_payload,
+	              decrypt ? p->src_length :
+	                        p->src_length + SDK_AES_GCM_TAG_SIZE,
+	              p->algorithm, p->flags);
+	memset(tag, 0, sizeof(tag));
+	return SDK_STATUS_OK;
+}
+
+static uint16_t crypto_kx_compute(const struct crypto_kx_params *p,
+                                  uint8_t *result_payload)
+{
+	const uint8_t *scalar_data = (const uint8_t *)(uintptr_t)p->scalar_addr;
+	const uint8_t *point_data = (const uint8_t *)(uintptr_t)p->point_addr;
+	uint8_t *dst_data = (uint8_t *)(uintptr_t)p->dst_addr;
+
+	if (p->algorithm == SDK_CRYPTO_KX_X25519) {
+		uint8_t xshared[SDK_X25519_SHARED_SIZE];
+		Xil_DCacheInvalidateRange((INTPTR)scalar_data, SDK_X25519_KEY_SIZE);
+		Xil_DCacheInvalidateRange((INTPTR)point_data, SDK_X25519_POINT_SIZE);
+		if (!sdk_x25519(scalar_data, point_data, xshared)) {
+			memset(xshared, 0, sizeof(xshared));
+			return SDK_STATUS_BAD_REQUEST;
+		}
+		memcpy(dst_data, xshared, SDK_X25519_SHARED_SIZE);
+		Xil_DCacheFlushRange((INTPTR)dst_data, SDK_X25519_SHARED_SIZE);
+		memset(xshared, 0, sizeof(xshared));
+		crypto_result(result_payload, SDK_X25519_SHARED_SIZE,
+		              SDK_CRYPTO_KX_X25519, 0U);
+	} else {  /* SDK_CRYPTO_KX_P256 -- the front validated the algorithm */
+		uint8_t shared[SDK_P256_SHARED_SIZE];
+		Xil_DCacheInvalidateRange((INTPTR)scalar_data, SDK_P256_KEY_SIZE);
+		Xil_DCacheInvalidateRange((INTPTR)point_data, SDK_P256_POINT_SIZE);
+		if (!sdk_p256_ecdh(scalar_data, point_data, shared)) {
+			memset(shared, 0, sizeof(shared));
+			return SDK_STATUS_BAD_REQUEST;
+		}
+		memcpy(dst_data, shared, SDK_P256_SHARED_SIZE);
+		Xil_DCacheFlushRange((INTPTR)dst_data, SDK_P256_SHARED_SIZE);
+		memset(shared, 0, sizeof(shared));
+		crypto_result(result_payload, SDK_P256_SHARED_SIZE,
+		              SDK_CRYPTO_KX_P256, 0U);
+	}
+	return SDK_STATUS_OK;
+}
+
+static uint16_t crypto_verify_compute(const struct crypto_verify_params *p,
+                                      uint8_t *result_payload)
+{
+	const uint8_t *hash_data = (const uint8_t *)(uintptr_t)p->hash_addr;
+	const uint8_t *key_data = (const uint8_t *)(uintptr_t)p->key_addr;
+	const uint8_t *sig_data = (const uint8_t *)(uintptr_t)p->sig_addr;
+	uint8_t hash[SDK_SHA256_DIGEST_SIZE];
+	int verified = 0;
+
+	if (p->algorithm == SDK_CRYPTO_VERIFY_ECDSA_P256_SHA256) {
+		uint8_t pubkey[SDK_P256_ECDSA_POINT_SIZE];
+		uint8_t signature[SDK_P256_ECDSA_SIG_SIZE];
+		Xil_DCacheInvalidateRange((INTPTR)hash_data, SDK_SHA256_DIGEST_SIZE);
+		Xil_DCacheInvalidateRange((INTPTR)key_data, SDK_P256_ECDSA_POINT_SIZE);
+		Xil_DCacheInvalidateRange((INTPTR)sig_data, SDK_P256_ECDSA_SIG_SIZE);
+		memcpy(hash, hash_data, SDK_SHA256_DIGEST_SIZE);
+		memcpy(pubkey, key_data, SDK_P256_ECDSA_POINT_SIZE);
+		memcpy(signature, sig_data, SDK_P256_ECDSA_SIG_SIZE);
+		verified = sdk_ecdsa_verify_p256(pubkey, signature, hash);
+		memset(pubkey, 0, sizeof(pubkey));
+		memset(signature, 0, sizeof(signature));
+	} else {  /* SDK_CRYPTO_VERIFY_RSA_PKCS1_2048_SHA256 -- front validated */
+		uint8_t modulus[SDK_RSA_MAX_KEY_BYTES];
+		uint8_t exponent[4];
+		uint8_t signature[SDK_RSA_MAX_KEY_BYTES];
+		uint32_t mod_len = p->key_length - 4U;
+		Xil_DCacheInvalidateRange((INTPTR)hash_data, SDK_SHA256_DIGEST_SIZE);
+		Xil_DCacheInvalidateRange((INTPTR)key_data, p->key_length);
+		Xil_DCacheInvalidateRange((INTPTR)sig_data, p->sig_length);
+		memcpy(hash, hash_data, SDK_SHA256_DIGEST_SIZE);
+		memcpy(modulus, key_data, mod_len);
+		memcpy(exponent, key_data + mod_len, 4);
+		memcpy(signature, sig_data, p->sig_length);
+		verified = sdk_rsa_verify_pkcs1_sha256(modulus, mod_len, exponent,
+		                                       4U, signature, p->sig_length,
+		                                       hash);
+		memset(modulus, 0, sizeof(modulus));
+		memset(exponent, 0, sizeof(exponent));
+		memset(signature, 0, sizeof(signature));
+	}
+
+	crypto_result(result_payload, verified ? 1U : 0U, p->algorithm, 0U);
+	memset(hash, 0, sizeof(hash));
+	return SDK_STATUS_OK;
+}
+
+/*
+ * Run a crypto task's compute on the calling core. Shared by the core-1 worker
+ * and the core-0 inline/fallback path. result_payload is a 48-byte
+ * SDKCryptoResultPayload buffer; it is fully zeroed here so reserved bytes are
+ * clean regardless of which op runs.
+ */
+uint16_t sdk_mailbox_run_crypto_task(uint16_t opcode, const void *op_params,
+                                     uint8_t *result_payload)
+{
+	memset(result_payload, 0, sizeof(struct SDKCryptoResultPayload));
+	switch (opcode) {
+	case SDK_OP_CRYPTO_HASH:
+		return crypto_hash_compute(
+		    (const struct crypto_hash_params *)op_params, result_payload);
+	case SDK_OP_CRYPTO_STREAM:
+		return crypto_stream_compute(
+		    (const struct crypto_stream_params *)op_params, result_payload);
+	case SDK_OP_CRYPTO_AEAD:
+		return crypto_aead_compute(
+		    (const struct crypto_aead_params *)op_params, result_payload);
+	case SDK_OP_CRYPTO_KX:
+		return crypto_kx_compute(
+		    (const struct crypto_kx_params *)op_params, result_payload);
+	case SDK_OP_CRYPTO_VERIFY:
+		return crypto_verify_compute(
+		    (const struct crypto_verify_params *)op_params, result_payload);
+	default:
+		return SDK_STATUS_UNSUPPORTED;
+	}
+}
+
+/*
+ * Front dispatch helper. Phase 1 (T11) runs the compute inline on core 0 so
+ * behaviour is identical to the pre-scheduler firmware; T13 switches this to
+ * enqueue-or-inline.
+ */
+static uint16_t crypto_dispatch(uint16_t opcode,
+                                volatile struct SDKMailboxEntry *req,
+                                volatile struct SDKMailboxEntry *comp,
+                                const void *params)
+{
+	uint8_t result_payload[sizeof(struct SDKCryptoResultPayload)];
+	uint16_t status = sdk_mailbox_run_crypto_task(opcode, params,
+	                                               result_payload);
+	if (status != SDK_STATUS_OK)
+		return complete_status(req, comp, status);
+	write_completion(comp, req, SDK_STATUS_OK,
+	                 sizeof(struct SDKCryptoResultPayload));
+	memset((void *)comp->payload, 0, sizeof(comp->payload));
+	memcpy((void *)comp->payload, result_payload,
+	       sizeof(struct SDKCryptoResultPayload));
+	return SDK_STATUS_OK;
+}
+
 static uint16_t handle_crypto_hash(volatile struct SDKMailboxEntry *req,
                                    volatile struct SDKMailboxEntry *comp,
                                    uint16_t payload_len)
 {
 	volatile struct SDKCryptoHashPayload *payload;
-	volatile struct SDKCryptoResultPayload *result;
 	struct SDKSharedBuffer *src;
 	struct SDKSharedBuffer *dst;
 	struct SDKSharedBuffer *key;
+	struct crypto_hash_params hp;
 	uint32_t src_offset;
 	uint32_t src_length;
 	uint32_t dst_offset;
@@ -3065,9 +3390,6 @@ static uint16_t handle_crypto_hash(volatile struct SDKMailboxEntry *req,
 	uint32_t flags;
 	uint32_t key_required;
 	uint16_t digest_length;
-	uint8_t digest[SDK_SHA256_DIGEST_SIZE];
-	const uint8_t *src_data;
-	const uint8_t *key_data;
 
 	if (payload_len < 40U)
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
@@ -3118,39 +3440,15 @@ static uint16_t handle_crypto_hash(volatile struct SDKMailboxEntry *req,
 		}
 	}
 
-	src_data = (const uint8_t *)(uintptr_t)(src->address + src_offset);
-	Xil_DCacheInvalidateRange((INTPTR)src_data, src_length);
-	if (key_required) {
-		key_data = (const uint8_t *)(uintptr_t)(key->address + key_offset);
-		Xil_DCacheInvalidateRange((INTPTR)key_data, key_length);
-		if (algorithm == SDK_CRYPTO_HASH_POLY1305)
-			sdk_poly1305(key_data, src_data, src_length, digest);
-		else if (algorithm == SDK_CRYPTO_HASH_SHA1)
-			sdk_hmac_sha1(key_data, key_length, src_data, src_length,
-			              digest);
-		else
-			sdk_hmac_sha256(key_data, key_length, src_data, src_length,
-			                digest);
-	} else {
-		if (algorithm == SDK_CRYPTO_HASH_SHA1)
-			sdk_sha1(src_data, src_length, digest);
-		else
-			sdk_sha256(src_data, src_length, digest);
-	}
-
-	memcpy((void *)(uintptr_t)(dst->address + dst_offset),
-	       digest, digest_length);
-	Xil_DCacheFlushRange((INTPTR)(dst->address + dst_offset),
-	                     digest_length);
-
-	write_completion(comp, req, SDK_STATUS_OK, sizeof(*result));
-	memset((void *)comp->payload, 0, sizeof(comp->payload));
-	result = (volatile struct SDKCryptoResultPayload *)comp->payload;
-	put_be32(result->bytes_written, digest_length);
-	put_be32(result->algorithm, algorithm);
-	put_be32(result->flags, flags);
-	memset(digest, 0, sizeof(digest));
-	return SDK_STATUS_OK;
+	hp.algorithm = algorithm;
+	hp.flags = flags;
+	hp.src_addr = src->address + src_offset;
+	hp.src_length = src_length;
+	hp.key_addr = key_required ? (key->address + key_offset) : 0U;
+	hp.key_length = key_length;
+	hp.dst_addr = dst->address + dst_offset;
+	hp.digest_length = digest_length;
+	return crypto_dispatch(SDK_OP_CRYPTO_HASH, req, comp, &hp);
 }
 
 static uint16_t handle_crypto_stream(volatile struct SDKMailboxEntry *req,
@@ -3158,11 +3456,11 @@ static uint16_t handle_crypto_stream(volatile struct SDKMailboxEntry *req,
                                      uint16_t payload_len)
 {
 	volatile struct SDKCryptoStreamPayload *payload;
-	volatile struct SDKCryptoResultPayload *result;
 	struct SDKSharedBuffer *src;
 	struct SDKSharedBuffer *dst;
 	struct SDKSharedBuffer *key;
 	struct SDKSharedBuffer *nonce;
+	struct crypto_stream_params sp;
 	uint32_t src_offset;
 	uint32_t src_length;
 	uint32_t dst_offset;
@@ -3171,10 +3469,6 @@ static uint16_t handle_crypto_stream(volatile struct SDKMailboxEntry *req,
 	uint32_t counter;
 	uint32_t algorithm;
 	uint32_t flags;
-	const uint8_t *src_data;
-	const uint8_t *key_data;
-	const uint8_t *nonce_data;
-	uint8_t *dst_data;
 
 	if (payload_len < sizeof(struct SDKCryptoStreamPayload))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
@@ -3206,25 +3500,15 @@ static uint16_t handle_crypto_stream(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
 	}
 
-	src_data = (const uint8_t *)(uintptr_t)(src->address + src_offset);
-	dst_data = (uint8_t *)(uintptr_t)(dst->address + dst_offset);
-	key_data = (const uint8_t *)(uintptr_t)(key->address + key_offset);
-	nonce_data = (const uint8_t *)(uintptr_t)(nonce->address + nonce_offset);
-	Xil_DCacheInvalidateRange((INTPTR)src_data, src_length);
-	Xil_DCacheInvalidateRange((INTPTR)key_data, SDK_CHACHA20_KEY_SIZE);
-	Xil_DCacheInvalidateRange((INTPTR)nonce_data, SDK_CHACHA20_NONCE_SIZE);
-
-	sdk_chacha20_xor(key_data, nonce_data, counter,
-	                 src_data, dst_data, src_length);
-	Xil_DCacheFlushRange((INTPTR)dst_data, src_length);
-
-	write_completion(comp, req, SDK_STATUS_OK, sizeof(*result));
-	memset((void *)comp->payload, 0, sizeof(comp->payload));
-	result = (volatile struct SDKCryptoResultPayload *)comp->payload;
-	put_be32(result->bytes_written, src_length);
-	put_be32(result->algorithm, algorithm);
-	put_be32(result->flags, flags);
-	return SDK_STATUS_OK;
+	(void)flags;
+	sp.algorithm = algorithm;
+	sp.src_addr = src->address + src_offset;
+	sp.src_length = src_length;
+	sp.key_addr = key->address + key_offset;
+	sp.nonce_addr = nonce->address + nonce_offset;
+	sp.counter = counter;
+	sp.dst_addr = dst->address + dst_offset;
+	return crypto_dispatch(SDK_OP_CRYPTO_STREAM, req, comp, &sp);
 }
 
 static uint16_t handle_crypto_aead(volatile struct SDKMailboxEntry *req,
@@ -3232,12 +3516,12 @@ static uint16_t handle_crypto_aead(volatile struct SDKMailboxEntry *req,
                                    uint16_t payload_len)
 {
 	volatile struct SDKCryptoAeadPayload *payload;
-	volatile struct SDKCryptoResultPayload *result;
 	struct SDKSharedBuffer *src;
 	struct SDKSharedBuffer *dst;
 	struct SDKSharedBuffer *aad;
 	struct SDKSharedBuffer *key;
 	struct SDKSharedBuffer *nonce;
+	struct crypto_aead_params ap;
 	uint32_t src_offset;
 	uint32_t src_length;
 	uint32_t src_total;
@@ -3248,12 +3532,6 @@ static uint16_t handle_crypto_aead(volatile struct SDKMailboxEntry *req,
 	uint32_t flags;
 	uint32_t algorithm;
 	uint32_t key_size;
-	const uint8_t *src_data;
-	const uint8_t *aad_data;
-	const uint8_t *key_data;
-	const uint8_t *nonce_data;
-	uint8_t *dst_data;
-	uint8_t tag[SDK_POLY1305_TAG_SIZE];
 
 	if (payload_len < sizeof(struct SDKCryptoAeadPayload))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
@@ -3313,67 +3591,24 @@ static uint16_t handle_crypto_aead(volatile struct SDKMailboxEntry *req,
 	}
 
 	aad = 0;
-	aad_data = 0;
 	if (aad_length != 0U) {
 		aad = find_shared_buffer(get_be32(payload->aad_handle));
 		if (!buffer_range_valid(aad, aad_offset, aad_length))
 			return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
-		aad_data = (const uint8_t *)(uintptr_t)(aad->address + aad_offset);
 	}
 
-	src_data = (const uint8_t *)(uintptr_t)(src->address + src_offset);
-	dst_data = (uint8_t *)(uintptr_t)(dst->address + dst_offset);
-	key_data = (const uint8_t *)(uintptr_t)(key->address + key_offset);
-	nonce_data = (const uint8_t *)(uintptr_t)nonce->address;
-	Xil_DCacheInvalidateRange((INTPTR)src_data, src_total);
-	if (aad_length != 0U)
-		Xil_DCacheInvalidateRange((INTPTR)aad_data, aad_length);
-	Xil_DCacheInvalidateRange((INTPTR)key_data, key_size);
-	Xil_DCacheInvalidateRange((INTPTR)nonce_data, SDK_AES_GCM_NONCE_SIZE);
-
-	if ((flags & SDK_CRYPTO_AEAD_FLAG_DECRYPT) != 0) {
-		int ok;
-		if (algorithm == SDK_CRYPTO_AEAD_CHACHA20_POLY1305) {
-			ok = sdk_chacha20_poly1305_decrypt(
-			    key_data, nonce_data, aad_data, aad_length,
-			    src_data, src_length,
-			    src_data + src_length, dst_data);
-		} else {
-			ok = sdk_aes_gcm_decrypt(
-			    key_data, key_size, nonce_data, aad_data, aad_length,
-			    src_data, src_length,
-			    src_data + src_length, dst_data);
-		}
-		if (!ok)
-			return complete_status(req, comp, SDK_STATUS_IO_ERROR);
-		Xil_DCacheFlushRange((INTPTR)dst_data, src_length);
-	} else {
-		if (algorithm == SDK_CRYPTO_AEAD_CHACHA20_POLY1305) {
-			sdk_chacha20_poly1305_encrypt(key_data, nonce_data,
-			                              aad_data, aad_length,
-			                              src_data, src_length,
-			                              dst_data, tag);
-		} else {
-			sdk_aes_gcm_encrypt(key_data, key_size, nonce_data,
-			                    aad_data, aad_length,
-			                    src_data, src_length,
-			                    dst_data, tag);
-		}
-		memcpy(dst_data + src_length, tag, sizeof(tag));
-		Xil_DCacheFlushRange((INTPTR)dst_data,
-		                     src_length + SDK_AES_GCM_TAG_SIZE);
-	}
-
-	write_completion(comp, req, SDK_STATUS_OK, sizeof(*result));
-	memset((void *)comp->payload, 0, sizeof(comp->payload));
-	result = (volatile struct SDKCryptoResultPayload *)comp->payload;
-	put_be32(result->bytes_written,
-	         (flags & SDK_CRYPTO_AEAD_FLAG_DECRYPT) != 0 ?
-	         src_length : src_length + SDK_AES_GCM_TAG_SIZE);
-	put_be32(result->algorithm, algorithm);
-	put_be32(result->flags, flags);
-	memset(tag, 0, sizeof(tag));
-	return SDK_STATUS_OK;
+	ap.algorithm = algorithm;
+	ap.flags = flags;
+	ap.src_addr = src->address + src_offset;
+	ap.src_length = src_length;
+	ap.src_total = src_total;
+	ap.dst_addr = dst->address + dst_offset;
+	ap.key_addr = key->address + key_offset;
+	ap.key_size = key_size;
+	ap.nonce_addr = nonce->address;
+	ap.aad_addr = (aad_length != 0U) ? (aad->address + aad_offset) : 0U;
+	ap.aad_length = aad_length;
+	return crypto_dispatch(SDK_OP_CRYPTO_AEAD, req, comp, &ap);
 }
 
 static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
@@ -3381,14 +3616,10 @@ static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
                                   uint16_t payload_len)
 {
 	volatile struct SDKCryptoKXPayload *p;
-	volatile struct SDKCryptoResultPayload *result;
 	struct SDKSharedBuffer *scalar;
 	struct SDKSharedBuffer *point;
 	struct SDKSharedBuffer *dst;
-	const uint8_t *scalar_data;
-	const uint8_t *point_data;
-	uint8_t *dst_data;
-	uint8_t shared[SDK_P256_SHARED_SIZE];  /* max shared secret size */
+	struct crypto_kx_params kp;
 	uint32_t algorithm;
 	uint32_t flags;
 	uint32_t scalar_off;
@@ -3412,70 +3643,24 @@ static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
 	dst_off    = get_be32(p->dst_offset);
 
 	if (algorithm == SDK_CRYPTO_KX_X25519) {
-		uint8_t xshared[SDK_X25519_SHARED_SIZE];
-
 		if (!buffer_range_valid(scalar, scalar_off, SDK_X25519_KEY_SIZE)   ||
 		    !buffer_range_valid(point,  point_off,  SDK_X25519_POINT_SIZE) ||
 		    !buffer_range_valid(dst,    dst_off,    SDK_X25519_SHARED_SIZE))
 			return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
-
-		scalar_data = (const uint8_t *)(uintptr_t)(scalar->address + scalar_off);
-		point_data  = (const uint8_t *)(uintptr_t)(point->address  + point_off);
-		dst_data    = (uint8_t *)(uintptr_t)(dst->address + dst_off);
-
-		Xil_DCacheInvalidateRange((INTPTR)scalar_data, SDK_X25519_KEY_SIZE);
-		Xil_DCacheInvalidateRange((INTPTR)point_data,  SDK_X25519_POINT_SIZE);
-
-		if (!sdk_x25519(scalar_data, point_data, xshared)) {
-			memset(xshared, 0, sizeof(xshared));
-			return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
-		}
-
-		memcpy(dst_data, xshared, SDK_X25519_SHARED_SIZE);
-		Xil_DCacheFlushRange((INTPTR)dst_data, SDK_X25519_SHARED_SIZE);
-		memset(xshared, 0, sizeof(xshared));  /* scrub stack copy */
-
-		write_completion(comp, req, SDK_STATUS_OK, sizeof(*result));
-		memset((void *)comp->payload, 0, sizeof(comp->payload));
-		result = (volatile struct SDKCryptoResultPayload *)comp->payload;
-		put_be32(result->bytes_written, SDK_X25519_SHARED_SIZE);
-		put_be32(result->algorithm, SDK_CRYPTO_KX_X25519);
-		put_be32(result->flags, 0U);
-		return SDK_STATUS_OK;
-
 	} else if (algorithm == SDK_CRYPTO_KX_P256) {
 		if (!buffer_range_valid(scalar, scalar_off, SDK_P256_KEY_SIZE)   ||
 		    !buffer_range_valid(point,  point_off,  SDK_P256_POINT_SIZE) ||
 		    !buffer_range_valid(dst,    dst_off,    SDK_P256_SHARED_SIZE))
 			return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
-
-		scalar_data = (const uint8_t *)(uintptr_t)(scalar->address + scalar_off);
-		point_data  = (const uint8_t *)(uintptr_t)(point->address  + point_off);
-		dst_data    = (uint8_t *)(uintptr_t)(dst->address + dst_off);
-
-		Xil_DCacheInvalidateRange((INTPTR)scalar_data, SDK_P256_KEY_SIZE);
-		Xil_DCacheInvalidateRange((INTPTR)point_data,  SDK_P256_POINT_SIZE);
-
-		if (!sdk_p256_ecdh(scalar_data, point_data, shared)) {
-			memset(shared, 0, sizeof(shared));
-			return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
-		}
-
-		memcpy(dst_data, shared, SDK_P256_SHARED_SIZE);
-		Xil_DCacheFlushRange((INTPTR)dst_data, SDK_P256_SHARED_SIZE);
-		memset(shared, 0, sizeof(shared));  /* scrub stack copy */
-
-		write_completion(comp, req, SDK_STATUS_OK, sizeof(*result));
-		memset((void *)comp->payload, 0, sizeof(comp->payload));
-		result = (volatile struct SDKCryptoResultPayload *)comp->payload;
-		put_be32(result->bytes_written, SDK_P256_SHARED_SIZE);
-		put_be32(result->algorithm, SDK_CRYPTO_KX_P256);
-		put_be32(result->flags, 0U);
-		return SDK_STATUS_OK;
-
 	} else {
-        return complete_status(req, comp, SDK_STATUS_UNSUPPORTED);
-    }
+		return complete_status(req, comp, SDK_STATUS_UNSUPPORTED);
+	}
+
+	kp.algorithm = algorithm;
+	kp.scalar_addr = scalar->address + scalar_off;
+	kp.point_addr  = point->address + point_off;
+	kp.dst_addr    = dst->address + dst_off;
+	return crypto_dispatch(SDK_OP_CRYPTO_KX, req, comp, &kp);
 }
 
 static uint16_t handle_crypto_verify(volatile struct SDKMailboxEntry *req,
@@ -3483,19 +3668,14 @@ static uint16_t handle_crypto_verify(volatile struct SDKMailboxEntry *req,
                                      uint16_t payload_len)
 {
 	volatile struct SDKCryptoVerifyPayload *p;
-	volatile struct SDKCryptoResultPayload *result;
 	struct SDKSharedBuffer *hash_buf;
 	struct SDKSharedBuffer *sig_buf;
 	struct SDKSharedBuffer *key_buf;
-	const uint8_t *hash_data;
-	const uint8_t *sig_data;
-	const uint8_t *key_data;
-	uint8_t hash[SDK_SHA256_DIGEST_SIZE];
+	struct crypto_verify_params vp;
 	uint32_t algorithm;
 	uint32_t hash_off;
 	uint32_t sig_off;
 	uint32_t key_off;
-	int verified = 0;
 
 	if (payload_len < sizeof(struct SDKCryptoVerifyPayload))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
@@ -3513,37 +3693,22 @@ static uint16_t handle_crypto_verify(volatile struct SDKMailboxEntry *req,
 	/* The caller supplies a precomputed 32-byte SHA-256 digest. */
 	if (!buffer_range_valid(hash_buf, hash_off, SDK_SHA256_DIGEST_SIZE))
 		return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
-	hash_data = (const uint8_t *)(uintptr_t)(hash_buf->address + hash_off);
+
+	vp.algorithm = algorithm;
+	vp.hash_addr = hash_buf->address + hash_off;
 
 	if (algorithm == SDK_CRYPTO_VERIFY_ECDSA_P256_SHA256) {
-		uint8_t pubkey[SDK_P256_ECDSA_POINT_SIZE];
-		uint8_t signature[SDK_P256_ECDSA_SIG_SIZE];
-
 		/* key buffer = 65-byte uncompressed point, signature = raw r||s. */
 		if (!buffer_range_valid(key_buf, key_off, SDK_P256_ECDSA_POINT_SIZE) ||
 		    !buffer_range_valid(sig_buf, sig_off, SDK_P256_ECDSA_SIG_SIZE))
 			return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
 
-		key_data = (const uint8_t *)(uintptr_t)(key_buf->address + key_off);
-		sig_data = (const uint8_t *)(uintptr_t)(sig_buf->address + sig_off);
-
-		Xil_DCacheInvalidateRange((INTPTR)hash_data, SDK_SHA256_DIGEST_SIZE);
-		Xil_DCacheInvalidateRange((INTPTR)key_data,  SDK_P256_ECDSA_POINT_SIZE);
-		Xil_DCacheInvalidateRange((INTPTR)sig_data,  SDK_P256_ECDSA_SIG_SIZE);
-
-		memcpy(hash, hash_data, SDK_SHA256_DIGEST_SIZE);
-		memcpy(pubkey, key_data, SDK_P256_ECDSA_POINT_SIZE);
-		memcpy(signature, sig_data, SDK_P256_ECDSA_SIG_SIZE);
-
-		verified = sdk_ecdsa_verify_p256(pubkey, signature, hash);
-
-		memset(pubkey, 0, sizeof(pubkey));
-		memset(signature, 0, sizeof(signature));
+		vp.key_addr = key_buf->address + key_off;
+		vp.key_length = SDK_P256_ECDSA_POINT_SIZE;
+		vp.sig_addr = sig_buf->address + sig_off;
+		vp.sig_length = SDK_P256_ECDSA_SIG_SIZE;
 
 	} else if (algorithm == SDK_CRYPTO_VERIFY_RSA_PKCS1_2048_SHA256) {
-		uint8_t modulus[SDK_RSA_MAX_KEY_BYTES];
-		uint8_t exponent[4];
-		uint8_t signature[SDK_RSA_MAX_KEY_BYTES];
 		uint32_t key_len = get_be32(p->key_length);
 		uint32_t sig_len = get_be32(p->sig_length);
 		uint32_t mod_len;
@@ -3560,38 +3725,16 @@ static uint16_t handle_crypto_verify(volatile struct SDKMailboxEntry *req,
 		    !buffer_range_valid(sig_buf, sig_off, sig_len))
 			return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
 
-		key_data = (const uint8_t *)(uintptr_t)(key_buf->address + key_off);
-		sig_data = (const uint8_t *)(uintptr_t)(sig_buf->address + sig_off);
-
-		Xil_DCacheInvalidateRange((INTPTR)hash_data, SDK_SHA256_DIGEST_SIZE);
-		Xil_DCacheInvalidateRange((INTPTR)key_data, key_len);
-		Xil_DCacheInvalidateRange((INTPTR)sig_data, sig_len);
-
-		memcpy(hash, hash_data, SDK_SHA256_DIGEST_SIZE);
-		memcpy(modulus, key_data, mod_len);
-		memcpy(exponent, key_data + mod_len, 4);
-		memcpy(signature, sig_data, sig_len);
-
-		verified = sdk_rsa_verify_pkcs1_sha256(modulus, mod_len, exponent, 4U,
-		                                       signature, sig_len, hash);
-
-		memset(modulus, 0, sizeof(modulus));
-		memset(exponent, 0, sizeof(exponent));
-		memset(signature, 0, sizeof(signature));
+		vp.key_addr = key_buf->address + key_off;
+		vp.key_length = key_len;
+		vp.sig_addr = sig_buf->address + sig_off;
+		vp.sig_length = sig_len;
 
 	} else {
 		return complete_status(req, comp, SDK_STATUS_UNSUPPORTED);
 	}
 
-	write_completion(comp, req, SDK_STATUS_OK, sizeof(*result));
-	memset((void *)comp->payload, 0, sizeof(comp->payload));
-	result = (volatile struct SDKCryptoResultPayload *)comp->payload;
-	put_be32(result->bytes_written, verified ? 1U : 0U);
-	put_be32(result->algorithm, algorithm);
-	put_be32(result->flags, 0U);
-
-	memset(hash, 0, sizeof(hash));
-	return SDK_STATUS_OK;
+	return crypto_dispatch(SDK_OP_CRYPTO_VERIFY, req, comp, &vp);
 }
 
 static uint16_t handle_decompress(volatile struct SDKMailboxEntry *req,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -756,6 +756,22 @@ static volatile int sdk_completion_irq_enabled;
  */
 static uint32_t sdk_mailbox_generation;
 static uint32_t g_task_generation[TASKQ_CAPACITY];
+
+/*
+ * Batch-tail gate for crypto offload. The request loop processes a FIFO batch
+ * (the requests present when it started); the synchronous dispatcher completed
+ * each request -- including its shared-buffer writes -- before the next ran, so
+ * a batched dependent op (e.g. CRYPTO_HASH -> H followed by MEM_COPY from H or
+ * FREE_SHARED H) always observed finished side effects. Deferring a crypto op
+ * to core 1 breaks that: core 0 would run the next request while core 1 is
+ * still writing H. So crypto_dispatch only defers when this flag says the
+ * current request is the LAST one in the batch (nothing behind it can depend on
+ * it); any crypto op with requests queued after it runs inline, preserving
+ * in-order side effects. Cross-batch ordering remains the client's job via the
+ * completion-is-a-barrier contract. Core-0-only, set immediately before each
+ * handle_request(); no cross-core barrier needed.
+ */
+static int g_request_is_batch_tail;
 static uint16_t sdk_status;
 static struct SDKSharedBuffer shared_buffers[SDK_MAX_SHARED_BUFFERS];
 static struct SDKSurface surfaces[SDK_MAX_SURFACES];
@@ -3415,7 +3431,13 @@ static uint16_t crypto_dispatch(uint16_t opcode, uint32_t in_len,
 	uint8_t result_payload[sizeof(struct SDKCryptoResultPayload)];
 	uint16_t status;
 
-	if (scheduler_core1_available()) {
+	/*
+	 * Only defer to core 1 when this is the last request in the batch; a crypto
+	 * op with requests behind it must complete its shared-buffer writes inline
+	 * so a later batched op (MEM_COPY/FREE_SHARED of the same handle, etc.)
+	 * never races core 1. See g_request_is_batch_tail.
+	 */
+	if (scheduler_core1_available() && g_request_is_batch_tail) {
 		taskq_shared_t *sh = scheduler_shared();
 		int slot = taskq_enqueue(&sh->queue, opcode,
 		                         taskq_class_for_opcode(opcode, in_len),
@@ -4512,6 +4534,9 @@ void sdk_mailbox_task(void)
 			pending_requests = SDK_MAILBOX_RING_ENTRIES - req_head + req_tail;
 
 		opcode = get_be16(req_ring[req_head].opcode);
+		/* Gate crypto offload: defer to core 1 only when nothing in this batch
+		 * is queued behind the current request (see g_request_is_batch_tail). */
+		g_request_is_batch_tail = (pending_requests == 1u) ? 1 : 0;
 		XTime_GetTime(&timing_start);
 		sdk_status = handle_request(&req_ring[req_head],
 		                            &comp_ring[comp_tail],

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3424,6 +3424,7 @@ uint16_t sdk_mailbox_run_crypto_task(uint16_t opcode, const void *op_params,
  * out_cap fields are unused for the crypto opcode class and passed as 0.
  */
 static uint16_t crypto_dispatch(uint16_t opcode, uint32_t in_len,
+                                uint32_t param_len,
                                 volatile struct SDKMailboxEntry *req,
                                 volatile struct SDKMailboxEntry *comp,
                                 const void *params)
@@ -3443,7 +3444,7 @@ static uint16_t crypto_dispatch(uint16_t opcode, uint32_t in_len,
 		                         taskq_class_for_opcode(opcode, in_len),
 		                         0u, in_len, 0u, 0u,
 		                         get_be32(req->request_id),
-		                         get_be32(req->user_cookie), params);
+		                         get_be32(req->user_cookie), params, param_len);
 		if (slot >= 0) {
 			/* Stamp the current mailbox generation so this task is dropped
 			 * rather than posted if the mailbox is re-initialised before it
@@ -3546,7 +3547,8 @@ static uint16_t handle_crypto_hash(volatile struct SDKMailboxEntry *req,
 	hp.key_length = key_length;
 	hp.dst_addr = dst->address + dst_offset;
 	hp.digest_length = digest_length;
-	return crypto_dispatch(SDK_OP_CRYPTO_HASH, src_length, req, comp, &hp);
+	return crypto_dispatch(SDK_OP_CRYPTO_HASH, src_length, sizeof(hp),
+	                       req, comp, &hp);
 }
 
 static uint16_t handle_crypto_stream(volatile struct SDKMailboxEntry *req,
@@ -3606,7 +3608,8 @@ static uint16_t handle_crypto_stream(volatile struct SDKMailboxEntry *req,
 	sp.nonce_addr = nonce->address + nonce_offset;
 	sp.counter = counter;
 	sp.dst_addr = dst->address + dst_offset;
-	return crypto_dispatch(SDK_OP_CRYPTO_STREAM, src_length, req, comp, &sp);
+	return crypto_dispatch(SDK_OP_CRYPTO_STREAM, src_length, sizeof(sp),
+	                       req, comp, &sp);
 }
 
 static uint16_t handle_crypto_aead(volatile struct SDKMailboxEntry *req,
@@ -3706,7 +3709,8 @@ static uint16_t handle_crypto_aead(volatile struct SDKMailboxEntry *req,
 	ap.nonce_addr = nonce->address;
 	ap.aad_addr = (aad_length != 0U) ? (aad->address + aad_offset) : 0U;
 	ap.aad_length = aad_length;
-	return crypto_dispatch(SDK_OP_CRYPTO_AEAD, src_length, req, comp, &ap);
+	return crypto_dispatch(SDK_OP_CRYPTO_AEAD, src_length, sizeof(ap),
+	                       req, comp, &ap);
 }
 
 static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
@@ -3771,7 +3775,7 @@ static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
 	                 flags == SDK_CRYPTO_KX_FLAG_KEYGEN)
 	                ? 0u : (point->address + point_off);
 	kp.dst_addr = dst->address + dst_off;
-	return crypto_dispatch(SDK_OP_CRYPTO_KX, 0u, req, comp, &kp);
+	return crypto_dispatch(SDK_OP_CRYPTO_KX, 0u, sizeof(kp), req, comp, &kp);
 }
 
 static uint16_t handle_crypto_verify(volatile struct SDKMailboxEntry *req,
@@ -3845,7 +3849,7 @@ static uint16_t handle_crypto_verify(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_UNSUPPORTED);
 	}
 
-	return crypto_dispatch(SDK_OP_CRYPTO_VERIFY, 0u, req, comp, &vp);
+	return crypto_dispatch(SDK_OP_CRYPTO_VERIFY, 0u, sizeof(vp), req, comp, &vp);
 }
 
 static uint16_t handle_decompress(volatile struct SDKMailboxEntry *req,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -742,6 +742,20 @@ typedef char SDKDecompressStreamResultPayload_must_be_48_bytes[
 static volatile int sdk_mailbox_pending;
 static volatile int sdk_mailbox_active;
 static volatile int sdk_completion_irq_enabled;
+
+/*
+ * Mailbox generation, bumped on every sdk_mailbox_init (Amiga reset / fw-update).
+ * Each offloaded task's slot is stamped with the generation live when it was
+ * enqueued; scheduler_core0_poll drops a harvested task whose stamp no longer
+ * matches, so a task that outlives the mailbox it was submitted under can never
+ * post its stale request_id/user_cookie into the next mailbox's completion ring.
+ * These are read/written only by core 0 (crypto_dispatch stamps, core0_poll
+ * checks, sdk_mailbox_init bumps), so they need no cross-core barrier. NOTE: any
+ * future non-crypto queue producer must stamp g_task_generation[slot] too, or
+ * its completions will be dropped as stale.
+ */
+static uint32_t sdk_mailbox_generation;
+static uint32_t g_task_generation[TASKQ_CAPACITY];
 static uint16_t sdk_status;
 static struct SDKSharedBuffer shared_buffers[SDK_MAX_SHARED_BUFFERS];
 static struct SDKSurface surfaces[SDK_MAX_SURFACES];
@@ -3409,6 +3423,11 @@ static uint16_t crypto_dispatch(uint16_t opcode, uint32_t in_len,
 		                         get_be32(req->request_id),
 		                         get_be32(req->user_cookie), params);
 		if (slot >= 0) {
+			/* Stamp the current mailbox generation so this task is dropped
+			 * rather than posted if the mailbox is re-initialised before it
+			 * finishes. Core-0-only field; safe to write after the QUEUED
+			 * release-store since core 1 never reads it. */
+			g_task_generation[slot] = sdk_mailbox_generation;
 			/* taskq_enqueue release-stored the QUEUED state; make it globally
 			 * visible and wake the worker if it is idling on WFE. */
 			__asm__ __volatile__("dsb ish\n\tsev" ::: "memory");
@@ -4361,6 +4380,9 @@ void sdk_mailbox_init(void)
 	sdk_status = SDK_STATUS_OK;
 	sdk_mailbox_active = 0;
 	sdk_mailbox_pending = 0;
+	/* New mailbox lifetime: any task still queued from the previous one is now
+	 * stale and must not post into this mailbox's completion ring. */
+	sdk_mailbox_generation++;
 	sdk_completion_irq_enabled = 0;
 	next_shared_handle = 1;
 	next_surface_handle = 1;
@@ -4526,6 +4548,19 @@ void sdk_mailbox_task(void)
 
 	if (completed_any && sdk_completion_irq_enabled)
 		amiga_interrupt_set(AMIGA_INTERRUPT_SDK);
+}
+
+/*
+ * True while a task whose slot was stamped at enqueue still belongs to the
+ * current mailbox lifetime. scheduler_core0_poll calls this before posting a
+ * harvested task's completion and drops it if this returns 0 -- so a task that
+ * outlived its mailbox never posts a stale request_id into the new one.
+ */
+int sdk_mailbox_task_gen_ok(int slot)
+{
+	if (slot < 0 || slot >= (int)TASKQ_CAPACITY)
+		return 0;
+	return g_task_generation[slot] == sdk_mailbox_generation;
 }
 
 /*

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -838,6 +838,7 @@ static const struct SDKServiceDescriptor sdk_services[] = {
 		SDK_CAP_CRYPTO,
 		SDK_SERVICE_FLAG_FIRMWARE | SDK_SERVICE_FLAG_CRYPTO_X25519 |
 			SDK_SERVICE_FLAG_CRYPTO_P256 |
+			SDK_SERVICE_FLAG_CRYPTO_P256_KEYGEN |
 			SDK_SERVICE_FLAG_CRYPTO_ECDSA_P256 |
 			SDK_SERVICE_FLAG_CRYPTO_RSA_2048 |
 			SDK_SERVICE_FLAG_CRYPTO_AES_GCM,
@@ -3101,8 +3102,9 @@ struct crypto_aead_params {
 
 struct crypto_kx_params {
 	uint32_t algorithm;
+	uint32_t flags;         /* SDK_CRYPTO_KX_FLAG_KEYGEN selects P-256 scalar*G */
 	uint32_t scalar_addr;
-	uint32_t point_addr;
+	uint32_t point_addr;    /* unused for keygen */
 	uint32_t dst_addr;
 };
 
@@ -3260,7 +3262,21 @@ static uint16_t crypto_kx_compute(const struct crypto_kx_params *p,
 		memset(xshared, 0, sizeof(xshared));
 		crypto_result(result_payload, SDK_X25519_SHARED_SIZE,
 		              SDK_CRYPTO_KX_X25519, 0U);
-	} else {  /* SDK_CRYPTO_KX_P256 -- the front validated the algorithm */
+	} else if (p->flags == SDK_CRYPTO_KX_FLAG_KEYGEN) {
+		/* P-256 keygen: scalar*G -> full 65-byte uncompressed point. No peer
+		 * point; the front validated scalar+dst and left point_addr unused. */
+		uint8_t pub[SDK_P256_POINT_SIZE];
+		Xil_DCacheInvalidateRange((INTPTR)scalar_data, SDK_P256_KEY_SIZE);
+		if (!sdk_p256_keygen(scalar_data, pub)) {
+			memset(pub, 0, sizeof(pub));
+			return SDK_STATUS_BAD_REQUEST;
+		}
+		memcpy(dst_data, pub, SDK_P256_POINT_SIZE);
+		Xil_DCacheFlushRange((INTPTR)dst_data, SDK_P256_POINT_SIZE);
+		memset(pub, 0, sizeof(pub));  /* public, but scrub the stack copy */
+		crypto_result(result_payload, SDK_P256_POINT_SIZE,
+		              SDK_CRYPTO_KX_P256, SDK_CRYPTO_KX_FLAG_KEYGEN);
+	} else {  /* SDK_CRYPTO_KX_P256 derive -- the front validated the algorithm */
 		uint8_t shared[SDK_P256_SHARED_SIZE];
 		Xil_DCacheInvalidateRange((INTPTR)scalar_data, SDK_P256_KEY_SIZE);
 		Xil_DCacheInvalidateRange((INTPTR)point_data, SDK_P256_POINT_SIZE);
@@ -3662,8 +3678,8 @@ static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
 	p = (volatile struct SDKCryptoKXPayload *)req->payload;
 	algorithm = get_be32(p->algorithm);
 	flags = get_be32(p->flags);
-	if (flags != 0U)
-		return complete_status(req, comp, SDK_STATUS_UNSUPPORTED);
+	/* flags are validated per algorithm below: X25519 requires 0; P-256 also
+	 * accepts SDK_CRYPTO_KX_FLAG_KEYGEN (scalar*G -> full public point). */
 
 	scalar = find_shared_buffer(get_be32(p->scalar_handle));
 	point  = find_shared_buffer(get_be32(p->point_handle));
@@ -3673,11 +3689,19 @@ static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
 	dst_off    = get_be32(p->dst_offset);
 
 	if (algorithm == SDK_CRYPTO_KX_X25519) {
+		if (flags != 0U)   /* X25519 keygen reuses derive with the base point */
+			return complete_status(req, comp, SDK_STATUS_UNSUPPORTED);
 		if (!buffer_range_valid(scalar, scalar_off, SDK_X25519_KEY_SIZE)   ||
 		    !buffer_range_valid(point,  point_off,  SDK_X25519_POINT_SIZE) ||
 		    !buffer_range_valid(dst,    dst_off,    SDK_X25519_SHARED_SIZE))
 			return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
-	} else if (algorithm == SDK_CRYPTO_KX_P256) {
+	} else if (algorithm == SDK_CRYPTO_KX_P256 &&
+	           flags == SDK_CRYPTO_KX_FLAG_KEYGEN) {
+		/* Keygen: scalar*G. No peer point; dst holds the full 65-byte point. */
+		if (!buffer_range_valid(scalar, scalar_off, SDK_P256_KEY_SIZE) ||
+		    !buffer_range_valid(dst,    dst_off,    SDK_P256_POINT_SIZE))
+			return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
+	} else if (algorithm == SDK_CRYPTO_KX_P256 && flags == 0U) {
 		if (!buffer_range_valid(scalar, scalar_off, SDK_P256_KEY_SIZE)   ||
 		    !buffer_range_valid(point,  point_off,  SDK_P256_POINT_SIZE) ||
 		    !buffer_range_valid(dst,    dst_off,    SDK_P256_SHARED_SIZE))
@@ -3687,9 +3711,14 @@ static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
 	}
 
 	kp.algorithm = algorithm;
+	kp.flags = flags;
 	kp.scalar_addr = scalar->address + scalar_off;
-	kp.point_addr  = point->address + point_off;
-	kp.dst_addr    = dst->address + dst_off;
+	/* keygen leaves the peer point unvalidated (and often unset), so don't
+	 * dereference it -- the compute ignores point_addr for keygen. */
+	kp.point_addr = (algorithm == SDK_CRYPTO_KX_P256 &&
+	                 flags == SDK_CRYPTO_KX_FLAG_KEYGEN)
+	                ? 0u : (point->address + point_off);
+	kp.dst_addr = dst->address + dst_off;
 	return crypto_dispatch(SDK_OP_CRYPTO_KX, 0u, req, comp, &kp);
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3355,18 +3355,43 @@ uint16_t sdk_mailbox_run_crypto_task(uint16_t opcode, const void *op_params,
 }
 
 /*
- * Front dispatch helper. Phase 1 (T11) runs the compute inline on core 0 so
- * behaviour is identical to the pre-scheduler firmware; T13 switches this to
- * enqueue-or-inline.
+ * Front dispatch helper. When core 1 is available, enqueue the task and defer
+ * the completion (return SDK_STATUS_QUEUED); sdk_mailbox_task then consumes the
+ * request without posting a completion, and scheduler_core0_poll posts it when
+ * the worker finishes. Otherwise -- single-core fallback, or a full queue --
+ * compute inline on core 0 and post the completion now, byte-identically to the
+ * pre-scheduler firmware.
+ *
+ * in_len is the input data length, used only to classify the task SHORT/LONG
+ * (KX/VERIFY are always SHORT and ignore it). Crypto tasks carry their resolved
+ * card-DDR addresses inside op_params, so the descriptor's in_addr/out_addr/
+ * out_cap fields are unused for the crypto opcode class and passed as 0.
  */
-static uint16_t crypto_dispatch(uint16_t opcode,
+static uint16_t crypto_dispatch(uint16_t opcode, uint32_t in_len,
                                 volatile struct SDKMailboxEntry *req,
                                 volatile struct SDKMailboxEntry *comp,
                                 const void *params)
 {
 	uint8_t result_payload[sizeof(struct SDKCryptoResultPayload)];
-	uint16_t status = sdk_mailbox_run_crypto_task(opcode, params,
-	                                               result_payload);
+	uint16_t status;
+
+	if (scheduler_core1_available()) {
+		taskq_shared_t *sh = scheduler_shared();
+		int slot = taskq_enqueue(&sh->queue, opcode,
+		                         taskq_class_for_opcode(opcode, in_len),
+		                         0u, in_len, 0u, 0u,
+		                         get_be32(req->request_id),
+		                         get_be32(req->user_cookie), params);
+		if (slot >= 0) {
+			/* taskq_enqueue release-stored the QUEUED state; make it globally
+			 * visible and wake the worker if it is idling on WFE. */
+			__asm__ __volatile__("dsb ish\n\tsev" ::: "memory");
+			return SDK_STATUS_QUEUED;
+		}
+		/* queue full -> fall through to synchronous inline compute */
+	}
+
+	status = sdk_mailbox_run_crypto_task(opcode, params, result_payload);
 	if (status != SDK_STATUS_OK)
 		return complete_status(req, comp, status);
 	write_completion(comp, req, SDK_STATUS_OK,
@@ -3453,7 +3478,7 @@ static uint16_t handle_crypto_hash(volatile struct SDKMailboxEntry *req,
 	hp.key_length = key_length;
 	hp.dst_addr = dst->address + dst_offset;
 	hp.digest_length = digest_length;
-	return crypto_dispatch(SDK_OP_CRYPTO_HASH, req, comp, &hp);
+	return crypto_dispatch(SDK_OP_CRYPTO_HASH, src_length, req, comp, &hp);
 }
 
 static uint16_t handle_crypto_stream(volatile struct SDKMailboxEntry *req,
@@ -3513,7 +3538,7 @@ static uint16_t handle_crypto_stream(volatile struct SDKMailboxEntry *req,
 	sp.nonce_addr = nonce->address + nonce_offset;
 	sp.counter = counter;
 	sp.dst_addr = dst->address + dst_offset;
-	return crypto_dispatch(SDK_OP_CRYPTO_STREAM, req, comp, &sp);
+	return crypto_dispatch(SDK_OP_CRYPTO_STREAM, src_length, req, comp, &sp);
 }
 
 static uint16_t handle_crypto_aead(volatile struct SDKMailboxEntry *req,
@@ -3613,7 +3638,7 @@ static uint16_t handle_crypto_aead(volatile struct SDKMailboxEntry *req,
 	ap.nonce_addr = nonce->address;
 	ap.aad_addr = (aad_length != 0U) ? (aad->address + aad_offset) : 0U;
 	ap.aad_length = aad_length;
-	return crypto_dispatch(SDK_OP_CRYPTO_AEAD, req, comp, &ap);
+	return crypto_dispatch(SDK_OP_CRYPTO_AEAD, src_length, req, comp, &ap);
 }
 
 static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
@@ -3665,7 +3690,7 @@ static uint16_t handle_crypto_kx(volatile struct SDKMailboxEntry *req,
 	kp.scalar_addr = scalar->address + scalar_off;
 	kp.point_addr  = point->address + point_off;
 	kp.dst_addr    = dst->address + dst_off;
-	return crypto_dispatch(SDK_OP_CRYPTO_KX, req, comp, &kp);
+	return crypto_dispatch(SDK_OP_CRYPTO_KX, 0u, req, comp, &kp);
 }
 
 static uint16_t handle_crypto_verify(volatile struct SDKMailboxEntry *req,
@@ -3739,7 +3764,7 @@ static uint16_t handle_crypto_verify(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_UNSUPPORTED);
 	}
 
-	return crypto_dispatch(SDK_OP_CRYPTO_VERIFY, req, comp, &vp);
+	return crypto_dispatch(SDK_OP_CRYPTO_VERIFY, 0u, req, comp, &vp);
 }
 
 static uint16_t handle_decompress(volatile struct SDKMailboxEntry *req,
@@ -4406,6 +4431,23 @@ void sdk_mailbox_task(void)
 		record_request_timing(opcode,
 		                      timing_delta_us(timing_start,
 		                                      timing_end));
+
+		if (sdk_status == SDK_STATUS_QUEUED) {
+			/*
+			 * Deferred to the core-1 task scheduler. Consume the request but
+			 * post no completion now and do NOT advance completion_tail --
+			 * scheduler_core0_poll -> sdk_mailbox_post_deferred posts it (and
+			 * counts it) when the worker finishes. The reserved comp slot at
+			 * comp_tail stays free for that later post; the completion IRQ is
+			 * raised then, not now.
+			 */
+			req_head = next_index(req_head);
+			put_be32(desc->request_head, req_head);
+			Xil_DCacheFlushRange((INTPTR)desc, sizeof(*desc));
+			__asm__ __volatile__("dsb" ::: "memory");
+			continue;
+		}
+
 		requests_completed++;
 		completed_any = 1;
 		if (sdk_status != SDK_STATUS_OK)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -4664,6 +4664,12 @@ int sdk_mailbox_post_deferred(uint32_t request_id, uint32_t user_cookie,
 	if (status != SDK_STATUS_OK)
 		requests_failed++;
 
+	/* Mirror the synchronous path: reflect this completion's result in the
+	 * global mailbox status. The offload left sdk_status at the QUEUED sentinel;
+	 * without this, REG_ZZ_SDK_DOORBELL / diag last_status would report QUEUED
+	 * forever after an offloaded request instead of its real success/error. */
+	sdk_status = status;
+
 	if (sdk_completion_irq_enabled)
 		amiga_interrupt_set(AMIGA_INTERRUPT_SDK);
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -161,6 +161,11 @@
 #define SDK_CRYPTO_KX_X25519           1U
 #define SDK_CRYPTO_KX_P256             2U
 
+/* KX flags word. KEYGEN turns a P-256 request into scalar*G: `scalar` is the
+ * private key, the peer point is ignored, and `dst` receives the full 65-byte
+ * uncompressed public point. Any other flag value is rejected (UNSUPPORTED). */
+#define SDK_CRYPTO_KX_FLAG_KEYGEN      1U
+
 #define SDK_OP_CRYPTO_VERIFY           0x0804U
 #define SDK_CRYPTO_VERIFY_ECDSA_P256_SHA256        1U
 #define SDK_CRYPTO_VERIFY_RSA_PKCS1_2048_SHA256    2U
@@ -170,6 +175,9 @@
 #define SDK_SERVICE_FLAG_CRYPTO_ECDSA_P256 (1U << 18)
 #define SDK_SERVICE_FLAG_CRYPTO_RSA_2048   (1U << 19)
 #define SDK_SERVICE_FLAG_CRYPTO_AES_GCM    (1U << 20)
+/* P-256 keygen (scalar*G -> full point) via the KX KEYGEN flag. Distinct from
+ * CRYPTO_P256 (derive only), which shipped without keygen. */
+#define SDK_SERVICE_FLAG_CRYPTO_P256_KEYGEN (1U << 21)
 
 /* Crypto verify payload: 48 bytes to match the inline mailbox entry size and
  * the SDK ZZ9KCryptoVerifyPayload byte-for-byte. All fields are big-endian

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -325,4 +325,13 @@ uint32_t sdk_mailbox_address(void);
 uint16_t sdk_mailbox_run_crypto_task(uint16_t opcode, const void *op_params,
                                      uint8_t *result_payload);
 
+/*
+ * Post a deferred completion for a task the core-1 scheduler finished (see
+ * scheduler_core0_poll). Returns 1 if posted, 0 if the completion ring is full
+ * (retry) or the mailbox is inactive. Runs only on core 0's main loop.
+ */
+int sdk_mailbox_post_deferred(uint32_t request_id, uint32_t user_cookie,
+                              uint16_t opcode, uint16_t status,
+                              const uint8_t *payload, uint16_t payload_len);
+
 #endif /* SDK_MAILBOX_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -314,4 +314,15 @@ void sdk_mailbox_task(void);
 uint16_t sdk_mailbox_status(void);
 uint32_t sdk_mailbox_address(void);
 
+/*
+ * Run a crypto task's compute on the calling core. op_params points at one of
+ * the crypto_*_params structs packed by the core-0 fronts; result_payload is a
+ * 48-byte SDKCryptoResultPayload buffer written by the compute. Returns an
+ * SDK_STATUS_* code. Shared by the dual-core scheduler's core-1 worker and the
+ * core-0 inline/fallback path (see scheduler.h). Cache maintenance for the data
+ * buffers is done inside, on whichever core runs it.
+ */
+uint16_t sdk_mailbox_run_crypto_task(uint16_t opcode, const void *op_params,
+                                     uint8_t *result_payload);
+
 #endif /* SDK_MAILBOX_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -343,4 +343,12 @@ int sdk_mailbox_post_deferred(uint32_t request_id, uint32_t user_cookie,
                               uint16_t opcode, uint16_t status,
                               const uint8_t *payload, uint16_t payload_len);
 
+/*
+ * True while a harvested task's slot still belongs to the current mailbox
+ * lifetime. scheduler_core0_poll drops (releases without posting) a task for
+ * which this returns 0, so a task that outlived the mailbox it was submitted
+ * under never posts a stale request_id/user_cookie into the new completion ring.
+ */
+int sdk_mailbox_task_gen_ok(int slot);
+
 #endif /* SDK_MAILBOX_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -203,6 +203,7 @@ struct SDKCryptoVerifyPayload {
 
 #define SDK_OP_DIAG_READ               0x0900U
 #define SDK_OP_DIAG_TIMING             0x0901U
+#define SDK_OP_DIAG_SCHED              0x0902U
 
 #define SDK_MAX_SHARED_BUFFERS         32U
 #define SDK_MAX_SURFACES               16U

--- a/build_firmware_docker.sh
+++ b/build_firmware_docker.sh
@@ -48,6 +48,7 @@ docker run --rm \
   -e CLEAN="$CLEAN" \
   -e BOOTIMAGE="$BOOTIMAGE" \
   -e OUTPUT="$OUTPUT" \
+  -e EXTRA_CFLAGS="${EXTRA_CFLAGS:-}" \
   "$IMAGE" bash -lc '
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive

--- a/test/scheduler/Makefile
+++ b/test/scheduler/Makefile
@@ -1,0 +1,23 @@
+CC ?= cc
+CFLAGS ?= -O2 -g -Wall -Wextra
+
+SRC_DIR := ../../ZZ9000_proto.sdk/ZZ9000OS/src
+BUILD_DIR := build
+TARGET := $(BUILD_DIR)/scheduler_test
+
+CPPFLAGS += -DTASKQ_HOST_TEST -I$(SRC_DIR)
+
+SOURCES := scheduler_test.c $(SRC_DIR)/scheduler.c
+DEPS := $(SRC_DIR)/scheduler.h
+
+.PHONY: test clean
+
+test: $(TARGET)
+	$(TARGET)
+
+$(TARGET): $(SOURCES) $(DEPS)
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $(SOURCES)
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/test/scheduler/scheduler_test.c
+++ b/test/scheduler/scheduler_test.c
@@ -207,6 +207,30 @@ static void test_should_drain_gates(void)
   expect_int("drain_no_core1", taskq_should_drain(0, 0, 0), 0);
 }
 
+static void test_watchdog_trips_at_threshold(void)
+{
+  taskq_watchdog_t w;
+  taskq_watchdog_init(&w, 3);
+  expect_int("wd_enabled0", taskq_watchdog_core1_enabled(&w), 1);
+  taskq_watchdog_on_fault(&w);
+  taskq_watchdog_on_fault(&w);
+  expect_int("wd_enabled2", taskq_watchdog_core1_enabled(&w), 1);
+  taskq_watchdog_on_fault(&w);
+  expect_int("wd_disabled3", taskq_watchdog_core1_enabled(&w), 0);
+}
+
+static void test_watchdog_success_resets_counter(void)
+{
+  taskq_watchdog_t w;
+  taskq_watchdog_init(&w, 3);
+  taskq_watchdog_on_fault(&w);
+  taskq_watchdog_on_fault(&w);
+  taskq_watchdog_on_success(&w);
+  taskq_watchdog_on_fault(&w);
+  taskq_watchdog_on_fault(&w);
+  expect_int("wd_still_enabled", taskq_watchdog_core1_enabled(&w), 1);
+}
+
 int main(void)
 {
   test_stress_fill_is_deterministic();
@@ -227,6 +251,8 @@ int main(void)
   test_class_data_ops_size_threshold();
   test_class_unknown_is_long();
   test_should_drain_gates();
+  test_watchdog_trips_at_threshold();
+  test_watchdog_success_resets_counter();
 
   if (failures) {
     printf("scheduler_test: %d failure(s)\n", failures);

--- a/test/scheduler/scheduler_test.c
+++ b/test/scheduler/scheduler_test.c
@@ -127,6 +127,59 @@ static void test_claim_short_skips_long(void)
   expect_u32("claim_short_left_long", q.descs[0].state, TASK_QUEUED);
 }
 
+static void test_complete_sets_done_and_payload(void)
+{
+  taskq_t q;
+  uint8_t pay[3] = {7, 8, 9};
+  taskq_init(&q);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  (void)taskq_claim_any(&q);
+  taskq_complete(&q, 0, 0 /*OK*/, pay, 3);
+  expect_u32("done_state", q.descs[0].state, TASK_DONE);
+  expect_u32("done_len", q.descs[0].result_len, 3u);
+  expect_u32("done_pay1", q.descs[0].result_payload[1], 8u);
+}
+
+static void test_complete_clamps_payload(void)
+{
+  taskq_t q;
+  uint8_t big[64];
+  uint32_t i;
+  taskq_init(&q);
+  for (i = 0; i < 64; i++) big[i] = (uint8_t)i;
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  (void)taskq_claim_any(&q);
+  taskq_complete(&q, 0, 0, big, 64);
+  expect_u32("clamp_len", q.descs[0].result_len, TASKQ_RESULT_PAYLOAD);
+}
+
+static void test_fail_sets_failed(void)
+{
+  taskq_t q;
+  taskq_init(&q);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  (void)taskq_claim_any(&q);
+  taskq_fail(&q, 0, 5 /*err*/);
+  expect_u32("fail_state", q.descs[0].state, TASK_FAILED);
+  expect_u32("fail_status", q.descs[0].result_status, 5u);
+}
+
+static void test_harvest_finds_done_then_release(void)
+{
+  taskq_t q;
+  int h;
+  taskq_init(&q);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  expect_int("harvest_none", taskq_harvest(&q), -1);
+  (void)taskq_claim_any(&q);
+  taskq_complete(&q, 0, 0, 0, 0);
+  h = taskq_harvest(&q);
+  expect_int("harvest_slot0", h, 0);
+  taskq_release(&q, 0);
+  expect_u32("release_free", q.descs[0].state, TASK_FREE);
+  expect_int("harvest_after_release", taskq_harvest(&q), -1);
+}
+
 int main(void)
 {
   test_stress_fill_is_deterministic();
@@ -139,6 +192,10 @@ int main(void)
   test_two_claims_never_collide();
   test_claim_advances_past_lost_cas();
   test_claim_short_skips_long();
+  test_complete_sets_done_and_payload();
+  test_complete_clamps_payload();
+  test_fail_sets_failed();
+  test_harvest_finds_done_then_release();
 
   if (failures) {
     printf("scheduler_test: %d failure(s)\n", failures);

--- a/test/scheduler/scheduler_test.c
+++ b/test/scheduler/scheduler_test.c
@@ -180,6 +180,33 @@ static void test_harvest_finds_done_then_release(void)
   expect_int("harvest_after_release", taskq_harvest(&q), -1);
 }
 
+static void test_class_kx_verify_always_short(void)
+{
+  expect_int("kx_short", taskq_class_for_opcode(TASKQ_OP_CRYPTO_KX, 999999u), TASK_SHORT);
+  expect_int("verify_short", taskq_class_for_opcode(TASKQ_OP_CRYPTO_VERIFY, 999999u), TASK_SHORT);
+}
+
+static void test_class_data_ops_size_threshold(void)
+{
+  expect_int("aead_small", taskq_class_for_opcode(TASKQ_OP_CRYPTO_AEAD, 4096u), TASK_SHORT);
+  expect_int("aead_big",   taskq_class_for_opcode(TASKQ_OP_CRYPTO_AEAD, 4097u), TASK_LONG);
+  expect_int("hash_big",   taskq_class_for_opcode(TASKQ_OP_CRYPTO_HASH, 65536u), TASK_LONG);
+  expect_int("stream_small", taskq_class_for_opcode(TASKQ_OP_CRYPTO_STREAM, 16u), TASK_SHORT);
+}
+
+static void test_class_unknown_is_long(void)
+{
+  expect_int("unknown_long", taskq_class_for_opcode(0x9999u, 0u), TASK_LONG);
+}
+
+static void test_should_drain_gates(void)
+{
+  expect_int("drain_idle",     taskq_should_drain(0, 0, 1), 1);
+  expect_int("drain_zorro",    taskq_should_drain(1, 0, 1), 0);
+  expect_int("drain_display",  taskq_should_drain(0, 1, 1), 0);
+  expect_int("drain_no_core1", taskq_should_drain(0, 0, 0), 0);
+}
+
 int main(void)
 {
   test_stress_fill_is_deterministic();
@@ -196,6 +223,10 @@ int main(void)
   test_complete_clamps_payload();
   test_fail_sets_failed();
   test_harvest_finds_done_then_release();
+  test_class_kx_verify_always_short();
+  test_class_data_ops_size_threshold();
+  test_class_unknown_is_long();
+  test_should_drain_gates();
 
   if (failures) {
     printf("scheduler_test: %d failure(s)\n", failures);

--- a/test/scheduler/scheduler_test.c
+++ b/test/scheduler/scheduler_test.c
@@ -56,7 +56,7 @@ static void test_enqueue_fills_and_queues(void)
   int s;
   taskq_init(&q);
   s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT,
-                    0x100u, 32u, 0x200u, 64u, 0xAAu, 0xBBu);
+                    0x100u, 32u, 0x200u, 64u, 0xAAu, 0xBBu, NULL);
   expect_int("enq_slot0", s, 0);
   expect_u32("enq_state", q.descs[0].state, TASK_QUEUED);
   expect_u32("enq_opcode", q.descs[0].opcode, TASKQ_OP_CRYPTO_KX);
@@ -72,10 +72,38 @@ static void test_enqueue_full_returns_minus1(void)
   int s;
   taskq_init(&q);
   for (i = 0; i < TASKQ_CAPACITY; i++) {
-    (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, i, i);
+    (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, i, i, NULL);
   }
-  s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 99, 99);
+  s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 99, 99, NULL);
   expect_int("enq_full", s, -1);
+}
+
+static void test_enqueue_copies_op_params(void)
+{
+  taskq_t q;
+  uint8_t params[TASKQ_OP_PARAM_BYTES];
+  uint32_t i;
+  int s;
+  for (i = 0; i < TASKQ_OP_PARAM_BYTES; i++) params[i] = (uint8_t)(i + 1);
+  taskq_init(&q);
+  s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_AEAD, TASK_LONG, 0, 0, 0, 0, 1, 1, params);
+  expect_int("enq_params_slot", s, 0);
+  for (i = 0; i < TASKQ_OP_PARAM_BYTES; i++) {
+    expect_u32("enq_params_byte", q.descs[0].op_params[i], (uint8_t)(i + 1));
+  }
+}
+
+static void test_enqueue_null_params_zeroes(void)
+{
+  taskq_t q;
+  uint32_t i;
+  taskq_init(&q);
+  /* pre-dirty the slot's params, then enqueue with NULL: must be zeroed */
+  for (i = 0; i < TASKQ_OP_PARAM_BYTES; i++) q.descs[0].op_params[i] = 0xEE;
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  for (i = 0; i < TASKQ_OP_PARAM_BYTES; i++) {
+    expect_u32("enq_null_params", q.descs[0].op_params[i], 0u);
+  }
 }
 
 static void test_claim_any_returns_queued_and_marks_claimed(void)
@@ -83,7 +111,7 @@ static void test_claim_any_returns_queued_and_marks_claimed(void)
   taskq_t q;
   int s;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
   s = taskq_claim_any(&q);
   expect_int("claim_slot0", s, 0);
   expect_u32("claim_state", q.descs[0].state, TASK_CLAIMED);
@@ -95,8 +123,8 @@ static void test_two_claims_never_collide(void)
   taskq_t q;
   int a, b;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2, NULL);
   a = taskq_claim_any(&q);
   b = taskq_claim_any(&q);
   if (a == b) { printf("claim_collision %d\n", a); failures++; }
@@ -107,8 +135,8 @@ static void test_claim_advances_past_lost_cas(void)
   taskq_t q;
   int s;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1); /* slot0 */
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2); /* slot1 */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL); /* slot0 */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2, NULL); /* slot1 */
   taskq_test_force_cas_fail = 1;    /* lose the race on the first CAS (slot0) */
   s = taskq_claim_any(&q);
   expect_int("claim_after_lost", s, 1);
@@ -120,8 +148,8 @@ static void test_claim_short_skips_long(void)
   taskq_t q;
   int s;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_AEAD, TASK_LONG, 0, 8192, 0, 0, 1, 1); /* slot0 LONG */
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2);     /* slot1 SHORT */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_AEAD, TASK_LONG, 0, 8192, 0, 0, 1, 1, NULL); /* slot0 LONG */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2, NULL);     /* slot1 SHORT */
   s = taskq_claim_short(&q);
   expect_int("claim_short_slot1", s, 1);
   expect_u32("claim_short_left_long", q.descs[0].state, TASK_QUEUED);
@@ -132,7 +160,7 @@ static void test_complete_sets_done_and_payload(void)
   taskq_t q;
   uint8_t pay[3] = {7, 8, 9};
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
   (void)taskq_claim_any(&q);
   taskq_complete(&q, 0, 0 /*OK*/, pay, 3);
   expect_u32("done_state", q.descs[0].state, TASK_DONE);
@@ -147,7 +175,7 @@ static void test_complete_clamps_payload(void)
   uint32_t i;
   taskq_init(&q);
   for (i = 0; i < 64; i++) big[i] = (uint8_t)i;
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
   (void)taskq_claim_any(&q);
   taskq_complete(&q, 0, 0, big, 64);
   expect_u32("clamp_len", q.descs[0].result_len, TASKQ_RESULT_PAYLOAD);
@@ -157,7 +185,7 @@ static void test_fail_sets_failed(void)
 {
   taskq_t q;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
   (void)taskq_claim_any(&q);
   taskq_fail(&q, 0, 5 /*err*/);
   expect_u32("fail_state", q.descs[0].state, TASK_FAILED);
@@ -169,7 +197,7 @@ static void test_harvest_finds_done_then_release(void)
   taskq_t q;
   int h;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
   expect_int("harvest_none", taskq_harvest(&q), -1);
   (void)taskq_claim_any(&q);
   taskq_complete(&q, 0, 0, 0, 0);
@@ -239,6 +267,8 @@ int main(void)
   test_init_marks_all_free();
   test_enqueue_fills_and_queues();
   test_enqueue_full_returns_minus1();
+  test_enqueue_copies_op_params();
+  test_enqueue_null_params_zeroes();
   test_claim_any_returns_queued_and_marks_claimed();
   test_two_claims_never_collide();
   test_claim_advances_past_lost_cas();

--- a/test/scheduler/scheduler_test.c
+++ b/test/scheduler/scheduler_test.c
@@ -1,0 +1,54 @@
+/*
+ * Host unit tests for the ZZ9000 dual-core task scheduler (portable core).
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include "scheduler.h"
+#include <stdio.h>
+
+static int failures;
+
+static void expect_u32(const char *n, uint32_t a, uint32_t e)
+{
+  if (a != e) { printf("%s: got %u expected %u\n", n, a, e); failures++; }
+}
+
+static void expect_int(const char *n, int a, int e)
+{
+  if (a != e) { printf("%s: got %d expected %d\n", n, a, e); failures++; }
+}
+
+static void test_stress_fill_is_deterministic(void)
+{
+  expect_u32("fill_same", taskq_stress_fill(0x1234u, 7u),
+             taskq_stress_fill(0x1234u, 7u));
+}
+
+static void test_stress_fill_varies_by_index(void)
+{
+  if (taskq_stress_fill(0x1234u, 7u) == taskq_stress_fill(0x1234u, 8u)) {
+    printf("fill_index_collision\n");
+    failures++;
+  }
+}
+
+static void test_stress_check_matches_fill(void)
+{
+  uint32_t v = taskq_stress_fill(0xABCDu, 42u);
+  expect_int("check_ok",  taskq_stress_check(0xABCDu, 42u, v), 1);
+  expect_int("check_bad", taskq_stress_check(0xABCDu, 42u, v ^ 1u), 0);
+}
+
+int main(void)
+{
+  test_stress_fill_is_deterministic();
+  test_stress_fill_varies_by_index();
+  test_stress_check_matches_fill();
+
+  if (failures) {
+    printf("scheduler_test: %d failure(s)\n", failures);
+    return 1;
+  }
+  printf("scheduler_test: all checks passed\n");
+  return 0;
+}

--- a/test/scheduler/scheduler_test.c
+++ b/test/scheduler/scheduler_test.c
@@ -39,11 +39,53 @@ static void test_stress_check_matches_fill(void)
   expect_int("check_bad", taskq_stress_check(0xABCDu, 42u, v ^ 1u), 0);
 }
 
+static void test_init_marks_all_free(void)
+{
+  taskq_t q;
+  uint32_t i;
+  taskq_init(&q);
+  for (i = 0; i < TASKQ_CAPACITY; i++) {
+    expect_u32("init_free", q.descs[i].state, TASK_FREE);
+  }
+  expect_u32("init_cursor", q.enqueue_cursor, 0u);
+}
+
+static void test_enqueue_fills_and_queues(void)
+{
+  taskq_t q;
+  int s;
+  taskq_init(&q);
+  s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT,
+                    0x100u, 32u, 0x200u, 64u, 0xAAu, 0xBBu);
+  expect_int("enq_slot0", s, 0);
+  expect_u32("enq_state", q.descs[0].state, TASK_QUEUED);
+  expect_u32("enq_opcode", q.descs[0].opcode, TASKQ_OP_CRYPTO_KX);
+  expect_u32("enq_in_addr", q.descs[0].in_addr, 0x100u);
+  expect_u32("enq_cookie", q.descs[0].user_cookie, 0xBBu);
+  expect_u32("enq_cursor", q.enqueue_cursor, 1u);
+}
+
+static void test_enqueue_full_returns_minus1(void)
+{
+  taskq_t q;
+  uint32_t i;
+  int s;
+  taskq_init(&q);
+  for (i = 0; i < TASKQ_CAPACITY; i++) {
+    (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, i, i);
+  }
+  s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 99, 99);
+  expect_int("enq_full", s, -1);
+}
+
 int main(void)
 {
   test_stress_fill_is_deterministic();
   test_stress_fill_varies_by_index();
   test_stress_check_matches_fill();
+  test_init_marks_all_free();
+  test_enqueue_fills_and_queues();
+  test_enqueue_full_returns_minus1();
 
   if (failures) {
     printf("scheduler_test: %d failure(s)\n", failures);

--- a/test/scheduler/scheduler_test.c
+++ b/test/scheduler/scheduler_test.c
@@ -78,6 +78,55 @@ static void test_enqueue_full_returns_minus1(void)
   expect_int("enq_full", s, -1);
 }
 
+static void test_claim_any_returns_queued_and_marks_claimed(void)
+{
+  taskq_t q;
+  int s;
+  taskq_init(&q);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  s = taskq_claim_any(&q);
+  expect_int("claim_slot0", s, 0);
+  expect_u32("claim_state", q.descs[0].state, TASK_CLAIMED);
+  expect_int("claim_again_empty", taskq_claim_any(&q), -1);
+}
+
+static void test_two_claims_never_collide(void)
+{
+  taskq_t q;
+  int a, b;
+  taskq_init(&q);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2);
+  a = taskq_claim_any(&q);
+  b = taskq_claim_any(&q);
+  if (a == b) { printf("claim_collision %d\n", a); failures++; }
+}
+
+static void test_claim_advances_past_lost_cas(void)
+{
+  taskq_t q;
+  int s;
+  taskq_init(&q);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1); /* slot0 */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2); /* slot1 */
+  taskq_test_force_cas_fail = 1;    /* lose the race on the first CAS (slot0) */
+  s = taskq_claim_any(&q);
+  expect_int("claim_after_lost", s, 1);
+  taskq_test_force_cas_fail = 0;
+}
+
+static void test_claim_short_skips_long(void)
+{
+  taskq_t q;
+  int s;
+  taskq_init(&q);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_AEAD, TASK_LONG, 0, 8192, 0, 0, 1, 1); /* slot0 LONG */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2);     /* slot1 SHORT */
+  s = taskq_claim_short(&q);
+  expect_int("claim_short_slot1", s, 1);
+  expect_u32("claim_short_left_long", q.descs[0].state, TASK_QUEUED);
+}
+
 int main(void)
 {
   test_stress_fill_is_deterministic();
@@ -86,6 +135,10 @@ int main(void)
   test_init_marks_all_free();
   test_enqueue_fills_and_queues();
   test_enqueue_full_returns_minus1();
+  test_claim_any_returns_queued_and_marks_claimed();
+  test_two_claims_never_collide();
+  test_claim_advances_past_lost_cas();
+  test_claim_short_skips_long();
 
   if (failures) {
     printf("scheduler_test: %d failure(s)\n", failures);

--- a/test/scheduler/scheduler_test.c
+++ b/test/scheduler/scheduler_test.c
@@ -56,7 +56,7 @@ static void test_enqueue_fills_and_queues(void)
   int s;
   taskq_init(&q);
   s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT,
-                    0x100u, 32u, 0x200u, 64u, 0xAAu, 0xBBu, NULL);
+                    0x100u, 32u, 0x200u, 64u, 0xAAu, 0xBBu, NULL, 0u);
   expect_int("enq_slot0", s, 0);
   expect_u32("enq_state", q.descs[0].state, TASK_QUEUED);
   expect_u32("enq_opcode", q.descs[0].opcode, TASKQ_OP_CRYPTO_KX);
@@ -72,9 +72,9 @@ static void test_enqueue_full_returns_minus1(void)
   int s;
   taskq_init(&q);
   for (i = 0; i < TASKQ_CAPACITY; i++) {
-    (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, i, i, NULL);
+    (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, i, i, NULL, 0u);
   }
-  s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 99, 99, NULL);
+  s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 99, 99, NULL, 0u);
   expect_int("enq_full", s, -1);
 }
 
@@ -86,7 +86,8 @@ static void test_enqueue_copies_op_params(void)
   int s;
   for (i = 0; i < TASKQ_OP_PARAM_BYTES; i++) params[i] = (uint8_t)(i + 1);
   taskq_init(&q);
-  s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_AEAD, TASK_LONG, 0, 0, 0, 0, 1, 1, params);
+  s = taskq_enqueue(&q, TASKQ_OP_CRYPTO_AEAD, TASK_LONG, 0, 0, 0, 0, 1, 1, params,
+                    TASKQ_OP_PARAM_BYTES);
   expect_int("enq_params_slot", s, 0);
   for (i = 0; i < TASKQ_OP_PARAM_BYTES; i++) {
     expect_u32("enq_params_byte", q.descs[0].op_params[i], (uint8_t)(i + 1));
@@ -100,9 +101,27 @@ static void test_enqueue_null_params_zeroes(void)
   taskq_init(&q);
   /* pre-dirty the slot's params, then enqueue with NULL: must be zeroed */
   for (i = 0; i < TASKQ_OP_PARAM_BYTES; i++) q.descs[0].op_params[i] = 0xEE;
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u);
   for (i = 0; i < TASKQ_OP_PARAM_BYTES; i++) {
     expect_u32("enq_null_params", q.descs[0].op_params[i], 0u);
+  }
+}
+
+static void test_enqueue_param_len_bounds_copy(void)
+{
+  taskq_t q;
+  uint8_t src[TASKQ_OP_PARAM_BYTES];
+  uint32_t i;
+  taskq_init(&q);
+  for (i = 0; i < TASKQ_OP_PARAM_BYTES; i++) src[i] = 0xC0;  /* all non-zero */
+  /* Copy only the first 8 bytes; the rest must be zero-filled, not leaked from
+   * the source past param_len (the callers pass structs < 48 bytes). */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, src, 8u);
+  for (i = 0; i < 8u; i++) {
+    expect_u32("param_copied", q.descs[0].op_params[i], 0xC0u);
+  }
+  for (i = 8u; i < TASKQ_OP_PARAM_BYTES; i++) {
+    expect_u32("param_zerofill", q.descs[0].op_params[i], 0u);
   }
 }
 
@@ -111,7 +130,7 @@ static void test_claim_any_returns_queued_and_marks_claimed(void)
   taskq_t q;
   int s;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u);
   s = taskq_claim_any(&q);
   expect_int("claim_slot0", s, 0);
   expect_u32("claim_state", q.descs[0].state, TASK_CLAIMED);
@@ -123,8 +142,8 @@ static void test_two_claims_never_collide(void)
   taskq_t q;
   int a, b;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2, NULL, 0u);
   a = taskq_claim_any(&q);
   b = taskq_claim_any(&q);
   if (a == b) { printf("claim_collision %d\n", a); failures++; }
@@ -135,8 +154,8 @@ static void test_claim_advances_past_lost_cas(void)
   taskq_t q;
   int s;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL); /* slot0 */
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2, NULL); /* slot1 */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u); /* slot0 */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2, NULL, 0u); /* slot1 */
   taskq_test_force_cas_fail = 1;    /* lose the race on the first CAS (slot0) */
   s = taskq_claim_any(&q);
   expect_int("claim_after_lost", s, 1);
@@ -148,8 +167,8 @@ static void test_claim_short_skips_long(void)
   taskq_t q;
   int s;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_AEAD, TASK_LONG, 0, 8192, 0, 0, 1, 1, NULL); /* slot0 LONG */
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2, NULL);     /* slot1 SHORT */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_AEAD, TASK_LONG, 0, 8192, 0, 0, 1, 1, NULL, 0u); /* slot0 LONG */
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 2, 2, NULL, 0u);     /* slot1 SHORT */
   s = taskq_claim_short(&q);
   expect_int("claim_short_slot1", s, 1);
   expect_u32("claim_short_left_long", q.descs[0].state, TASK_QUEUED);
@@ -160,7 +179,7 @@ static void test_complete_sets_done_and_payload(void)
   taskq_t q;
   uint8_t pay[3] = {7, 8, 9};
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u);
   (void)taskq_claim_any(&q);
   taskq_complete(&q, 0, 0 /*OK*/, pay, 3);
   expect_u32("done_state", q.descs[0].state, TASK_DONE);
@@ -175,7 +194,7 @@ static void test_complete_clamps_payload(void)
   uint32_t i;
   taskq_init(&q);
   for (i = 0; i < 64; i++) big[i] = (uint8_t)i;
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u);
   (void)taskq_claim_any(&q);
   taskq_complete(&q, 0, 0, big, 64);
   expect_u32("clamp_len", q.descs[0].result_len, TASKQ_RESULT_PAYLOAD);
@@ -185,7 +204,7 @@ static void test_fail_sets_failed(void)
 {
   taskq_t q;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u);
   (void)taskq_claim_any(&q);
   taskq_fail(&q, 0, 5 /*err*/);
   expect_u32("fail_state", q.descs[0].state, TASK_FAILED);
@@ -197,7 +216,7 @@ static void test_harvest_finds_done_then_release(void)
   taskq_t q;
   int h;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u);
   expect_int("harvest_none", taskq_harvest(&q), -1);
   (void)taskq_claim_any(&q);
   taskq_complete(&q, 0, 0, 0, 0);
@@ -213,7 +232,7 @@ static void test_has_active_tracks_queued_and_claimed(void)
   taskq_t q;
   taskq_init(&q);
   expect_int("active_empty", taskq_has_active(&q), 0);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u);
   expect_int("active_queued", taskq_has_active(&q), 1);   /* QUEUED counts */
   (void)taskq_claim_any(&q);
   expect_int("active_claimed", taskq_has_active(&q), 1);  /* CLAIMED counts */
@@ -227,7 +246,7 @@ static void test_has_active_ignores_failed(void)
 {
   taskq_t q;
   taskq_init(&q);
-  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL, 0u);
   (void)taskq_claim_any(&q);
   taskq_fail(&q, 0, 5);
   expect_int("active_failed", taskq_has_active(&q), 0);   /* FAILED does not */
@@ -294,6 +313,7 @@ int main(void)
   test_enqueue_full_returns_minus1();
   test_enqueue_copies_op_params();
   test_enqueue_null_params_zeroes();
+  test_enqueue_param_len_bounds_copy();
   test_claim_any_returns_queued_and_marks_claimed();
   test_two_claims_never_collide();
   test_claim_advances_past_lost_cas();

--- a/test/scheduler/scheduler_test.c
+++ b/test/scheduler/scheduler_test.c
@@ -208,6 +208,31 @@ static void test_harvest_finds_done_then_release(void)
   expect_int("harvest_after_release", taskq_harvest(&q), -1);
 }
 
+static void test_has_active_tracks_queued_and_claimed(void)
+{
+  taskq_t q;
+  taskq_init(&q);
+  expect_int("active_empty", taskq_has_active(&q), 0);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  expect_int("active_queued", taskq_has_active(&q), 1);   /* QUEUED counts */
+  (void)taskq_claim_any(&q);
+  expect_int("active_claimed", taskq_has_active(&q), 1);  /* CLAIMED counts */
+  taskq_complete(&q, 0, 0, 0, 0);
+  expect_int("active_done", taskq_has_active(&q), 0);     /* DONE does not */
+  taskq_release(&q, 0);
+  expect_int("active_free", taskq_has_active(&q), 0);     /* FREE does not */
+}
+
+static void test_has_active_ignores_failed(void)
+{
+  taskq_t q;
+  taskq_init(&q);
+  (void)taskq_enqueue(&q, TASKQ_OP_CRYPTO_KX, TASK_SHORT, 0, 0, 0, 0, 1, 1, NULL);
+  (void)taskq_claim_any(&q);
+  taskq_fail(&q, 0, 5);
+  expect_int("active_failed", taskq_has_active(&q), 0);   /* FAILED does not */
+}
+
 static void test_class_kx_verify_always_short(void)
 {
   expect_int("kx_short", taskq_class_for_opcode(TASKQ_OP_CRYPTO_KX, 999999u), TASK_SHORT);
@@ -277,6 +302,8 @@ int main(void)
   test_complete_clamps_payload();
   test_fail_sets_failed();
   test_harvest_finds_done_then_release();
+  test_has_active_tracks_queued_and_claimed();
+  test_has_active_ignores_failed();
   test_class_kx_verify_always_short();
   test_class_data_ops_size_threshold();
   test_class_unknown_is_long();


### PR DESCRIPTION
## Dual-core task scheduler — move LONG ops (crypto) off the main loop onto core 1

Fixes the display-contention stalls: heavyweight crypto operations ran inline on
the core-0 main loop, so a busy RTG/display path could starve TLS offload (and
vice-versa). This branch stands up a real two-core task scheduler on the Zynq
(Cortex-A9 SMP) and routes LONG opcodes to core 1, while core 0 keeps the
mailbox and display responsive.

### Phase 0 — coherency bring-up (the gate)
- Reserve a 1 MB coherent task-queue region at `0x18000000` (`memorymap.h`).
- Core-1 MMU / D-cache / SMP bring-up + shareable task-queue mapping
  (`scheduler_arm.c`).
- Flag-gated two-core coherency **stress harness** (`scheduler_stress.c`) that
  hammers the shared queue from both cores and kicks the private watchdog — the
  gate that had to pass before any service conversion.

### Phase 1 — scheduler + crypto conversion
- Portable, **host-tested** queue core (`test/scheduler/`, 293 lines): queue
  init + single-producer enqueue, lock-free `claim_any` / class-filtered
  `claim_short`, complete/fail/harvest/release transitions, SHORT/LONG opcode
  policy + bus-safe drain predicate, fault watchdog with single-core-fallback
  trip.
- Core-1 worker loop + crypto opcode dispatch; crypto handlers refactored into
  resolved-address compute cores so they run identically on either core.
- Crypto requests **enqueue and defer** completion (`SDK_STATUS_QUEUED`); core 0
  harvests results, posts deferred completions, and opportunistically drains
  SHORT tasks.
- Per-task fault recovery: a core-1 fault marks the task `FAILED` and triggers a
  core-0-driven cold restart of core 1; **single-core fallback** keeps crypto
  working if core 1 never comes up.
- P-256 keygen added to the KX op, routed through the scheduler (supersedes the
  standalone `crypto-p256-keygen` branch).

### Observability + the core-1 bring-up fix (HW-validated)
- `DIAG_SCHED` (0x0902) exposes per-core task counters.
- **Critical fix found via that observability:** core 1 was never actually
  booting in the production build — the C entry prologue faulted on an undefined
  reset stack pointer, and there was no cache flush before `sev`. Fix: a naked
  `core1_entry` stub with a valid reserved stack + proper reset entry
  (`a542143`) and zeroed core0/core1 counters at boot (`2f426b9`). After the fix,
  core 1 executes real work: **core1=82 / core0=0** tasks under load.
- Rate-limit the RX-buffer-exhausted console spam so the scheduler diagnostics
  stay readable under an ethernet flood (`5edc72f`).

### Testing
- Host: `test/scheduler/` queue/claim/transition/watchdog suite (portable C).
- CI: `.github/workflows/build.yml` runs the scheduler host test.
- ARM firmware builds clean via the Docker toolchain.
- **Hardware-validated** by the card owner (core-1 execution confirmed under
  live display + offload load).

Base: `master`.
