### PR TITLE
Ethernet RX-accept handshake fixes + issue #29 stall instrumentation

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -821,7 +821,10 @@ void ethernet_diag_poll(u32 txreq, u32 rdreq) {
 	static u16 diag_last_read = 0;
 	static u32 diag_stuck = 0;
 	static int diag_reported = 0;
-	static XTime diag_last_hb = 0;
+	static XTime diag_tick = 0;
+	static u32 p_tx = 0, p_rd = 0, p_rx = 0, p_ftx = 0;
+	static u32 last_reqs = 0xffffffffu;
+	static int quiet = 0;
 	XTime now;
 
 	/* Stuck detector: frames queued but the read pointer is not advancing.
@@ -838,15 +841,45 @@ void ethernet_diag_poll(u32 txreq, u32 rdreq) {
 		diag_last_read = frames_backlog_read;
 	}
 
-	/* Wall-clock heartbeat (~1/s) — prints regardless of RX activity, so it
-	 * keeps reporting even when the m68k has frozen and RX has gone quiet.
-	 * Lines KEEP coming through the freeze => firmware main loop is alive and
-	 * the wedge is m68k-side; lines STOP => the firmware itself hung. The
-	 * txreq/rdreq deltas show whether the frozen m68k still issues bus cycles. */
+	/* Once-a-second internal tick (otherwise this is just a cheap timer read). */
 	XTime_GetTime(&now);
-	if ((now - diag_last_hb) >= (XTime)COUNTS_PER_SECOND) {
-		diag_last_hb = now;
-		ethernet_diag_dump("wall", txreq, rdreq);
+	if ((now - diag_tick) < (XTime)COUNTS_PER_SECOND)
+		return;
+	diag_tick = now;
+
+	/* Per-second rates. */
+	u32 d_tx  = txreq - p_tx;			/* Zorro WRITE requests serviced */
+	u32 d_rd  = rdreq - p_rd;			/* Zorro READ  requests serviced */
+	u32 d_rx  = frames_received - p_rx;		/* frames received from the wire */
+	u32 d_ftx = FramesTx - p_ftx;			/* frames transmitted to the wire */
+	u32 reqs  = d_tx + d_rd;
+	p_tx = txreq; p_rd = rdreq; p_rx = frames_received; p_ftx = FramesTx;
+
+	/* Print only when the Zorro request RATE changes sharply (>=2x up or down)
+	 * — that brackets the freeze transition and any Forbid-spin flood/collapse
+	 * — or as a slow keepalive every 20 s to confirm the firmware is alive and
+	 * sample a steady freeze state. Keeps the log quiet during the minutes of
+	 * steady transfer. Rates are per second, so a stall is obvious at a glance. */
+	quiet++;
+	int changed = (last_reqs == 0xffffffffu) ||
+	              (reqs > (last_reqs << 1)) ||
+	              ((reqs << 1) < last_reqs);
+	if (changed || quiet >= 20) {
+		quiet = 0;
+		last_reqs = reqs;
+		printf("EMAC[%s]: reqs/s=%lu (txw=%lu rdr=%lu) rx/s=%lu ftx/s=%lu backlog=%u read=%u dropped=%d mismatch=%d ackrej=%d intraises=%lu\n",
+		       changed ? "CHG" : "hb",
+		       (unsigned long)reqs,
+		       (unsigned long)d_tx,
+		       (unsigned long)d_rd,
+		       (unsigned long)d_rx,
+		       (unsigned long)d_ftx,
+		       (unsigned)frames_backlog,
+		       (unsigned)frames_backlog_read,
+		       frames_dropped,
+		       rx_slot_mismatch,
+		       frames_ack_rejected,
+		       (unsigned long)eth_int_raises);
 	}
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -697,15 +697,23 @@ static void XEmacPsRecvHandler(void *Callback)
 		for (int i=0; i<num_rx_bufs; i++) {
 
 			frame_serial++;
-			/* 0 is the empty-slot / "no frame" sentinel: the driver skips an
-			 * all-zero header without acking, and the RX-accept handshake
-			 * rejects acked_serial == 0. frame_serial is a u16, so a plain
-			 * increment wraps 0xffff -> 0 once every 65536 frames; skip 0 so a
-			 * real frame is never tagged with the sentinel. Otherwise the
-			 * handshake would reject that frame forever (frames_backlog_read
-			 * never advances) and RX would stall until reset (issue #29). */
-			if (frame_serial == 0)
-				frame_serial++;
+			/* 0 and 1 are reserved values the RX-accept handshake treats
+			 * specially, so a real frame must never be tagged with either:
+			 *   0 = empty-slot / "no frame" sentinel — the driver skips an
+			 *       all-zero header without acking, and the handshake rejects
+			 *       acked_serial == 0. A frame tagged 0 would be rejected
+			 *       forever (frames_backlog_read never advances) → RX stalls.
+			 *   1 = legacy bare-advance — old drivers write a constant 1, which
+			 *       must bypass validation for backward compat. A frame tagged
+			 *       1 would be left unprotected by the handshake (a stray or
+			 *       duplicate legacy-style ack could consume it unread).
+			 * frame_serial is a u16, so a plain increment would emit 0 once per
+			 * 65536-frame wrap, and 1 on the first frame after reset and once
+			 * per wrap. frame_serial reaches 0 only by wrapping 0xffff->0 and 1
+			 * only from the post-reset 0->1, so a single jump to 2 skips both.
+			 * Real serials therefore stay in [2, 0xffff] (issue #29). */
+			if (frame_serial == 0 || frame_serial == 1)
+				frame_serial = 2;
 
 			//printf("RX ser: %d\n",frame_serial);
 
@@ -828,9 +836,10 @@ int ethernet_receive_frame(u16 acked_serial) {
 		 * Backward compatibility: legacy drivers write a constant 1 instead of
 		 * the real serial. We honour acked_serial == 1 as a bare advance so
 		 * those drivers keep working unchanged (the check is then a no-op);
-		 * reject 0 (never a valid serial — frame_serial is pre-incremented);
-		 * and for any other value require an exact match with the presented
-		 * frame's serial. */
+		 * reject 0. The serial generator skips both 0 and 1 (see frame_serial
+		 * above), so a handshake driver never emits either as a real serial —
+		 * value 1 is therefore only ever a legacy ack, and every real frame is
+		 * protected by the exact-match branch below. */
 		uint8_t* slot = ethernet_current_receive_ptr();
 		u16 presented = ((u16)slot[2] << 8) | slot[3];
 		int consume;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -72,6 +72,7 @@ static volatile int tx_recoveries = 0;
 static volatile int rx_backpressure = 0;
 static volatile int rx_pause_frames = 0;
 static volatile int rx_slot_mismatch = 0;
+static volatile int frames_ack_rejected = 0;	/* issue #29: RX-accept handshake rejects */
 
 #define ETH_PHY_TYPE_MICREL 0
 #define ETH_PHY_TYPE_MOTORCOMM 1
@@ -395,7 +396,7 @@ static void ethernet_log_status(const char *reason) {
 	XEmacPs* EmacPsInstancePtr = &EmacPsInstance;
 	u32 BaseAddress = EmacPsInstancePtr->Config.BaseAddress;
 
-	printf("EMAC[%s]: state=%d backlog=%u reserved=%u pending=%u read=%u write=%u reserve=%u serial=%u rx=%lu tx=%lu drops=%d full=%d bp=%d pause=%d mismatch=%d txrec=%d errors=%ld\n",
+	printf("EMAC[%s]: state=%d backlog=%u reserved=%u pending=%u read=%u write=%u reserve=%u serial=%u rx=%lu tx=%lu drops=%d full=%d bp=%d pause=%d mismatch=%d ackrej=%d txrec=%d errors=%ld\n",
 	       reason,
 	       ethernet_task_state,
 	       (unsigned int)frames_backlog,
@@ -412,6 +413,7 @@ static void ethernet_log_status(const char *reason) {
 	       rx_backpressure,
 	       rx_pause_frames,
 	       rx_slot_mismatch,
+	       frames_ack_rejected,
 	       tx_recoveries,
 	       (long)DeviceErrors);
 
@@ -797,17 +799,50 @@ u16 ethernet_get_rx_stats() {
 	return (dropped << 8) | pause;
 }
 
-int ethernet_receive_frame() {
+int ethernet_receive_frame(u16 acked_serial) {
 	//printf("[eth rx] backlog %d read %d write %d\n", frames_backlog, frames_backlog_read, frames_backlog_write);
 
 	int paused = ethernet_pause_rx_irq();
 	if (frames_backlog>0) {
-		uint16_t consumed_slot = frames_backlog_read;
-		frames_backlog_read = ethernet_next_backlog_slot(frames_backlog_read);
-		frames_backlog--;
-		ethernet_clear_backlog_slot(consumed_slot);
-		if (frames_backlog == 0) {
-			ethernet_clear_backlog_slot(frames_backlog_read);
+		/* Defense-in-depth (issue #29): only consume the presented frame when
+		 * the Amiga's ack actually corresponds to it. The Amiga writes the
+		 * serial of the frame it just read into the RX-accept register; we
+		 * compare it to the serial stored in the presented backlog slot.
+		 *
+		 * Why: a driver that acks an EMPTY (firmware-cleared) slot, or that
+		 * races a frame landing in the read slot between its read and its ack,
+		 * would otherwise make us advance past a frame the Amiga never read,
+		 * silently dropping it — the original issue #29 stall. An empty slot
+		 * carries serial 0; a mismatched ack carries a different serial. In
+		 * both cases we refuse to advance and leave the frame for the Amiga.
+		 *
+		 * Backward compatibility: legacy drivers write a constant 1 instead of
+		 * the real serial. We honour acked_serial == 1 as a bare advance so
+		 * those drivers keep working unchanged (the check is then a no-op);
+		 * reject 0 (never a valid serial — frame_serial is pre-incremented);
+		 * and for any other value require an exact match with the presented
+		 * frame's serial. */
+		uint8_t* slot = ethernet_current_receive_ptr();
+		u16 presented = ((u16)slot[2] << 8) | slot[3];
+		int consume;
+		if (acked_serial == 0) {
+			consume = 0;                            /* empty / invalid ack */
+		} else if (acked_serial == 1) {
+			consume = 1;                            /* legacy bare advance */
+		} else {
+			consume = (acked_serial == presented);  /* handshake: must match */
+		}
+
+		if (consume) {
+			uint16_t consumed_slot = frames_backlog_read;
+			frames_backlog_read = ethernet_next_backlog_slot(frames_backlog_read);
+			frames_backlog--;
+			ethernet_clear_backlog_slot(consumed_slot);
+			if (frames_backlog == 0) {
+				ethernet_clear_backlog_slot(frames_backlog_read);
+			}
+		} else {
+			frames_ack_rejected++;
 		}
 	} else {
 		// this is NOT an error, Amiga wants data and there is no data on RX buffers

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -820,29 +820,14 @@ void ethernet_note_int_raised(void) {
 /* txreq/rdreq = running counts of Zorro write/read requests the firmware has
  * serviced from the m68k (passed in from main.c). During a freeze these tell
  * us whether the m68k is still issuing ANY bus cycles. */
-void ethernet_diag_poll(u32 txreq, u32 rdreq) {
-	static u16 diag_last_read = 0;
-	static u32 diag_stuck = 0;
-	static int diag_reported = 0;
+void ethernet_diag_poll(const struct eth_diag_z *z) {
 	static XTime diag_tick = 0;
-	static u32 p_tx = 0, p_rd = 0, p_rx = 0, p_ftx = 0, p_sc = 0;
+	static u32 p_wreg=0, p_wtx=0, p_wfb=0, p_woth=0;
+	static u32 p_rreg=0, p_rrx=0, p_roth=0;
+	static u32 p_rx=0, p_ftx=0, p_sc=0;
 	static u32 last_reqs = 0xffffffffu;
 	static int quiet = 0;
 	XTime now;
-
-	/* Stuck detector: frames queued but the read pointer is not advancing.
-	 * Healthy draining advances read constantly, so this only trips when the
-	 * Amiga has stopped consuming while backlog>0. Dump once per stuck episode. */
-	if (frames_backlog > 0 && frames_backlog_read == diag_last_read) {
-		if (++diag_stuck >= 3000000u && !diag_reported) {
-			ethernet_diag_dump("STALL", txreq, rdreq);
-			diag_reported = 1;
-		}
-	} else {
-		diag_stuck = 0;
-		diag_reported = 0;
-		diag_last_read = frames_backlog_read;
-	}
 
 	/* Once-a-second internal tick (otherwise this is just a cheap timer read). */
 	XTime_GetTime(&now);
@@ -850,20 +835,25 @@ void ethernet_diag_poll(u32 txreq, u32 rdreq) {
 		return;
 	diag_tick = now;
 
-	/* Per-second rates. */
-	u32 d_tx  = txreq - p_tx;			/* Zorro WRITE requests serviced */
-	u32 d_rd  = rdreq - p_rd;			/* Zorro READ  requests serviced */
-	u32 d_rx  = frames_received - p_rx;		/* frames received from the wire */
-	u32 d_ftx = FramesTx - p_ftx;			/* frames transmitted to the wire */
-	u32 d_sc  = eth_send_calls - p_sc;		/* ethernet_send_frame() calls */
-	u32 reqs  = d_tx + d_rd;
-	p_tx = txreq; p_rd = rdreq; p_rx = frames_received; p_ftx = FramesTx; p_sc = eth_send_calls;
+	/* Per-second rates, Zorro requests bucketed by target region. */
+	u32 wreg = z->w_reg - p_wreg;	/* control-register writes  (< 0x2000) */
+	u32 wtx  = z->w_tx  - p_wtx;	/* TX payload window writes (0x8000-0x9fff) */
+	u32 wfb  = z->w_fb  - p_wfb;	/* framebuffer / video writes */
+	u32 woth = z->w_oth - p_woth;	/* other window writes */
+	u32 rreg = z->r_reg - p_rreg;	/* control-register reads   (< 0x2000) */
+	u32 rrx  = z->r_rx  - p_rrx;	/* RX window reads (0x2000-0x5fff) */
+	u32 roth = z->r_oth - p_roth;	/* other reads */
+	u32 d_rx  = frames_received - p_rx;
+	u32 d_ftx = FramesTx - p_ftx;
+	u32 d_sc  = eth_send_calls - p_sc;
+	u32 reqs  = wreg + wtx + wfb + woth + rreg + rrx + roth;
+	p_wreg=z->w_reg; p_wtx=z->w_tx; p_wfb=z->w_fb; p_woth=z->w_oth;
+	p_rreg=z->r_reg; p_rrx=z->r_rx; p_roth=z->r_oth;
+	p_rx=frames_received; p_ftx=FramesTx; p_sc=eth_send_calls;
 
-	/* Print only when the Zorro request RATE changes sharply (>=2x up or down)
-	 * — that brackets the freeze transition and any Forbid-spin flood/collapse
-	 * — or as a slow keepalive every 20 s to confirm the firmware is alive and
-	 * sample a steady freeze state. Keeps the log quiet during the minutes of
-	 * steady transfer. Rates are per second, so a stall is obvious at a glance. */
+	/* Print only when the request RATE shifts >=2x (freeze transition / flood)
+	 * or as a 20 s keepalive. The W/R breakdown shows WHICH region the m68k is
+	 * hammering during a stall. */
 	quiet++;
 	int changed = (last_reqs == 0xffffffffu) ||
 	              (reqs > (last_reqs << 1)) ||
@@ -871,20 +861,22 @@ void ethernet_diag_poll(u32 txreq, u32 rdreq) {
 	if (changed || quiet >= 20) {
 		quiet = 0;
 		last_reqs = reqs;
-		printf("EMAC[%s]: reqs/s=%lu (txw=%lu rdr=%lu) rx/s=%lu ftx/s=%lu sc/s=%lu state=%d snr=%lu sto=%lu txrec=%d backlog=%u ackrej=%d\n",
+		printf("EMAC[%s]: reqs/s=%lu rx/s=%lu ftx/s=%lu sc/s=%lu | W reg=%lu tx=%lu fb=%lu oth=%lu | R reg=%lu rx=%lu oth=%lu | state=%d snr=%lu backlog=%u\n",
 		       changed ? "CHG" : "hb",
 		       (unsigned long)reqs,
-		       (unsigned long)d_tx,
-		       (unsigned long)d_rd,
 		       (unsigned long)d_rx,
 		       (unsigned long)d_ftx,
 		       (unsigned long)d_sc,
+		       (unsigned long)wreg,
+		       (unsigned long)wtx,
+		       (unsigned long)wfb,
+		       (unsigned long)woth,
+		       (unsigned long)rreg,
+		       (unsigned long)rrx,
+		       (unsigned long)roth,
 		       ethernet_task_state,
 		       (unsigned long)eth_send_notready,
-		       (unsigned long)eth_send_timeout,
-		       tx_recoveries,
-		       (unsigned)frames_backlog,
-		       frames_ack_rejected);
+		       (unsigned)frames_backlog);
 	}
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -75,6 +75,9 @@ static volatile int rx_pause_frames = 0;
 static volatile int rx_slot_mismatch = 0;
 static volatile int frames_ack_rejected = 0;	/* issue #29: RX-accept handshake rejects */
 static volatile u32 eth_int_raises = 0;		/* diag (issue #29 stall probe): # times firmware raised the Amiga ETH IRQ */
+static volatile u32 eth_send_calls = 0;		/* diag: ethernet_send_frame() entries */
+static volatile u32 eth_send_notready = 0;	/* diag: sends bailed because task_state != READY */
+static volatile u32 eth_send_timeout = 0;	/* diag: sends that hit the TX-complete timeout */
 
 #define ETH_PHY_TYPE_MICREL 0
 #define ETH_PHY_TYPE_MOTORCOMM 1
@@ -822,7 +825,7 @@ void ethernet_diag_poll(u32 txreq, u32 rdreq) {
 	static u32 diag_stuck = 0;
 	static int diag_reported = 0;
 	static XTime diag_tick = 0;
-	static u32 p_tx = 0, p_rd = 0, p_rx = 0, p_ftx = 0;
+	static u32 p_tx = 0, p_rd = 0, p_rx = 0, p_ftx = 0, p_sc = 0;
 	static u32 last_reqs = 0xffffffffu;
 	static int quiet = 0;
 	XTime now;
@@ -852,8 +855,9 @@ void ethernet_diag_poll(u32 txreq, u32 rdreq) {
 	u32 d_rd  = rdreq - p_rd;			/* Zorro READ  requests serviced */
 	u32 d_rx  = frames_received - p_rx;		/* frames received from the wire */
 	u32 d_ftx = FramesTx - p_ftx;			/* frames transmitted to the wire */
+	u32 d_sc  = eth_send_calls - p_sc;		/* ethernet_send_frame() calls */
 	u32 reqs  = d_tx + d_rd;
-	p_tx = txreq; p_rd = rdreq; p_rx = frames_received; p_ftx = FramesTx;
+	p_tx = txreq; p_rd = rdreq; p_rx = frames_received; p_ftx = FramesTx; p_sc = eth_send_calls;
 
 	/* Print only when the Zorro request RATE changes sharply (>=2x up or down)
 	 * — that brackets the freeze transition and any Forbid-spin flood/collapse
@@ -867,19 +871,20 @@ void ethernet_diag_poll(u32 txreq, u32 rdreq) {
 	if (changed || quiet >= 20) {
 		quiet = 0;
 		last_reqs = reqs;
-		printf("EMAC[%s]: reqs/s=%lu (txw=%lu rdr=%lu) rx/s=%lu ftx/s=%lu backlog=%u read=%u dropped=%d mismatch=%d ackrej=%d intraises=%lu\n",
+		printf("EMAC[%s]: reqs/s=%lu (txw=%lu rdr=%lu) rx/s=%lu ftx/s=%lu sc/s=%lu state=%d snr=%lu sto=%lu txrec=%d backlog=%u ackrej=%d\n",
 		       changed ? "CHG" : "hb",
 		       (unsigned long)reqs,
 		       (unsigned long)d_tx,
 		       (unsigned long)d_rd,
 		       (unsigned long)d_rx,
 		       (unsigned long)d_ftx,
+		       (unsigned long)d_sc,
+		       ethernet_task_state,
+		       (unsigned long)eth_send_notready,
+		       (unsigned long)eth_send_timeout,
+		       tx_recoveries,
 		       (unsigned)frames_backlog,
-		       (unsigned)frames_backlog_read,
-		       frames_dropped,
-		       rx_slot_mismatch,
-		       frames_ack_rejected,
-		       (unsigned long)eth_int_raises);
+		       frames_ack_rejected);
 	}
 }
 
@@ -1371,7 +1376,10 @@ u16 ethernet_send_frame(u16 frame_size) {
 	XEmacPs* EmacPsInstancePtr = &EmacPsInstance;
 	XEmacPs_Bd *BdTxPtr;
 
+	eth_send_calls++;			/* issue #29 stall probe */
+
 	if (ethernet_task_state != ETH_TASK_READY) {
+		eth_send_notready++;		/* issue #29 stall probe */
 		return 1;
 	}
 
@@ -1424,6 +1432,7 @@ u16 ethernet_send_frame(u16 frame_size) {
 		if (counter>10) {
 			printf("ERROR: timeout in ethernet_send_frame waiting for tx!\n");
 			ethernet_log_status("tx-timeout");
+			eth_send_timeout++;		/* issue #29 stall probe */
 			tx_recoveries++;
 			printf("EMAC: TX recovery #%d\n", tx_recoveries);
 			ethernet_restart_dma("tx-timeout-restart");

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -73,6 +73,7 @@ static volatile int rx_backpressure = 0;
 static volatile int rx_pause_frames = 0;
 static volatile int rx_slot_mismatch = 0;
 static volatile int frames_ack_rejected = 0;	/* issue #29: RX-accept handshake rejects */
+static volatile u32 eth_int_raises = 0;		/* diag (issue #29 stall probe): # times firmware raised the Amiga ETH IRQ */
 
 #define ETH_PHY_TYPE_MICREL 0
 #define ETH_PHY_TYPE_MOTORCOMM 1
@@ -782,6 +783,64 @@ static void XEmacPsRecvHandler(void *Callback)
 
 uint8_t* ethernet_current_receive_ptr() {
 	return (uint8_t*)(RX_BACKLOG_ADDRESS+frames_backlog_read*FRAME_SIZE);
+}
+
+/* ---- issue #29 stall probe (diagnostic build only; NOT for merge) ----
+ * The Amiga-freeze symptom points at main.c re-raising the ETH IRQ every main-
+ * loop pass while backlog>0 (an interrupt storm that starves the m68k). This
+ * dumps the ring/GEM state over UART — which runs on the Zynq, independent of
+ * the frozen m68k — so we can catch the wedge in-situ. */
+static void ethernet_diag_dump(const char *reason) {
+	printf("EMAC[%s]: backlog=%u read=%u write=%u reserve=%u reserved=%u pending=%u serial=%u rx=%lu tx=%lu dropped=%d full=%d mismatch=%d ackrej=%d intraises=%lu bp=%d pause=%d\n",
+	       reason,
+	       (unsigned)frames_backlog,
+	       (unsigned)frames_backlog_read,
+	       (unsigned)frames_backlog_write,
+	       (unsigned)frames_backlog_reserve,
+	       (unsigned)frames_backlog_reserved,
+	       (unsigned)ethernet_backlog_pending(),
+	       (unsigned)frame_serial,
+	       (unsigned long)frames_received,
+	       (unsigned long)FramesTx,
+	       frames_dropped,
+	       frames_backlog_full,
+	       rx_slot_mismatch,
+	       frames_ack_rejected,
+	       (unsigned long)eth_int_raises,
+	       rx_backpressure,
+	       rx_pause_frames);
+}
+
+void ethernet_note_int_raised(void) {
+	eth_int_raises++;
+}
+
+void ethernet_diag_poll(void) {
+	static u16 diag_last_read = 0;
+	static u32 diag_stuck = 0;
+	static int diag_reported = 0;
+	static u32 diag_last_hb = 0;
+
+	/* Stuck detector: frames queued but the read pointer is not advancing.
+	 * Healthy draining advances read constantly, so this only trips when the
+	 * Amiga has stopped consuming while backlog>0 — the exact state that makes
+	 * main.c re-raise the ETH IRQ every pass. Dump once per stuck episode. */
+	if (frames_backlog > 0 && frames_backlog_read == diag_last_read) {
+		if (++diag_stuck >= 3000000u && !diag_reported) {
+			ethernet_diag_dump("STALL");
+			diag_reported = 1;
+		}
+	} else {
+		diag_stuck = 0;
+		diag_reported = 0;
+		diag_last_read = frames_backlog_read;
+	}
+
+	/* Run-up context: heartbeat every 65536 received frames. */
+	if ((u32)(frames_received - diag_last_hb) >= 65536u) {
+		diag_last_hb = frames_received;
+		ethernet_diag_dump("hb");
+	}
 }
 
 int ethernet_get_backlog() {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -697,6 +697,15 @@ static void XEmacPsRecvHandler(void *Callback)
 		for (int i=0; i<num_rx_bufs; i++) {
 
 			frame_serial++;
+			/* 0 is the empty-slot / "no frame" sentinel: the driver skips an
+			 * all-zero header without acking, and the RX-accept handshake
+			 * rejects acked_serial == 0. frame_serial is a u16, so a plain
+			 * increment wraps 0xffff -> 0 once every 65536 frames; skip 0 so a
+			 * real frame is never tagged with the sentinel. Otherwise the
+			 * handshake would reject that frame forever (frames_backlog_read
+			 * never advances) and RX would stall until reset (issue #29). */
+			if (frame_serial == 0)
+				frame_serial++;
 
 			//printf("RX ser: %d\n",frame_serial);
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.c
@@ -23,6 +23,7 @@
 #include <xil_cache.h>
 #include <xil_mmu.h>
 #include "sleep.h"
+#include "xtime_l.h"		/* diag (issue #29): wall-clock heartbeat */
 #include "xparameters.h"
 #include <xemacps.h>
 #include <xscugic.h>
@@ -790,44 +791,45 @@ uint8_t* ethernet_current_receive_ptr() {
  * loop pass while backlog>0 (an interrupt storm that starves the m68k). This
  * dumps the ring/GEM state over UART — which runs on the Zynq, independent of
  * the frozen m68k — so we can catch the wedge in-situ. */
-static void ethernet_diag_dump(const char *reason) {
-	printf("EMAC[%s]: backlog=%u read=%u write=%u reserve=%u reserved=%u pending=%u serial=%u rx=%lu tx=%lu dropped=%d full=%d mismatch=%d ackrej=%d intraises=%lu bp=%d pause=%d\n",
+static void ethernet_diag_dump(const char *reason, u32 txreq, u32 rdreq) {
+	printf("EMAC[%s]: backlog=%u read=%u write=%u reserved=%u pending=%u serial=%u rx=%lu tx=%lu txreq=%lu rdreq=%lu dropped=%d mismatch=%d ackrej=%d intraises=%lu\n",
 	       reason,
 	       (unsigned)frames_backlog,
 	       (unsigned)frames_backlog_read,
 	       (unsigned)frames_backlog_write,
-	       (unsigned)frames_backlog_reserve,
 	       (unsigned)frames_backlog_reserved,
 	       (unsigned)ethernet_backlog_pending(),
 	       (unsigned)frame_serial,
 	       (unsigned long)frames_received,
 	       (unsigned long)FramesTx,
+	       (unsigned long)txreq,
+	       (unsigned long)rdreq,
 	       frames_dropped,
-	       frames_backlog_full,
 	       rx_slot_mismatch,
 	       frames_ack_rejected,
-	       (unsigned long)eth_int_raises,
-	       rx_backpressure,
-	       rx_pause_frames);
+	       (unsigned long)eth_int_raises);
 }
 
 void ethernet_note_int_raised(void) {
 	eth_int_raises++;
 }
 
-void ethernet_diag_poll(void) {
+/* txreq/rdreq = running counts of Zorro write/read requests the firmware has
+ * serviced from the m68k (passed in from main.c). During a freeze these tell
+ * us whether the m68k is still issuing ANY bus cycles. */
+void ethernet_diag_poll(u32 txreq, u32 rdreq) {
 	static u16 diag_last_read = 0;
 	static u32 diag_stuck = 0;
 	static int diag_reported = 0;
-	static u32 diag_last_hb = 0;
+	static XTime diag_last_hb = 0;
+	XTime now;
 
 	/* Stuck detector: frames queued but the read pointer is not advancing.
 	 * Healthy draining advances read constantly, so this only trips when the
-	 * Amiga has stopped consuming while backlog>0 — the exact state that makes
-	 * main.c re-raise the ETH IRQ every pass. Dump once per stuck episode. */
+	 * Amiga has stopped consuming while backlog>0. Dump once per stuck episode. */
 	if (frames_backlog > 0 && frames_backlog_read == diag_last_read) {
 		if (++diag_stuck >= 3000000u && !diag_reported) {
-			ethernet_diag_dump("STALL");
+			ethernet_diag_dump("STALL", txreq, rdreq);
 			diag_reported = 1;
 		}
 	} else {
@@ -836,10 +838,15 @@ void ethernet_diag_poll(void) {
 		diag_last_read = frames_backlog_read;
 	}
 
-	/* Run-up context: heartbeat every 65536 received frames. */
-	if ((u32)(frames_received - diag_last_hb) >= 65536u) {
-		diag_last_hb = frames_received;
-		ethernet_diag_dump("hb");
+	/* Wall-clock heartbeat (~1/s) — prints regardless of RX activity, so it
+	 * keeps reporting even when the m68k has frozen and RX has gone quiet.
+	 * Lines KEEP coming through the freeze => firmware main loop is alive and
+	 * the wedge is m68k-side; lines STOP => the firmware itself hung. The
+	 * txreq/rdreq deltas show whether the frozen m68k still issues bus cycles. */
+	XTime_GetTime(&now);
+	if ((now - diag_last_hb) >= (XTime)COUNTS_PER_SECOND) {
+		diag_last_hb = now;
+		ethernet_diag_dump("wall", txreq, rdreq);
 	}
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
@@ -31,8 +31,12 @@ void ethernet_task();
 void ethernet_reset_for_amiga();
 
 /* issue #29 stall probe (diagnostic build only) */
+struct eth_diag_z {
+	u32 w_reg, w_tx, w_fb, w_oth;	/* Zorro WRITE requests bucketed by target */
+	u32 r_reg, r_rx, r_oth;		/* Zorro READ  requests bucketed by target */
+};
 void ethernet_note_int_raised(void);
-void ethernet_diag_poll(u32 txreq, u32 rdreq);
+void ethernet_diag_poll(const struct eth_diag_z *z);
 
 #define FRAME_MAX_BACKLOG 128
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
@@ -30,6 +30,10 @@ u16 ethernet_get_rx_stats();
 void ethernet_task();
 void ethernet_reset_for_amiga();
 
+/* issue #29 stall probe (diagnostic build only) */
+void ethernet_note_int_raised(void);
+void ethernet_diag_poll(void);
+
 #define FRAME_MAX_BACKLOG 128
 
 #define RXBD_CNT       32	/* Number of RxBDs to use */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
@@ -19,7 +19,7 @@
 
 int ethernet_init();
 u16 ethernet_send_frame(u16 frame_size);
-int ethernet_receive_frame();
+int ethernet_receive_frame(u16 acked_serial);
 u32 get_frames_received();
 uint8_t* ethernet_get_mac_address_ptr();
 void ethernet_update_mac_address();

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ethernet.h
@@ -32,7 +32,7 @@ void ethernet_reset_for_amiga();
 
 /* issue #29 stall probe (diagnostic build only) */
 void ethernet_note_int_raised(void);
-void ethernet_diag_poll(void);
+void ethernet_diag_poll(u32 txreq, u32 rdreq);
 
 #define FRAME_MAX_BACKLOG 128
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -135,6 +135,8 @@ static uint32_t sd_storage_write_block = 0;
 uint16_t ethernet_send_result = 0;
 int eth_backlog_nag_counter = 0;
 int interrupt_enabled_ethernet = 0;
+static u32 diag_zorro_txreq = 0;	/* issue #29 stall probe: Zorro write requests serviced */
+static u32 diag_zorro_rdreq = 0;	/* issue #29 stall probe: Zorro read requests serviced */
 
 static uint32_t sdk_diag_last_reg_write_addr = 0;
 static uint32_t sdk_diag_last_reg_write_raw_addr = 0;
@@ -1353,6 +1355,7 @@ int main() {
 			// ack the write, set bit 31 in register 0
 			mntzorro_write(MNTZ_BASE_ADDR, MNTZORRO_REG0, (1 << 31));
 			need_req_ack = 1;
+			diag_zorro_txreq++;	/* issue #29 stall probe */
 		} else if (readreq) {
 			uint32_t zaddr = mntzorro_read(MNTZ_BASE_ADDR, MNTZORRO_REG0);
 
@@ -1562,6 +1565,7 @@ int main() {
 			// ack the read, set bit 30 in register 0
 			mntzorro_write(MNTZ_BASE_ADDR, MNTZORRO_REG0, (1 << 30));
 			need_req_ack = 2;
+			diag_zorro_rdreq++;	/* issue #29 stall probe */
 		} else {
 			// there are no read/write requests, we can do other housekeeping
 
@@ -1667,7 +1671,7 @@ int main() {
 				eth_backlog_nag_counter = 0;
 				ethernet_note_int_raised();	/* issue #29 stall probe */
 			}
-			ethernet_diag_poll();	/* issue #29 stall probe */
+			ethernet_diag_poll(diag_zorro_txreq, diag_zorro_rdreq);	/* issue #29 stall probe */
 		}
 
 		if (need_req_ack) {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -944,7 +944,10 @@ int main() {
 					break;
 				case REG_ZZ_ETH_RX: {
 					//printf("RECV eth frame sz: %ld\n",zdata);
-					int frfb = ethernet_receive_frame();
+					/* zdata carries the serial of the frame the Amiga consumed
+					 * (legacy drivers write a constant 1). issue #29: the RX
+					 * handshake validates it before advancing. */
+					int frfb = ethernet_receive_frame((u16)zdata);
 					mntzorro_write(MNTZ_BASE_ADDR, MNTZORRO_REG4, frfb);
 					break;
 				}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -135,8 +135,7 @@ static uint32_t sd_storage_write_block = 0;
 uint16_t ethernet_send_result = 0;
 int eth_backlog_nag_counter = 0;
 int interrupt_enabled_ethernet = 0;
-static u32 diag_zorro_txreq = 0;	/* issue #29 stall probe: Zorro write requests serviced */
-static u32 diag_zorro_rdreq = 0;	/* issue #29 stall probe: Zorro read requests serviced */
+static struct eth_diag_z diag_z;	/* issue #29 stall probe: Zorro requests bucketed by target */
 
 static uint32_t sdk_diag_last_reg_write_addr = 0;
 static uint32_t sdk_diag_last_reg_write_raw_addr = 0;
@@ -397,7 +396,7 @@ int main() {
 		 * heartbeat prints every iteration regardless of which branch runs
 		 * below — in particular it survives a flood of Zorro requests that
 		 * would otherwise starve the housekeeping branch. */
-		ethernet_diag_poll(diag_zorro_txreq, diag_zorro_rdreq);
+		ethernet_diag_poll(&diag_z);
 #if ENABLE_LEGACY_USB_BLOCK_STORAGE
 		if (usb_read_pending) {
 			usb_status = zz_usb_read_blocks(0, usb_storage_read_block, usb_read_write_num_blocks, (void*)USB_BLOCK_STORAGE_ADDRESS);
@@ -1360,7 +1359,15 @@ int main() {
 			// ack the write, set bit 31 in register 0
 			mntzorro_write(MNTZ_BASE_ADDR, MNTZORRO_REG0, (1 << 31));
 			need_req_ack = 1;
-			diag_zorro_txreq++;	/* issue #29 stall probe */
+			/* issue #29 stall probe: bucket the write target */
+			if (zaddr >= MNT_FB_BASE)
+				diag_z.w_fb++;
+			else if (zaddr >= MNT_REG_BASE + 0x8000 && zaddr < MNT_REG_BASE + 0xa000)
+				diag_z.w_tx++;		/* TX frame payload window */
+			else if (zaddr >= MNT_REG_BASE + 0x2000)
+				diag_z.w_oth++;
+			else
+				diag_z.w_reg++;		/* control registers < 0x2000 */
 		} else if (readreq) {
 			uint32_t zaddr = mntzorro_read(MNTZ_BASE_ADDR, MNTZORRO_REG0);
 
@@ -1570,7 +1577,13 @@ int main() {
 			// ack the read, set bit 30 in register 0
 			mntzorro_write(MNTZ_BASE_ADDR, MNTZORRO_REG0, (1 << 30));
 			need_req_ack = 2;
-			diag_zorro_rdreq++;	/* issue #29 stall probe */
+			/* issue #29 stall probe: bucket the read target */
+			if (zaddr >= MNT_REG_BASE + 0x2000 && zaddr < MNT_REG_BASE + 0x6000)
+				diag_z.r_rx++;		/* RX window reads */
+			else if (zaddr >= MNT_REG_BASE && zaddr < MNT_REG_BASE + 0x2000)
+				diag_z.r_reg++;		/* control registers < 0x2000 */
+			else
+				diag_z.r_oth++;
 		} else {
 			// there are no read/write requests, we can do other housekeeping
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -1665,7 +1665,9 @@ int main() {
 			if (interrupt_enabled_ethernet && ethernet_get_backlog()) {
 				amiga_interrupt_set(AMIGA_INTERRUPT_ETH);
 				eth_backlog_nag_counter = 0;
+				ethernet_note_int_raised();	/* issue #29 stall probe */
 			}
+			ethernet_diag_poll();	/* issue #29 stall probe */
 		}
 
 		if (need_req_ack) {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -393,6 +393,11 @@ int main() {
 
 	while (1) {
 		watchdog_kick();
+		/* issue #29 stall probe: run at the loop TOP so the wall-clock
+		 * heartbeat prints every iteration regardless of which branch runs
+		 * below — in particular it survives a flood of Zorro requests that
+		 * would otherwise starve the housekeeping branch. */
+		ethernet_diag_poll(diag_zorro_txreq, diag_zorro_rdreq);
 #if ENABLE_LEGACY_USB_BLOCK_STORAGE
 		if (usb_read_pending) {
 			usb_status = zz_usb_read_blocks(0, usb_storage_read_block, usb_read_write_num_blocks, (void*)USB_BLOCK_STORAGE_ADDRESS);
@@ -1671,7 +1676,6 @@ int main() {
 				eth_backlog_nag_counter = 0;
 				ethernet_note_int_raised();	/* issue #29 stall probe */
 			}
-			ethernet_diag_poll(diag_zorro_txreq, diag_zorro_rdreq);	/* issue #29 stall probe */
 		}
 
 		if (need_req_ack) {


### PR DESCRIPTION
## Ethernet RX-accept handshake fixes + issue #29 stall instrumentation

Addresses issue #29 (ethernet stalls under a Zorro request flood). Opened whole
for review: it carries both the **fixes** and the **diagnostics** used to locate
the flood source.

### Fixes (ethernet RX-accept handshake)
- `b4ed2ba` fix(eth): validate the RX-accept serial before consuming — defense
  against a stale/duplicate accept advancing the ring.
- `c4cac68` fix(eth): skip serial 0 on wraparound so the RX handshake never
  stalls.
- `463a6f5` fix(eth): also skip serial 1 so the handshake protects every real
  frame.

### Diagnostics (instrumentation to find the flood target)
- `53fbb9b` UART dump of ring state on a stuck backlog.
- `a931d23` wall-clock heartbeat + Zorro request counters.
- `89c41a4` move the stall probe to the top of the main loop so it survives a
  Zorro flood.
- `4f94e8a` change-triggered heartbeat (quiet unless the Zorro rate shifts).
- `3dfefc8` instrument the TX path (send calls / state / not-ready / timeout).
- `0ae356c` bucket Zorro requests by target region to identify the flood's
  target.

### Status
The three RX-accept fixes are the substantive change; the six diagnostic commits
are instrumentation for the investigation and can be gated/dropped before merge
if preferred. **Hardware validation of the issue-29 fixes is pending** on the
reporter's A2000TX + ZZ9000AX setup.

Base: `master`.
