### PR TITLE
Route decompression offload to core 1 (SMP-safe heap foundation)

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/Makefile
+++ b/ZZ9000_proto.sdk/ZZ9000OS/Makefile
@@ -105,6 +105,8 @@ C_SRCS = \
 	$(SRC_DIR)/scheduler.c \
 	$(SRC_DIR)/scheduler_arm.c \
 	$(SRC_DIR)/scheduler_stress.c \
+	$(SRC_DIR)/sdk_smp_lock.c \
+	$(SRC_DIR)/sdk_smp_lock_arm.c \
 	$(SRC_DIR)/dma_acc.c \
 	$(SRC_DIR)/dma_rtg.c \
 	$(SRC_DIR)/usb.c \

--- a/ZZ9000_proto.sdk/ZZ9000OS/Makefile
+++ b/ZZ9000_proto.sdk/ZZ9000OS/Makefile
@@ -107,6 +107,8 @@ C_SRCS = \
 	$(SRC_DIR)/scheduler_stress.c \
 	$(SRC_DIR)/sdk_smp_lock.c \
 	$(SRC_DIR)/sdk_smp_lock_arm.c \
+	$(SRC_DIR)/sdk_decode_reclaim.c \
+	$(SRC_DIR)/sdk_decode_reclaim_arm.c \
 	$(SRC_DIR)/dma_acc.c \
 	$(SRC_DIR)/dma_rtg.c \
 	$(SRC_DIR)/usb.c \

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -8,6 +8,7 @@
 #include "sleep.h"
 #include "scheduler.h"
 #include "memorymap.h"
+#include "sdk_smp_lock.h"
 
 #define A9_CPU_RST_CTRL		(XSLCR_BASEADDR + 0x244)
 #define A9_RST1_MASK 		0x00000002
@@ -86,6 +87,19 @@ struct core_fault_slot core1_fault __attribute__((aligned(32))) = { CORE_FAULT_N
 
 static void record_fault(uint32_t code, const char *name)
 {
+	/*
+	 * Free the cross-core malloc lock immediately if core 1 (this core) is
+	 * its owner. Decompress (zlib/LZMA) runs on core 1 and calls malloc, so
+	 * a fault here can strike mid-critical-section, i.e. while this core
+	 * holds g_malloc_lock. Doing this as early as possible narrows the
+	 * window where core 0 could still observe (and spin forever on) an
+	 * orphaned lock before core1_cold_restart's unconditional reset runs.
+	 * Owner-checked: if core 1 faulted merely spinning to acquire, core 0
+	 * may legitimately hold the lock, and this must not free it out from
+	 * under core 0.
+	 */
+	sdk_smp_lock_reset_malloc_if_owned();
+
 	taskq_shared_t *sh = scheduler_shared();
 	int slot = sh->core1_current_slot;
 
@@ -142,6 +156,19 @@ void core1_cold_restart(void)
 	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
 	RegVal |= A9_CLKSTOP1_MASK;
 	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
+
+	/*
+	 * CPU1 is now held in reset with its clock stopped, i.e. provably
+	 * halted and not concurrently touching any lock. Unconditionally free
+	 * the cross-core malloc lock here, before CPU1 is released below, so
+	 * the restarted core always finds it free -- whether or not core 1 was
+	 * holding it (mid-malloc/free, e.g. inside zlib/LZMA decompress) when
+	 * this restart was triggered. This single choke point covers both
+	 * restart paths: the fault path (record_fault -> scheduler_core0_poll)
+	 * and the quiesce-timeout path (scheduler_quiesce_for_reset).
+	 */
+	sdk_smp_lock_reset_malloc();
+
 	RegVal &= ~A9_RST1_MASK;
 	Xil_Out32(A9_CPU_RST_CTRL, RegVal);
 	RegVal &= ~A9_CLKSTOP1_MASK;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/core2.c
@@ -9,6 +9,7 @@
 #include "scheduler.h"
 #include "memorymap.h"
 #include "sdk_smp_lock.h"
+#include "sdk_compression.h"
 
 #define A9_CPU_RST_CTRL		(XSLCR_BASEADDR + 0x244)
 #define A9_RST1_MASK 		0x00000002
@@ -168,6 +169,14 @@ void core1_cold_restart(void)
 	 * and the quiesce-timeout path (scheduler_quiesce_for_reset).
 	 */
 	sdk_smp_lock_reset_malloc();
+
+	/*
+	 * CPU1 is still halted and the malloc lock is now free: reclaim any heap
+	 * blocks a one-shot decode still held when it was reset. inflateEnd /
+	 * LzmaDec_Free never ran on the killed worker, so without this the
+	 * inflate state/window and LZMA probs/dict leak on every mid-decode reset.
+	 */
+	sdk_compression_reclaim_core1_decode();
 
 	RegVal &= ~A9_RST1_MASK;
 	Xil_Out32(A9_CPU_RST_CTRL, RegVal);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -246,6 +246,8 @@ taskq_class_t taskq_class_for_opcode(uint32_t opcode, uint32_t in_len)
   case TASKQ_OP_CRYPTO_STREAM:
   case TASKQ_OP_CRYPTO_AEAD:
     return (in_len <= TASKQ_SHORT_MAX_BYTES) ? TASK_SHORT : TASK_LONG;
+  case TASKQ_OP_DECOMPRESS:
+    return TASK_LONG;
   default:
     return TASK_LONG;              /* unknown/heavy: never drained on core 0 */
   }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -26,6 +26,10 @@
 #define TASKQ_OP_CRYPTO_KX     0x0803u
 #define TASKQ_OP_CRYPTO_VERIFY 0x0804u
 
+/* Decompress opcode mirrored from sdk_mailbox.h (SDK_OP_DECOMPRESS); same
+ * value, two namespaces, matching the crypto pattern above. */
+#define TASKQ_OP_DECOMPRESS    0x0600u
+
 typedef enum {
   TASK_FREE    = 0,
   TASK_QUEUED  = 1,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -143,9 +143,11 @@ void scheduler_coherency_init_core1(void)
 /*
  * Run one claimed task's compute on the calling core and mark it DONE. This is
  * the scheduler's compute-dispatch seam: the queue/worker/harvest machinery is
- * opcode-agnostic, and this function routes a task to its service handler.
- * Phase 1 wires only the crypto service (sdk_mailbox_run_crypto_task); later
- * phases extend the dispatch to image/compression and MP3 offload here.
+ * opcode-agnostic, and this function hands the task to the opcode-dispatched
+ * offload executor, sdk_mailbox_run_offload_task (sdk_mailbox.c), which routes
+ * it to its service handler. Today that executor wires only the crypto
+ * service (sdk_mailbox_run_crypto_task); later phases extend its dispatch to
+ * decompression, image, and MP3 offload without changing this function.
  *
  * The service handler owns all data-buffer cache maintenance, so this runs
  * correctly on whichever core executes it: core 1 in the normal async path, or
@@ -153,19 +155,18 @@ void scheduler_coherency_init_core1(void)
  * task that ran to completion -- including a legitimate failure such as an AEAD
  * auth mismatch -- is a DONE task carrying its exact SDK_STATUS_*; only a
  * core-1 hardware fault (handled in core2.c) marks a slot FAILED. For crypto the
- * completion payload is always one SDKCryptoResultPayload (== TASKQ_RESULT_PAYLOAD
- * bytes) on success, none on error, matching the pre-scheduler handlers
- * byte-for-byte.
+ * completion payload length is decided inside sdk_mailbox_run_offload_task:
+ * one SDKCryptoResultPayload (== TASKQ_RESULT_PAYLOAD bytes) on success, none
+ * on error, matching the pre-scheduler handlers byte-for-byte.
  */
 static uint16_t scheduler_run_slot(taskq_desc_t *d)
 {
   taskq_shared_t *sh = scheduler_shared();
   uint8_t payload[TASKQ_RESULT_PAYLOAD];
+  uint32_t len = 0;
   int slot = (int)(d - sh->queue.descs);
-  uint16_t status = sdk_mailbox_run_crypto_task((uint16_t)d->opcode,
-                                                d->op_params, payload);
-  uint16_t len = (status == SDK_STATUS_OK) ? (uint16_t)TASKQ_RESULT_PAYLOAD : 0u;
-  taskq_complete(&sh->queue, slot, status, payload, len);
+  uint16_t status = sdk_mailbox_run_offload_task(d, payload, &len);
+  taskq_complete(&sh->queue, slot, status, payload, (uint16_t)len);
   return status;
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -33,6 +33,10 @@ typedef char sched_opcode_drift_check[
      TASKQ_OP_CRYPTO_KX     == SDK_OP_CRYPTO_KX     &&
      TASKQ_OP_CRYPTO_VERIFY == SDK_OP_CRYPTO_VERIFY) ? 1 : -1];
 
+/* Same drift guard for the decompress opcode. */
+typedef char sched_decompress_opcode_drift_check[
+    (TASKQ_OP_DECOMPRESS == SDK_OP_DECOMPRESS) ? 1 : -1];
+
 /* Core-0 view of scheduler run state. The taskq watchdog trips core 1 off
  * after repeated faults; g_core1_started is set by the worker on entry. */
 static taskq_watchdog_t g_sched_watchdog;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_compression.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_compression.c
@@ -9,6 +9,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include "sdk_compression.h"
+#include "sdk_smp_lock.h"
+#include "sdk_decode_reclaim.h"
 #include "Lzma2Dec.h"
 #include "LzmaDec.h"
 #include "zlib.h"
@@ -55,19 +57,97 @@ static struct SDKDecompressStreamSession decompress_streams[
 ];
 static uint32_t next_decompress_stream_id = 1U;
 
+/*
+ * Heap wrappers for the decode backends. On core 1 the block is recorded (and
+ * the table cleaned to DRAM via sdk_decode_flush_table) so core 0 can reclaim
+ * it if the worker is cold-reset mid-decode; on core 0 (inline fallback, and
+ * the stream/test paths, which never run on core 1) they are plain malloc/free
+ * because core 0 is never force-reset. Ordering is deliberate -- track AFTER a
+ * successful malloc, untrack-then-clean BEFORE free -- so a worker halted at any
+ * point leaks at most one block and never exposes a freed pointer to core 0's
+ * reclaim. See sdk_decode_reclaim.h.
+ */
+static void *decode_malloc(size_t size)
+{
+	void *p = malloc(size);
+
+	if (p && smp_cpu_id() == 1) {
+		sdk_decode_track(p);
+		sdk_decode_flush_table();
+	}
+	return p;
+}
+
+static void decode_free(void *ptr)
+{
+	if (ptr && smp_cpu_id() == 1) {
+		sdk_decode_untrack(ptr);
+		sdk_decode_flush_table();   /* DRAM shows slot cleared before free */
+	}
+	free(ptr);
+}
+
 static void *lzma_alloc(ISzAllocPtr alloc, size_t size)
 {
 	(void)alloc;
-	return malloc(size);
+	return decode_malloc(size);
 }
 
 static void lzma_free(ISzAllocPtr alloc, void *address)
 {
 	(void)alloc;
-	free(address);
+	decode_free(address);
 }
 
 static const ISzAlloc lzma_allocator = { lzma_alloc, lzma_free };
+
+/* zlib allocator callbacks routed through the same core-1-tracking wrappers. */
+static voidpf zlib_decode_alloc(voidpf opaque, uInt items, uInt size)
+{
+	(void)opaque;
+	return (voidpf)decode_malloc((size_t)items * (size_t)size);
+}
+
+static void zlib_decode_free(voidpf opaque, voidpf address)
+{
+	(void)opaque;
+	decode_free((void *)address);
+}
+
+/*
+ * Reclaim the blocks a killed core-1 decode still held. This closes the leak
+ * and, together with the tracking table's clean/invalidate discipline, the
+ * table-driven double-free.
+ *
+ * Residual (known, low-probability): the blocks live in the shared newlib heap,
+ * and free() trusts that heap's chunk/arena metadata. That metadata was written
+ * by core 1 under g_malloc_lock (ordering barriers, not write-back); if a line
+ * of it were still dirty-only in core 1's L1 at the force-reset it would be
+ * dropped, and freeing against the stale DRAM view could corrupt the free list.
+ * Decode working sets are large, so that metadata is almost always evicted to
+ * DRAM long before any reset -- but the only absolute guarantee is a dedicated
+ * non-shared decode arena (tracked follow-up). This is a property of core-1
+ * heap use under force-reset, not of the reclaim itself.
+ */
+unsigned sdk_compression_reclaim_core1_decode(void)
+{
+	unsigned reclaimed;
+
+	/*
+	 * Discard any stale copy of the table in core 0's cache so the read sees
+	 * core 1's last cleaned-to-DRAM state (invalidate, not flush: core 0 holds
+	 * no dirty table lines here -- the previous reclaim ended with a flush --
+	 * so nothing of core 1's fresh state is overwritten).
+	 */
+	sdk_decode_invalidate_table();
+	reclaimed = sdk_decode_reclaim(free);
+	/*
+	 * Push the cleared slots to DRAM before core 1 is released: the restarted
+	 * worker boots with an empty cache and must read the emptied table.
+	 */
+	sdk_decode_flush_table();
+	return reclaimed;
+}
 
 static void free_decompress_stream(
 	struct SDKDecompressStreamSession *stream)
@@ -999,6 +1079,11 @@ uint16_t sdk_decompress_buffer(uint32_t algorithm, uint32_t flags,
 		return SDK_STATUS_UNSUPPORTED;
 
 	memset(&stream, 0, sizeof(stream));
+	/* Track this decode's heap use so a core-1 cold-reset mid-inflate does not
+	 * leak the inflate state/window (see sdk_decode_reclaim.h). */
+	stream.zalloc = zlib_decode_alloc;
+	stream.zfree = zlib_decode_free;
+	stream.opaque = Z_NULL;
 	stream.next_in = (Bytef *)src;
 	stream.avail_in = (uInt)src_length;
 	stream.next_out = dst;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_compression.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_compression.h
@@ -55,4 +55,12 @@ uint16_t sdk_decompress_stream_read(
 	struct SDKDecompressStreamResult *result);
 uint16_t sdk_decompress_stream_close(uint32_t session);
 
+/*
+ * Reclaim any heap blocks a core-1 one-shot decode still held when it was
+ * cold-reset mid-decode. Call from core 0 (core1_cold_restart) while core 1 is
+ * halted and after the malloc lock has been reset. Returns blocks reclaimed
+ * (0 when the last decode completed cleanly).
+ */
+unsigned sdk_compression_reclaim_core1_decode(void);
+
 #endif /* SDK_COMPRESSION_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_decode_reclaim.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_decode_reclaim.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ *
+ * Single-writer allocation tracker for the core-1 one-shot decode path.
+ * See sdk_decode_reclaim.h for the concurrency contract.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stddef.h>
+#include "sdk_decode_reclaim.h"
+
+/*
+ * Cross-core visibility CANNOT rely on SCU snoop coherency here: at the reclaim
+ * point core 1 is held in reset, and a reset core's dirty L1 lines are dropped,
+ * not snooped. The firmware wrappers therefore maintain this table to the point
+ * of coherency explicitly -- core 1 cleans it to DRAM after every track/untrack,
+ * core 0 invalidates before reading and flushes after clearing (see
+ * sdk_compression.c). That works on both reset paths because it happens at
+ * store time, not in core-1 cleanup code (the quiesce path runs none).
+ *
+ * Aligned to a cache line and sized to a whole number of lines so the range
+ * clean/invalidate cannot touch neighbouring data.
+ */
+static void *g_tracked[SDK_DECODE_MAX_TRACKED] __attribute__((aligned(32)));
+
+/*
+ * The firmware cleans/invalidates the whole table by range, so it must be a
+ * whole number of 32-byte cache lines or a range op could touch a neighbour.
+ * Fails the build if SDK_DECODE_MAX_TRACKED is ever set to a non-multiple-of-8.
+ */
+typedef char sdk_decode_table_is_line_multiple[
+	(sizeof(g_tracked) % 32u == 0u) ? 1 : -1];
+
+void *sdk_decode_table_base(void)
+{
+	return (void *)g_tracked;
+}
+
+unsigned sdk_decode_table_bytes(void)
+{
+	return (unsigned)sizeof(g_tracked);
+}
+
+void sdk_decode_track(void *ptr)
+{
+	unsigned i;
+
+	if (!ptr)
+		return;
+	for (i = 0u; i < SDK_DECODE_MAX_TRACKED; i++) {
+		if (g_tracked[i] == NULL) {
+			g_tracked[i] = ptr;   /* single aligned store: atomic */
+			return;
+		}
+	}
+	/*
+	 * Table full: this allocation cannot be tracked and would leak if the
+	 * worker is reset before freeing it. That is the pre-existing behaviour
+	 * and strictly safer than overrunning the table; the backends never
+	 * exceed the ceiling in practice.
+	 */
+}
+
+void sdk_decode_untrack(void *ptr)
+{
+	unsigned i;
+
+	if (!ptr)
+		return;
+	for (i = 0u; i < SDK_DECODE_MAX_TRACKED; i++) {
+		if (g_tracked[i] == ptr) {
+			g_tracked[i] = NULL;   /* single aligned store: atomic */
+			return;
+		}
+	}
+}
+
+unsigned sdk_decode_reclaim(void (*free_fn)(void *))
+{
+	unsigned i;
+	unsigned reclaimed = 0u;
+
+	for (i = 0u; i < SDK_DECODE_MAX_TRACKED; i++) {
+		void *p = g_tracked[i];
+
+		if (p != NULL) {
+			g_tracked[i] = NULL;
+			if (free_fn)
+				free_fn(p);
+			reclaimed++;
+		}
+	}
+	return reclaimed;
+}
+
+unsigned sdk_decode_tracked_count(void)
+{
+	unsigned i;
+	unsigned count = 0u;
+
+	for (i = 0u; i < SDK_DECODE_MAX_TRACKED; i++)
+		if (g_tracked[i] != NULL)
+			count++;
+	return count;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_decode_reclaim.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_decode_reclaim.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ *
+ * Single-writer allocation tracker for the core-1 one-shot decode path.
+ *
+ * The dual-core scheduler runs one-shot decompression on core 1. Each decode
+ * makes heap allocations (zlib inflateInit2 state + window; LZMA probs + dict)
+ * that are only released when the backend's cleanup (inflateEnd / LzmaDec_Free)
+ * runs on normal return. If core 1 is cold-reset mid-decode -- a mailbox
+ * teardown that outlives the quiesce budget, or a fault -- that cleanup never
+ * runs and those blocks leak until a full firmware reboot.
+ *
+ * The core-1 worker records every live allocation here; core 0 frees any
+ * survivors at the cold-restart choke point, while core 1 is provably halted.
+ *
+ * Concurrency: only core 1 writes the table (the allocator wrappers gate on
+ * smp_cpu_id()), and core 0 reads/reclaims it only when core 1 is halted, so
+ * there is never concurrent access. Each slot is a single pointer-sized word,
+ * so a store is atomic on ARM: a worker halted mid-update leaves the table
+ * self-consistent. The wrapper ordering (track AFTER malloc, untrack BEFORE
+ * free) means an interrupted worker leaks at most one block and never lets
+ * core 0 double-free.
+ *
+ * Cache: a reset core's dirty L1 lines are dropped, not snooped, so the
+ * firmware wrappers maintain this table to the point of coherency explicitly
+ * (core 1 cleans after each track/untrack; core 0 invalidates before reading
+ * and flushes after clearing) using sdk_decode_table_base()/_bytes(). The table
+ * is cache-line aligned and line-sized so those range operations touch nothing
+ * else.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef SDK_DECODE_RECLAIM_H
+#define SDK_DECODE_RECLAIM_H
+
+/*
+ * Maximum distinct live allocations a single core-1 decode holds at once.
+ * zlib inflate uses 2 (state + window); LZMA/LZMA2 use 2-3 (probs + dict).
+ * 16 is a safe ceiling with generous headroom.
+ */
+#define SDK_DECODE_MAX_TRACKED 16u
+
+/* Record a live allocation. Call AFTER malloc succeeds. NULL is ignored. */
+void sdk_decode_track(void *ptr);
+
+/* Drop a tracked allocation. Call BEFORE free. NULL / untracked is ignored. */
+void sdk_decode_untrack(void *ptr);
+
+/*
+ * Free every still-tracked allocation via free_fn and clear the table. Call on
+ * core 0 while core 1 is halted. Returns the number of blocks reclaimed (0 when
+ * the last decode completed cleanly).
+ */
+unsigned sdk_decode_reclaim(void (*free_fn)(void *));
+
+/* Number of slots currently occupied. For tests and diagnostics. */
+unsigned sdk_decode_tracked_count(void);
+
+/*
+ * Extent of the tracking table, for the firmware's cache clean/invalidate range
+ * (the table is cache-line aligned and line-sized). base is never NULL.
+ */
+void *sdk_decode_table_base(void);
+unsigned sdk_decode_table_bytes(void);
+
+/*
+ * Cortex-A9 cache maintenance (sdk_decode_reclaim_arm.c, ARM-only). Core 1
+ * cleans the table to DRAM after each track/untrack; core 0 invalidates its
+ * stale copy before reading at reclaim. Not built for host tests, which never
+ * call them.
+ */
+void sdk_decode_flush_table(void);
+void sdk_decode_invalidate_table(void);
+
+#endif /* SDK_DECODE_RECLAIM_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_decode_reclaim_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_decode_reclaim_arm.c
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ *
+ * Cortex-A9 cache maintenance for the core-1 decode allocation tracker;
+ * compiled only for ARM. Kept separate from sdk_compression.c because
+ * xil_cache.h pulls in Xilinx's LONG/ULONG typedefs, which collide with the
+ * LZMA SDK's 7zTypes.h that sdk_compression.c also includes.
+ *
+ * The table is cache-line aligned and line-sized (see sdk_decode_reclaim.c), so
+ * these range operations touch nothing but the table.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "xil_cache.h"
+#include "sdk_decode_reclaim.h"
+
+/* Core 1: clean the table to DRAM after each track/untrack. */
+void sdk_decode_flush_table(void)
+{
+	Xil_DCacheFlushRange((INTPTR)sdk_decode_table_base(),
+	                     sdk_decode_table_bytes());
+}
+
+/* Core 0: discard any stale cached copy before reading the table at reclaim. */
+void sdk_decode_invalidate_table(void)
+{
+	Xil_DCacheInvalidateRange((INTPTR)sdk_decode_table_base(),
+	                          sdk_decode_table_bytes());
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -13,6 +13,7 @@
 #include "sdk_mailbox.h"
 #include "sdk_compression.h"
 #include "sdk_crypto.h"
+#include "sdk_offload_params.h"
 #include "sdk_image_stream.h"
 #include "sdk_jpeg.h"
 #include "sdk_surface.h"
@@ -3417,12 +3418,13 @@ uint16_t sdk_mailbox_run_crypto_task(uint16_t opcode, const void *op_params,
  * claimed taskq_desc_t to its service handler, filling result_payload and
  * *result_len for taskq_complete().
  *
- * Today only the crypto opcode class is wired up, reproducing the
- * pre-extraction behaviour exactly: on SDK_STATUS_OK the completion carries
- * one full SDKCryptoResultPayload; on any other status it carries zero
- * payload bytes, matching sdk_mailbox's own inline dispatch (crypto_dispatch,
- * above) which likewise omits the payload on failure via complete_status().
- * SDK_OP_DECOMPRESS is added in Task 5.
+ * The crypto opcode class reproduces the pre-extraction behaviour exactly:
+ * on SDK_STATUS_OK the completion carries one full SDKCryptoResultPayload;
+ * on any other status it carries zero payload bytes, matching sdk_mailbox's
+ * own inline dispatch (crypto_dispatch, above) which likewise omits the
+ * payload on failure via complete_status(). SDK_OP_DECOMPRESS mirrors the
+ * same convention against handle_decompress's SDKDecompressResultPayload
+ * (field order and cache invalidate/flush match exactly).
  */
 uint16_t sdk_mailbox_run_offload_task(const taskq_desc_t *d,
                                       uint8_t *result_payload,
@@ -3440,7 +3442,33 @@ uint16_t sdk_mailbox_run_offload_task(const taskq_desc_t *d,
 		    (uint32_t)sizeof(struct SDKCryptoResultPayload) : 0U;
 		return s;
 	}
-	/* case SDK_OP_DECOMPRESS: added in Task 5 */
+	case SDK_OP_DECOMPRESS: {
+		const struct decompress_op_params *p =
+		    (const struct decompress_op_params *)d->op_params;
+		struct SDKDecompressResult result;
+		volatile struct SDKDecompressResultPayload *reply;
+		uint16_t s;
+
+		Xil_DCacheInvalidateRange((INTPTR)d->in_addr, d->in_len);
+		s = sdk_decompress_buffer(p->algorithm, p->flags,
+		        (const uint8_t *)(uintptr_t)d->in_addr, d->in_len,
+		        (uint8_t *)(uintptr_t)d->out_addr, d->out_cap, &result);
+		if (s != SDK_STATUS_OK) {
+			*result_len = 0;
+			return s;
+		}
+		Xil_DCacheFlushRange((INTPTR)d->out_addr, result.bytes_written);
+
+		memset(result_payload, 0, sizeof(struct SDKDecompressResultPayload));
+		reply = (volatile struct SDKDecompressResultPayload *)result_payload;
+		put_be32(reply->bytes_consumed, result.bytes_consumed);
+		put_be32(reply->bytes_written, result.bytes_written);
+		put_be32(reply->checksum, result.checksum);
+		put_be32(reply->algorithm, result.algorithm);
+		put_be32(reply->flags, result.flags);
+		*result_len = sizeof(struct SDKDecompressResultPayload);
+		return SDK_STATUS_OK;
+	}
 	default:
 		*result_len = 0;
 		return SDK_STATUS_UNSUPPORTED;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3411,6 +3411,43 @@ uint16_t sdk_mailbox_run_crypto_task(uint16_t opcode, const void *op_params,
 }
 
 /*
+ * Opcode-dispatched offload executor. This is the scheduler's single
+ * compute-dispatch seam (scheduler_run_slot in scheduler_arm.c): the queue/
+ * worker/harvest machinery is opcode-agnostic, and this function routes a
+ * claimed taskq_desc_t to its service handler, filling result_payload and
+ * *result_len for taskq_complete().
+ *
+ * Today only the crypto opcode class is wired up, reproducing the
+ * pre-extraction behaviour exactly: on SDK_STATUS_OK the completion carries
+ * one full SDKCryptoResultPayload; on any other status it carries zero
+ * payload bytes, matching sdk_mailbox's own inline dispatch (crypto_dispatch,
+ * above) which likewise omits the payload on failure via complete_status().
+ * SDK_OP_DECOMPRESS is added in Task 5.
+ */
+uint16_t sdk_mailbox_run_offload_task(const taskq_desc_t *d,
+                                      uint8_t *result_payload,
+                                      uint32_t *result_len)
+{
+	switch (d->opcode) {
+	case SDK_OP_CRYPTO_HASH:
+	case SDK_OP_CRYPTO_STREAM:
+	case SDK_OP_CRYPTO_AEAD:
+	case SDK_OP_CRYPTO_KX:
+	case SDK_OP_CRYPTO_VERIFY: {
+		uint16_t s = sdk_mailbox_run_crypto_task((uint16_t)d->opcode,
+		                                         d->op_params, result_payload);
+		*result_len = (s == SDK_STATUS_OK) ?
+		    (uint32_t)sizeof(struct SDKCryptoResultPayload) : 0U;
+		return s;
+	}
+	/* case SDK_OP_DECOMPRESS: added in Task 5 */
+	default:
+		*result_len = 0;
+		return SDK_STATUS_UNSUPPORTED;
+	}
+}
+
+/*
  * Front dispatch helper. When core 1 is available, enqueue the task and defer
  * the completion (return SDK_STATUS_QUEUED); sdk_mailbox_task then consumes the
  * request without posting a completion, and scheduler_core0_poll posts it when

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3536,6 +3536,62 @@ static uint16_t crypto_dispatch(uint16_t opcode, uint32_t in_len,
 	return SDK_STATUS_OK;
 }
 
+/*
+ * Front dispatch helper for decompress, mirroring crypto_dispatch exactly
+ * (same batch-tail deferral gate, generation stamp, and inline-fallback
+ * completion idiom). handle_decompress computes in_addr/out_addr from its
+ * resolved shared buffers and hands off here after validation.
+ *
+ * Only defer to core 1 when this is the last request in the batch; a
+ * decompress op with requests behind it must complete its shared-buffer
+ * writes inline so a later batched op touching the same handle never races
+ * core 1. See g_request_is_batch_tail.
+ */
+static uint16_t decompress_dispatch(volatile struct SDKMailboxEntry *req,
+                                    volatile struct SDKMailboxEntry *comp,
+                                    uint32_t in_addr, uint32_t in_len,
+                                    uint32_t out_addr, uint32_t out_cap,
+                                    uint32_t algorithm, uint32_t flags)
+{
+	uint8_t result_payload[TASKQ_RESULT_PAYLOAD];
+	uint32_t result_len = 0;
+	taskq_desc_t local;
+	uint16_t status;
+
+	if (scheduler_core1_available() && g_request_is_batch_tail) {
+		taskq_shared_t *sh = scheduler_shared();
+		struct decompress_op_params p = { algorithm, flags };
+		int slot = taskq_enqueue(&sh->queue, SDK_OP_DECOMPRESS, TASK_LONG,
+		                         in_addr, in_len, out_addr, out_cap,
+		                         get_be32(req->request_id),
+		                         get_be32(req->user_cookie), &p, sizeof(p));
+		if (slot >= 0) {
+			/* Stamp the current mailbox generation so this task is dropped
+			 * rather than posted if the mailbox is re-initialised before it
+			 * finishes. Core-0-only field; safe to write after the QUEUED
+			 * release-store since core 1 never reads it. */
+			g_task_generation[slot] = sdk_mailbox_generation;
+			/* taskq_enqueue release-stored the QUEUED state; make it globally
+			 * visible and wake the worker if it is idling on WFE. */
+			__asm__ __volatile__("dsb ish\n\tsev" ::: "memory");
+			return SDK_STATUS_QUEUED;
+		}
+		/* queue full -> fall through to synchronous inline compute */
+	}
+
+	memset(&local, 0, sizeof(local));
+	decompress_fill_desc(&local, in_addr, in_len, out_addr, out_cap,
+	                     algorithm, flags);
+	status = sdk_mailbox_run_offload_task(&local, result_payload, &result_len);
+	scheduler_shared()->tasks_on_core0++;   /* executed inline on core 0 */
+	if (status != SDK_STATUS_OK)
+		return complete_status(req, comp, status);
+	write_completion(comp, req, SDK_STATUS_OK, (uint16_t)result_len);
+	memset((void *)comp->payload, 0, sizeof(comp->payload));
+	memcpy((void *)comp->payload, result_payload, result_len);
+	return SDK_STATUS_OK;
+}
+
 static uint16_t handle_crypto_hash(volatile struct SDKMailboxEntry *req,
                                    volatile struct SDKMailboxEntry *comp,
                                    uint16_t payload_len)
@@ -3922,17 +3978,16 @@ static uint16_t handle_decompress(volatile struct SDKMailboxEntry *req,
                                   uint16_t payload_len)
 {
 	volatile struct SDKDecompressPayload *payload;
-	volatile struct SDKDecompressResultPayload *reply;
 	struct SDKSharedBuffer *src;
 	struct SDKSharedBuffer *dst;
-	struct SDKDecompressResult result;
 	uint32_t src_offset;
 	uint32_t src_length;
 	uint32_t dst_offset;
 	uint32_t dst_capacity;
 	uint32_t algorithm;
 	uint32_t flags;
-	uint16_t status;
+	uint32_t in_addr;
+	uint32_t out_addr;
 
 	if (payload_len < sizeof(*payload))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
@@ -3959,30 +4014,10 @@ static uint16_t handle_decompress(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
 	}
 
-	Xil_DCacheInvalidateRange((INTPTR)(src->address + src_offset),
-	                          src_length);
-	status = sdk_decompress_buffer(
-		algorithm, flags,
-		(const uint8_t *)(uintptr_t)(src->address + src_offset),
-		src_length,
-		(uint8_t *)(uintptr_t)(dst->address + dst_offset),
-		dst_capacity,
-		&result);
-	if (status != SDK_STATUS_OK)
-		return complete_status(req, comp, status);
-
-	Xil_DCacheFlushRange((INTPTR)(dst->address + dst_offset),
-	                     result.bytes_written);
-
-	write_completion(comp, req, SDK_STATUS_OK, sizeof(*reply));
-	memset((void *)comp->payload, 0, sizeof(comp->payload));
-	reply = (volatile struct SDKDecompressResultPayload *)comp->payload;
-	put_be32(reply->bytes_consumed, result.bytes_consumed);
-	put_be32(reply->bytes_written, result.bytes_written);
-	put_be32(reply->checksum, result.checksum);
-	put_be32(reply->algorithm, result.algorithm);
-	put_be32(reply->flags, result.flags);
-	return SDK_STATUS_OK;
+	in_addr = src->address + src_offset;
+	out_addr = dst->address + dst_offset;
+	return decompress_dispatch(req, comp, in_addr, src_length,
+	                           out_addr, dst_capacity, algorithm, flags);
 }
 
 static uint16_t handle_decompress_test(volatile struct SDKMailboxEntry *req,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -186,6 +186,9 @@ struct SDKDiagSchedPayload {
 	uint8_t core1_online[4];
 	uint8_t tasks_on_core1[4];
 	uint8_t tasks_on_core0[4];
+	/* version 2: decode-only timing, see timing_decode_requests/_us. */
+	uint8_t decode_requests[4];
+	uint8_t decode_us[4];
 };
 
 struct SDKSurfaceInfoPayload {
@@ -640,8 +643,8 @@ typedef char SDKDiagPayload_must_be_48_bytes[
 typedef char SDKDiagTimingPayload_must_be_48_bytes[
 	(sizeof(struct SDKDiagTimingPayload) == 48U) ? 1 : -1
 ];
-typedef char SDKDiagSchedPayload_must_be_16_bytes[
-	(sizeof(struct SDKDiagSchedPayload) == 16U) ? 1 : -1
+typedef char SDKDiagSchedPayload_must_be_24_bytes[
+	(sizeof(struct SDKDiagSchedPayload) == 24U) ? 1 : -1
 ];
 typedef char SDKSurfaceInfoPayload_must_be_48_bytes[
 	(sizeof(struct SDKSurfaceInfoPayload) == 48U) ? 1 : -1
@@ -792,6 +795,18 @@ static uint32_t timing_last_opcode;
 static uint32_t timing_last_us;
 static uint32_t timing_max_opcode;
 static uint32_t timing_max_us;
+/*
+ * Decode-only timing (diagnostic, not functional). Brackets just the
+ * sdk_decompress_buffer() compute inside sdk_mailbox_run_offload_task, which
+ * is shared by the core-1 worker and the core-0 inline fallback. Unlike
+ * timing_total_us (whole-request time -- for a core-1-deferred decompress
+ * that is only the enqueue latency, not the decode itself), this isolates
+ * actual decode compute time so archive transfer-vs-decode can be split on
+ * hardware. Counts every attempt, success or failure, like
+ * record_request_timing does for the whole-request counters above.
+ */
+static uint32_t timing_decode_requests;
+static uint32_t timing_decode_us;
 
 static uint32_t surface_format_bytes(uint32_t format);
 
@@ -3447,12 +3462,19 @@ uint16_t sdk_mailbox_run_offload_task(const taskq_desc_t *d,
 		    (const struct decompress_op_params *)d->op_params;
 		struct SDKDecompressResult result;
 		volatile struct SDKDecompressResultPayload *reply;
+		XTime decode_start;
+		XTime decode_end;
 		uint16_t s;
 
 		Xil_DCacheInvalidateRange((INTPTR)d->in_addr, d->in_len);
+		XTime_GetTime(&decode_start);
 		s = sdk_decompress_buffer(p->algorithm, p->flags,
 		        (const uint8_t *)(uintptr_t)d->in_addr, d->in_len,
 		        (uint8_t *)(uintptr_t)d->out_addr, d->out_cap, &result);
+		XTime_GetTime(&decode_end);
+		timing_decode_requests = saturated_add_u32(timing_decode_requests, 1U);
+		timing_decode_us = saturated_add_u32(timing_decode_us,
+		    timing_delta_us(decode_start, decode_end));
 		if (s != SDK_STATUS_OK) {
 			*result_len = 0;
 			return s;
@@ -4335,10 +4357,14 @@ static uint16_t handle_diag_sched(volatile struct SDKMailboxEntry *req,
 	write_completion(comp, req, SDK_STATUS_OK, sizeof(*sched));
 	memset((void *)comp->payload, 0, sizeof(comp->payload));
 	sched = (volatile struct SDKDiagSchedPayload *)comp->payload;
-	put_be32(sched->version, 1U);
+	/* version 2: appends decode_requests/decode_us (Task 7). Readers that
+	 * only know version 1 can keep reading the first 16 bytes unchanged. */
+	put_be32(sched->version, 2U);
 	put_be32(sched->core1_online, scheduler_core1_available() ? 1U : 0U);
 	put_be32(sched->tasks_on_core1, sh->tasks_on_core1);
 	put_be32(sched->tasks_on_core0, sh->tasks_on_core0);
+	put_be32(sched->decode_requests, timing_decode_requests);
+	put_be32(sched->decode_us, timing_decode_us);
 	return SDK_STATUS_OK;
 }
 
@@ -4534,6 +4560,8 @@ void sdk_mailbox_init(void)
 	timing_last_us = 0;
 	timing_max_opcode = 0;
 	timing_max_us = 0;
+	timing_decode_requests = 0;
+	timing_decode_us = 0;
 	memset(shared_buffers, 0, sizeof(shared_buffers));
 	memset(surfaces, 0, sizeof(surfaces));
 	memset(audio_streams, 0, sizeof(audio_streams));

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -339,11 +339,11 @@ uint16_t sdk_mailbox_run_crypto_task(uint16_t opcode, const void *op_params,
  * Opcode-dispatched offload executor: routes a claimed taskq_desc_t (see
  * scheduler.h) to its service handler on the calling core, filling
  * result_payload (a TASKQ_RESULT_PAYLOAD-byte buffer) and *result_len.
- * Currently only the crypto opcode class is wired up (byte-identical to the
- * pre-extraction scheduler_run_slot: full SDKCryptoResultPayload length on
- * SDK_STATUS_OK, zero otherwise); SDK_OP_DECOMPRESS is added in Task 5. Used
- * by the dual-core scheduler's core-1 worker and core-0 inline/fallback path
- * (scheduler_arm.c: scheduler_run_slot).
+ * Both the crypto opcode class and SDK_OP_DECOMPRESS are wired up, each
+ * byte-identical to the pre-extraction inline dispatch: full result-payload
+ * length (SDKCryptoResultPayload or SDKDecompressResultPayload) on
+ * SDK_STATUS_OK, zero otherwise. Used by the dual-core scheduler's core-1
+ * worker and core-0 inline/fallback path (scheduler_arm.c: scheduler_run_slot).
  */
 uint16_t sdk_mailbox_run_offload_task(const taskq_desc_t *d,
                                       uint8_t *result_payload,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -10,6 +10,7 @@
 #define SDK_MAILBOX_H
 
 #include <stdint.h>
+#include "scheduler.h"
 
 #define SDK_MAILBOX_MAGIC              0x5a5a394bUL
 #define SDK_MAILBOX_REG_MAGIC_VALUE    0x5a39U
@@ -333,6 +334,20 @@ uint32_t sdk_mailbox_address(void);
  */
 uint16_t sdk_mailbox_run_crypto_task(uint16_t opcode, const void *op_params,
                                      uint8_t *result_payload);
+
+/*
+ * Opcode-dispatched offload executor: routes a claimed taskq_desc_t (see
+ * scheduler.h) to its service handler on the calling core, filling
+ * result_payload (a TASKQ_RESULT_PAYLOAD-byte buffer) and *result_len.
+ * Currently only the crypto opcode class is wired up (byte-identical to the
+ * pre-extraction scheduler_run_slot: full SDKCryptoResultPayload length on
+ * SDK_STATUS_OK, zero otherwise); SDK_OP_DECOMPRESS is added in Task 5. Used
+ * by the dual-core scheduler's core-1 worker and core-0 inline/fallback path
+ * (scheduler_arm.c: scheduler_run_slot).
+ */
+uint16_t sdk_mailbox_run_offload_task(const taskq_desc_t *d,
+                                      uint8_t *result_payload,
+                                      uint32_t *result_len);
 
 /*
  * Post a deferred completion for a task the core-1 scheduler finished (see

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_offload_params.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_offload_params.h
@@ -1,0 +1,38 @@
+/*
+ * ZZ9000 dual-core task scheduler -- decompress task descriptor helper.
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Host-compilable (no xil_ or firmware includes) so the pack/unpack of
+ * struct decompress_op_params into taskq_desc_t::op_params is unit-tested
+ * off-target, mirroring scheduler.h/scheduler.c. Shared by the producer
+ * (Task 6) and the ARM-side executor in sdk_mailbox.c.
+ */
+#ifndef ZZ9K_SDK_OFFLOAD_PARAMS_H
+#define ZZ9K_SDK_OFFLOAD_PARAMS_H
+
+#include <stdint.h>
+#include "scheduler.h"
+
+struct decompress_op_params {
+  uint32_t algorithm;
+  uint32_t flags;
+};
+
+/* op_params is 4-byte aligned within taskq_desc_t, so the struct-pointer
+ * cast below is safe -- same pattern the crypto op-params structs use. */
+static inline void decompress_fill_desc(taskq_desc_t *d,
+    uint32_t in_addr, uint32_t in_len, uint32_t out_addr, uint32_t out_cap,
+    uint32_t algorithm, uint32_t flags)
+{
+  struct decompress_op_params *p = (struct decompress_op_params *)d->op_params;
+  d->opcode = TASKQ_OP_DECOMPRESS;
+  d->in_addr = in_addr;
+  d->in_len = in_len;
+  d->out_addr = out_addr;
+  d->out_cap = out_cap;
+  p->algorithm = algorithm;
+  p->flags = flags;
+}
+
+#endif /* ZZ9K_SDK_OFFLOAD_PARAMS_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock.c
@@ -1,0 +1,32 @@
+#include "sdk_smp_lock.h"
+
+void sdk_smp_lock_acquire(sdk_smp_lock_t *l)
+{
+    uint32_t flags = smp_local_irq_save();   /* mask local IRQs first */
+    int me = smp_cpu_id();
+    if (l->owner == me) {
+        l->depth++;
+        /* We were already the owner => IRQs were already masked at depth 0.
+         * Undo this call's extra mask to keep save/restore balanced. */
+        smp_local_irq_restore(flags);
+        return;
+    }
+    smp_raw_spin_lock(&l->raw);               /* spin with local IRQs masked */
+    l->owner = me;
+    l->depth = 1u;
+    l->saved_irq = flags;                     /* original state, restored at depth 0 */
+    /* keep IRQs masked until release at depth 0 */
+}
+
+void sdk_smp_lock_release(sdk_smp_lock_t *l)
+{
+    /* Precondition: caller is the owner and local IRQs are masked. */
+    if (l->depth == 0u) return;               /* defensive: unbalanced release */
+    l->depth--;
+    if (l->depth == 0u) {
+        uint32_t flags = l->saved_irq;
+        l->owner = -1;
+        smp_raw_spin_unlock(&l->raw);
+        smp_local_irq_restore(flags);
+    }
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock.c
@@ -30,3 +30,14 @@ void sdk_smp_lock_release(sdk_smp_lock_t *l)
         smp_local_irq_restore(flags);
     }
 }
+
+void sdk_smp_lock_reset(sdk_smp_lock_t *l)
+{
+    /* Unconditional: force to the free state regardless of current holder.
+     * Fault-recovery only -- the caller is responsible for ensuring it is
+     * safe to do so (e.g. the owning core is provably halted). */
+    l->raw = 0u;
+    l->owner = -1;
+    l->depth = 0u;
+    l->saved_irq = 0u;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock.h
@@ -1,0 +1,26 @@
+/* sdk_smp_lock.h - recursive, IRQ-safe, cross-core allocator lock */
+#ifndef SDK_SMP_LOCK_H
+#define SDK_SMP_LOCK_H
+
+#include <stdint.h>
+
+typedef struct {
+    volatile uint32_t raw;          /* raw spinlock word: 0 free, 1 held */
+    volatile int32_t  owner;        /* CPU id of holder, -1 when free     */
+    volatile uint32_t depth;        /* recursion count                    */
+    volatile uint32_t saved_irq;    /* IRQ state captured at depth 0->1   */
+} sdk_smp_lock_t;
+
+#define SDK_SMP_LOCK_INIT { 0u, -1, 0u, 0u }
+
+/* Platform primitives (ARM in sdk_smp_lock_arm.c; mocked in host tests). */
+int      smp_cpu_id(void);
+uint32_t smp_local_irq_save(void);         /* disable local IRQs, return prior state */
+void     smp_local_irq_restore(uint32_t s);
+void     smp_raw_spin_lock(volatile uint32_t *word);
+void     smp_raw_spin_unlock(volatile uint32_t *word);
+
+void sdk_smp_lock_acquire(sdk_smp_lock_t *l);
+void sdk_smp_lock_release(sdk_smp_lock_t *l);
+
+#endif /* SDK_SMP_LOCK_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock.h
@@ -23,4 +23,19 @@ void     smp_raw_spin_unlock(volatile uint32_t *word);
 void sdk_smp_lock_acquire(sdk_smp_lock_t *l);
 void sdk_smp_lock_release(sdk_smp_lock_t *l);
 
+/* Force a lock to the free state, unconditionally. Portable (host-testable):
+ * touches only the sdk_smp_lock_t fields, no platform calls. For fault
+ * recovery when the owning core cannot run its normal release path (e.g. it
+ * was reset mid-critical-section) -- NOT a substitute for sdk_smp_lock_release
+ * in ordinary code paths. */
+void sdk_smp_lock_reset(sdk_smp_lock_t *l);
+
+/* ARM-only wrappers (implemented in sdk_smp_lock_arm.c under
+ * #ifndef SMP_LOCK_HOST_TEST) operating on the file-static cross-core
+ * allocator lock g_malloc_lock. Used by core-1 fault recovery (core2.c) to
+ * free a lock that core 1 could have orphaned by faulting/being reset while
+ * holding it mid-malloc/free. */
+void sdk_smp_lock_reset_malloc(void);          /* unconditional reset + dsb/sev */
+void sdk_smp_lock_reset_malloc_if_owned(void); /* reset + dsb/sev only if this core owns it */
+
 #endif /* SDK_SMP_LOCK_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock_arm.c
@@ -1,0 +1,68 @@
+/* sdk_smp_lock_arm.c - Cortex-A9 primitives; compiled only for ARM. */
+#ifndef SMP_LOCK_HOST_TEST
+#include "sdk_smp_lock.h"
+#include "xpseudo_asm.h"
+#include "xreg_cortexa9.h"
+#include <reent.h>
+
+int smp_cpu_id(void)
+{
+    uint32_t mpidr;
+    __asm__ __volatile__("mrc p15, 0, %0, c0, c0, 5" : "=r"(mpidr));
+    return (int)(mpidr & 0xFFu);
+}
+
+uint32_t smp_local_irq_save(void)
+{
+    uint32_t cpsr;
+    __asm__ __volatile__("mrs %0, cpsr" : "=r"(cpsr));
+    __asm__ __volatile__("cpsid i" ::: "memory");
+    return cpsr & (1u << 7);              /* prior I-bit only */
+}
+
+void smp_local_irq_restore(uint32_t saved_i_bit)
+{
+    if (saved_i_bit == 0u) {              /* IRQs were enabled before */
+        __asm__ __volatile__("cpsie i" ::: "memory");
+    }
+}
+
+void smp_raw_spin_lock(volatile uint32_t *word)
+{
+    /* NOTE: deviates from the task brief's literal asm, which used the same
+     * register for both the strex status and the store value
+     * ("strex %0, %0, [%1]"). That is rejected by this toolchain's assembler
+     * ("registers may not be the same") because STREX requires Rd != Rt.
+     * Fixed with a second temporary (value) for the STREX source register;
+     * the ldrex/teq/wfene/bne/strex/teq/bne/dmb structure and barrier
+     * placement are otherwise transcribed faithfully. */
+    uint32_t status, value;
+    __asm__ __volatile__(
+        "1: ldrex   %0, [%2]        \n"
+        "   teq     %0, #0          \n"
+        "   wfene                   \n"   /* sleep if held */
+        "   bne     1b              \n"
+        "   mov     %1, #1          \n"
+        "   strex   %0, %1, [%2]    \n"   /* try to take */
+        "   teq     %0, #0          \n"
+        "   bne     1b              \n"
+        "   dmb                     \n"
+        : "=&r"(status), "=&r"(value) : "r"(word) : "cc", "memory");
+}
+
+void smp_raw_spin_unlock(volatile uint32_t *word)
+{
+    __asm__ __volatile__(
+        "   dmb                     \n"
+        "   mov     r1, #0          \n"
+        "   str     r1, [%0]        \n"
+        "   dsb                     \n"
+        "   sev                     \n"
+        :: "r"(word) : "r1", "memory");
+}
+
+static sdk_smp_lock_t g_malloc_lock = SDK_SMP_LOCK_INIT;
+
+void __malloc_lock(struct _reent *r)   { (void)r; sdk_smp_lock_acquire(&g_malloc_lock); }
+void __malloc_unlock(struct _reent *r) { (void)r; sdk_smp_lock_release(&g_malloc_lock); }
+#endif /* !SMP_LOCK_HOST_TEST */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_smp_lock_arm.c
@@ -65,4 +65,29 @@ static sdk_smp_lock_t g_malloc_lock = SDK_SMP_LOCK_INIT;
 
 void __malloc_lock(struct _reent *r)   { (void)r; sdk_smp_lock_acquire(&g_malloc_lock); }
 void __malloc_unlock(struct _reent *r) { (void)r; sdk_smp_lock_release(&g_malloc_lock); }
+
+/*
+ * Fault-recovery lock reset for g_malloc_lock. Core 1 runs decompress
+ * (zlib/LZMA) and can therefore be holding this lock (mid-malloc/free) at the
+ * instant it faults or is cold-restarted. Left held, it strands core 0's next
+ * malloc forever. The dsb;sev after the reset publishes the freed lock to the
+ * other core and wakes it if it is spinning in smp_raw_spin_lock's wfe.
+ */
+void sdk_smp_lock_reset_malloc(void)
+{
+    sdk_smp_lock_reset(&g_malloc_lock);
+    __asm__ __volatile__("dsb\n\tsev" ::: "memory");
+}
+
+void sdk_smp_lock_reset_malloc_if_owned(void)
+{
+    /* Only free the lock if THIS core holds it. If core 1 faulted while
+     * merely spinning to acquire, core 0 may legitimately own it -- freeing
+     * it out from under core 0 would reintroduce the exact race this lock
+     * exists to prevent. */
+    if (g_malloc_lock.owner == smp_cpu_id()) {
+        sdk_smp_lock_reset(&g_malloc_lock);
+        __asm__ __volatile__("dsb\n\tsev" ::: "memory");
+    }
+}
 #endif /* !SMP_LOCK_HOST_TEST */

--- a/test/scheduler/Makefile
+++ b/test/scheduler/Makefile
@@ -16,7 +16,12 @@ SMP_LOCK_SOURCES := smp_lock_test.c $(SRC_DIR)/sdk_smp_lock.c
 SMP_LOCK_DEPS := $(SRC_DIR)/sdk_smp_lock.h
 SMP_LOCK_LDLIBS := -lpthread
 
-.PHONY: test clean smp_lock
+OFFLOAD_PARAMS_TARGET := $(BUILD_DIR)/offload_params_test
+OFFLOAD_PARAMS_CPPFLAGS := -DTASKQ_HOST_TEST -I$(SRC_DIR)
+OFFLOAD_PARAMS_SOURCES := offload_params_test.c $(SRC_DIR)/scheduler.c
+OFFLOAD_PARAMS_DEPS := $(SRC_DIR)/scheduler.h $(SRC_DIR)/sdk_offload_params.h
+
+.PHONY: test clean smp_lock offload_params
 
 test: $(TARGET)
 	$(TARGET)
@@ -31,6 +36,13 @@ smp_lock: $(SMP_LOCK_TARGET)
 $(SMP_LOCK_TARGET): $(SMP_LOCK_SOURCES) $(SMP_LOCK_DEPS)
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(SMP_LOCK_CPPFLAGS) $(CFLAGS) -o $@ $(SMP_LOCK_SOURCES) $(SMP_LOCK_LDLIBS)
+
+offload_params: $(OFFLOAD_PARAMS_TARGET)
+	$(OFFLOAD_PARAMS_TARGET)
+
+$(OFFLOAD_PARAMS_TARGET): $(OFFLOAD_PARAMS_SOURCES) $(OFFLOAD_PARAMS_DEPS)
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(OFFLOAD_PARAMS_CPPFLAGS) $(CFLAGS) -o $@ $(OFFLOAD_PARAMS_SOURCES)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/test/scheduler/Makefile
+++ b/test/scheduler/Makefile
@@ -21,7 +21,12 @@ OFFLOAD_PARAMS_CPPFLAGS := -DTASKQ_HOST_TEST -I$(SRC_DIR)
 OFFLOAD_PARAMS_SOURCES := offload_params_test.c $(SRC_DIR)/scheduler.c
 OFFLOAD_PARAMS_DEPS := $(SRC_DIR)/scheduler.h $(SRC_DIR)/sdk_offload_params.h
 
-.PHONY: test clean smp_lock offload_params
+DECODE_RECLAIM_TARGET := $(BUILD_DIR)/decode_reclaim_test
+DECODE_RECLAIM_CPPFLAGS := -I$(SRC_DIR)
+DECODE_RECLAIM_SOURCES := decode_reclaim_test.c $(SRC_DIR)/sdk_decode_reclaim.c
+DECODE_RECLAIM_DEPS := $(SRC_DIR)/sdk_decode_reclaim.h
+
+.PHONY: test clean smp_lock offload_params decode_reclaim
 
 test: $(TARGET)
 	$(TARGET)
@@ -43,6 +48,13 @@ offload_params: $(OFFLOAD_PARAMS_TARGET)
 $(OFFLOAD_PARAMS_TARGET): $(OFFLOAD_PARAMS_SOURCES) $(OFFLOAD_PARAMS_DEPS)
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(OFFLOAD_PARAMS_CPPFLAGS) $(CFLAGS) -o $@ $(OFFLOAD_PARAMS_SOURCES)
+
+decode_reclaim: $(DECODE_RECLAIM_TARGET)
+	$(DECODE_RECLAIM_TARGET)
+
+$(DECODE_RECLAIM_TARGET): $(DECODE_RECLAIM_SOURCES) $(DECODE_RECLAIM_DEPS)
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(DECODE_RECLAIM_CPPFLAGS) $(CFLAGS) -o $@ $(DECODE_RECLAIM_SOURCES)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/test/scheduler/Makefile
+++ b/test/scheduler/Makefile
@@ -10,7 +10,13 @@ CPPFLAGS += -DTASKQ_HOST_TEST -I$(SRC_DIR)
 SOURCES := scheduler_test.c $(SRC_DIR)/scheduler.c
 DEPS := $(SRC_DIR)/scheduler.h
 
-.PHONY: test clean
+SMP_LOCK_TARGET := $(BUILD_DIR)/smp_lock_test
+SMP_LOCK_CPPFLAGS := -DSMP_LOCK_HOST_TEST -I$(SRC_DIR)
+SMP_LOCK_SOURCES := smp_lock_test.c $(SRC_DIR)/sdk_smp_lock.c
+SMP_LOCK_DEPS := $(SRC_DIR)/sdk_smp_lock.h
+SMP_LOCK_LDLIBS := -lpthread
+
+.PHONY: test clean smp_lock
 
 test: $(TARGET)
 	$(TARGET)
@@ -18,6 +24,13 @@ test: $(TARGET)
 $(TARGET): $(SOURCES) $(DEPS)
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $(SOURCES)
+
+smp_lock: $(SMP_LOCK_TARGET)
+	$(SMP_LOCK_TARGET)
+
+$(SMP_LOCK_TARGET): $(SMP_LOCK_SOURCES) $(SMP_LOCK_DEPS)
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(SMP_LOCK_CPPFLAGS) $(CFLAGS) -o $@ $(SMP_LOCK_SOURCES) $(SMP_LOCK_LDLIBS)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/test/scheduler/decode_reclaim_test.c
+++ b/test/scheduler/decode_reclaim_test.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ *
+ * Host test for the core-1 decode allocation tracker (sdk_decode_reclaim.c).
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include "sdk_decode_reclaim.h"
+
+static void *g_freed[64];
+static unsigned g_freed_count;
+
+static void mock_free(void *ptr)
+{
+	if (g_freed_count < (sizeof(g_freed) / sizeof(g_freed[0])))
+		g_freed[g_freed_count++] = ptr;
+}
+
+static void reset_mock(void)
+{
+	memset(g_freed, 0, sizeof(g_freed));
+	g_freed_count = 0u;
+}
+
+static int mock_freed(void *ptr)
+{
+	unsigned i;
+
+	for (i = 0u; i < g_freed_count; i++)
+		if (g_freed[i] == ptr)
+			return 1;
+	return 0;
+}
+
+/* Distinct non-NULL fake pointers. */
+static char blocks[SDK_DECODE_MAX_TRACKED + 8u];
+static void *blk(unsigned i) { return &blocks[i]; }
+
+static int test_clean_decode_reclaims_nothing(void)
+{
+	reset_mock();
+	/* A decode that frees everything it allocated leaves an empty table. */
+	sdk_decode_track(blk(0));
+	sdk_decode_track(blk(1));
+	if (sdk_decode_tracked_count() != 2u) return 1;
+	sdk_decode_untrack(blk(0));
+	sdk_decode_untrack(blk(1));
+	if (sdk_decode_tracked_count() != 0u) return 2;
+	if (sdk_decode_reclaim(mock_free) != 0u) return 3;
+	if (g_freed_count != 0u) return 4;
+	return 0;
+}
+
+static int test_killed_decode_reclaims_survivors(void)
+{
+	reset_mock();
+	/* A decode killed mid-flight: some blocks were never freed. */
+	sdk_decode_track(blk(0));
+	sdk_decode_track(blk(1));
+	sdk_decode_track(blk(2));
+	sdk_decode_untrack(blk(1));            /* one freed before the reset */
+	if (sdk_decode_tracked_count() != 2u) return 1;
+	if (sdk_decode_reclaim(mock_free) != 2u) return 2;
+	if (!mock_freed(blk(0)) || !mock_freed(blk(2))) return 3;
+	if (mock_freed(blk(1))) return 4;      /* already freed: not double-freed */
+	if (sdk_decode_tracked_count() != 0u) return 5;   /* table cleared */
+	/* A second reclaim frees nothing. */
+	reset_mock();
+	if (sdk_decode_reclaim(mock_free) != 0u) return 6;
+	if (g_freed_count != 0u) return 7;
+	return 0;
+}
+
+static int test_untrack_before_free_prevents_double_free(void)
+{
+	reset_mock();
+	/* Ordering contract: untrack happens before free, so a block the worker
+	 * already freed is not tracked and reclaim never touches it. */
+	sdk_decode_track(blk(3));
+	sdk_decode_untrack(blk(3));
+	if (sdk_decode_reclaim(mock_free) != 0u) return 1;
+	if (mock_freed(blk(3))) return 2;
+	return 0;
+}
+
+static int test_null_and_untracked_are_ignored(void)
+{
+	reset_mock();
+	sdk_decode_track(NULL);                /* ignored */
+	if (sdk_decode_tracked_count() != 0u) return 1;
+	sdk_decode_untrack(NULL);              /* ignored */
+	sdk_decode_untrack(blk(4));            /* never tracked: ignored */
+	if (sdk_decode_tracked_count() != 0u) return 2;
+	if (sdk_decode_reclaim(mock_free) != 0u) return 3;
+	return 0;
+}
+
+static int test_table_full_drops_extra_without_overrun(void)
+{
+	unsigned i;
+
+	reset_mock();
+	/* Fill the table exactly. */
+	for (i = 0u; i < SDK_DECODE_MAX_TRACKED; i++)
+		sdk_decode_track(blk(i));
+	if (sdk_decode_tracked_count() != SDK_DECODE_MAX_TRACKED) return 1;
+	/* Extra allocations are silently dropped (safer than overrunning). */
+	sdk_decode_track(blk(SDK_DECODE_MAX_TRACKED));
+	sdk_decode_track(blk(SDK_DECODE_MAX_TRACKED + 1u));
+	if (sdk_decode_tracked_count() != SDK_DECODE_MAX_TRACKED) return 2;
+	/* Reclaim frees exactly the tracked set; the dropped ones are not seen. */
+	if (sdk_decode_reclaim(mock_free) != SDK_DECODE_MAX_TRACKED) return 3;
+	if (mock_freed(blk(SDK_DECODE_MAX_TRACKED))) return 4;
+	if (sdk_decode_tracked_count() != 0u) return 5;
+	return 0;
+}
+
+static int test_reclaim_tolerates_null_free_fn(void)
+{
+	reset_mock();
+	sdk_decode_track(blk(0));
+	sdk_decode_track(blk(1));
+	/* Should still clear the table and count, without calling through NULL. */
+	if (sdk_decode_reclaim(NULL) != 2u) return 1;
+	if (sdk_decode_tracked_count() != 0u) return 2;
+	return 0;
+}
+
+static int test_table_extent_accessors(void)
+{
+	/* The firmware uses these to bound its cache clean/invalidate range. */
+	if (sdk_decode_table_base() == NULL) return 1;
+	if (sdk_decode_table_bytes() != SDK_DECODE_MAX_TRACKED * sizeof(void *))
+		return 2;
+	/* Cache-line aligned so a range flush cannot touch neighbouring data. */
+	if (((unsigned long)(size_t)sdk_decode_table_base() & 31u) != 0u) return 3;
+	return 0;
+}
+
+int main(void)
+{
+	struct { const char *name; int (*fn)(void); } tests[] = {
+		{ "clean_decode_reclaims_nothing", test_clean_decode_reclaims_nothing },
+		{ "killed_decode_reclaims_survivors", test_killed_decode_reclaims_survivors },
+		{ "untrack_before_free_prevents_double_free", test_untrack_before_free_prevents_double_free },
+		{ "null_and_untracked_are_ignored", test_null_and_untracked_are_ignored },
+		{ "table_full_drops_extra_without_overrun", test_table_full_drops_extra_without_overrun },
+		{ "reclaim_tolerates_null_free_fn", test_reclaim_tolerates_null_free_fn },
+		{ "table_extent_accessors", test_table_extent_accessors },
+	};
+	unsigned i;
+	int failures = 0;
+
+	for (i = 0u; i < sizeof(tests) / sizeof(tests[0]); i++) {
+		int rc = tests[i].fn();
+
+		if (rc != 0) {
+			printf("FAIL %s (rc=%d)\n", tests[i].name, rc);
+			failures++;
+		} else {
+			printf("ok   %s\n", tests[i].name);
+		}
+	}
+	if (failures) {
+		printf("decode_reclaim_test: %d failure(s)\n", failures);
+		return 1;
+	}
+	printf("decode_reclaim_test: all passed\n");
+	return 0;
+}

--- a/test/scheduler/offload_params_test.c
+++ b/test/scheduler/offload_params_test.c
@@ -1,0 +1,46 @@
+/*
+ * Host unit tests for the decompress task descriptor helper
+ * (sdk_offload_params.h): pack/unpack symmetry + dispatch class.
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#include "sdk_offload_params.h"
+#include "scheduler.h"
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+#define SDK_COMPRESSION_ZLIB 2U
+
+static void test_decompress_fill_desc_packs_fields(void)
+{
+  taskq_desc_t d;
+  const struct decompress_op_params *p;
+
+  memset(&d, 0, sizeof d);
+  decompress_fill_desc(&d, 0x11000000u, 4096u, 0x12000000u, 65536u,
+                       SDK_COMPRESSION_ZLIB, 0u);
+
+  assert(d.opcode == TASKQ_OP_DECOMPRESS);
+  assert(d.in_addr == 0x11000000u && d.in_len == 4096u);
+  assert(d.out_addr == 0x12000000u && d.out_cap == 65536u);
+
+  p = (const struct decompress_op_params *)d.op_params;
+  assert(p->algorithm == SDK_COMPRESSION_ZLIB && p->flags == 0u);
+
+  printf("test_decompress_fill_desc_packs_fields OK\n");
+}
+
+static void test_decompress_class_is_long(void)
+{
+  assert(taskq_class_for_opcode(TASKQ_OP_DECOMPRESS, 999999u) == TASK_LONG);
+  printf("test_decompress_class_is_long OK\n");
+}
+
+int main(void)
+{
+  test_decompress_fill_desc_packs_fields();
+  test_decompress_class_is_long();
+  printf("all offload_params tests passed\n");
+  return 0;
+}

--- a/test/scheduler/smp_lock_test.c
+++ b/test/scheduler/smp_lock_test.c
@@ -36,6 +36,33 @@ static void test_recursion_balances_irq(void) {
     printf("test_recursion_balances_irq OK\n");
 }
 
+/* Fault-recovery reset: must force a HELD lock back to the free state, and
+ * the freed lock must be cleanly re-acquirable afterwards (models core-1
+ * restart finding g_malloc_lock stranded mid-malloc/free and releasing it). */
+static void test_reset_frees_held_lock(void) {
+    sdk_smp_lock_t l = SDK_SMP_LOCK_INIT;
+    t_cpu = 0; g_irq_disabled_depth = 0;
+    sdk_smp_lock_acquire(&l);            /* held: owner=0, depth=1 */
+    assert(l.owner == 0 && l.depth == 1);
+
+    sdk_smp_lock_reset(&l);
+    assert(l.owner == -1 && l.depth == 0 && l.raw == 0);
+    /* Test-mock-only bookkeeping: the raw word here is backed by a real
+     * pthread_mutex (g_raw) so test_stress_no_lost_updates gets genuine
+     * cross-thread exclusion. sdk_smp_lock_reset only touches the
+     * sdk_smp_lock_t fields (matching production, where raw is a bare
+     * spinlock word and writing 0 to it IS the unlock) -- so free the mock's
+     * backing mutex here too, or the acquire below deadlocks on it. */
+    pthread_mutex_unlock(&g_raw);
+
+    /* freshly acquirable again after reset */
+    sdk_smp_lock_acquire(&l);
+    assert(l.owner == 0 && l.depth == 1);
+    sdk_smp_lock_release(&l);
+    assert(l.owner == -1 && l.depth == 0);
+    printf("test_reset_frees_held_lock OK\n");
+}
+
 /* 2-thread stress: increments under the lock must never race. */
 static sdk_smp_lock_t g_stress = SDK_SMP_LOCK_INIT;
 static long g_counter = 0;
@@ -61,6 +88,7 @@ static void test_stress_no_lost_updates(void) {
 
 int main(void) {
     test_recursion_balances_irq();
+    test_reset_frees_held_lock();
     test_stress_no_lost_updates();
     printf("ALL smp_lock tests passed\n");
     return 0;

--- a/test/scheduler/smp_lock_test.c
+++ b/test/scheduler/smp_lock_test.c
@@ -1,0 +1,67 @@
+/* Host test: mock the platform primitives, exercise the state machine. */
+#include "sdk_smp_lock.h"
+#include <assert.h>
+#include <stdio.h>
+#include <pthread.h>
+
+/* Per-thread CPU id: real cores each have a fixed, hardware-distinct id, so
+ * smp_cpu_id() can never collide across cores. A single shared global here
+ * would let a second thread's unsynchronized "owner == me" read alias onto
+ * the first thread's id mid-critical-section, letting it take the recursive
+ * fast path without ever taking the raw spinlock. Thread-local storage
+ * models "one fixed id per core" faithfully instead. */
+static __thread int t_cpu = 0;          /* test-controlled current CPU */
+static int   g_irq_disabled_depth = 0;  /* tracks nested disables      */
+static pthread_mutex_t g_raw = PTHREAD_MUTEX_INITIALIZER;
+
+int      smp_cpu_id(void) { return t_cpu; }
+uint32_t smp_local_irq_save(void) { int was = g_irq_disabled_depth; g_irq_disabled_depth++; return (uint32_t)was; }
+void     smp_local_irq_restore(uint32_t s) { g_irq_disabled_depth = (int)s; }
+void     smp_raw_spin_lock(volatile uint32_t *w) { pthread_mutex_lock(&g_raw); *w = 1u; }
+void     smp_raw_spin_unlock(volatile uint32_t *w) { *w = 0u; pthread_mutex_unlock(&g_raw); }
+
+static void test_recursion_balances_irq(void) {
+    sdk_smp_lock_t l = SDK_SMP_LOCK_INIT;
+    t_cpu = 0; g_irq_disabled_depth = 0;
+    sdk_smp_lock_acquire(&l);            /* depth 0->1 */
+    assert(l.owner == 0 && l.depth == 1);
+    sdk_smp_lock_acquire(&l);            /* recursive */
+    assert(l.depth == 2);
+    sdk_smp_lock_release(&l);
+    assert(l.depth == 1 && l.owner == 0);
+    assert(g_irq_disabled_depth > 0);    /* still masked while held */
+    sdk_smp_lock_release(&l);
+    assert(l.owner == -1 && l.depth == 0);
+    assert(g_irq_disabled_depth == 0);   /* restored exactly at depth 0 */
+    printf("test_recursion_balances_irq OK\n");
+}
+
+/* 2-thread stress: increments under the lock must never race. */
+static sdk_smp_lock_t g_stress = SDK_SMP_LOCK_INIT;
+static long g_counter = 0;
+static void *worker(void *arg) {
+    int id = (int)(long)arg;
+    t_cpu = id;   /* this worker models one fixed, distinct CPU core */
+    for (int i = 0; i < 100000; i++) {
+        sdk_smp_lock_acquire(&g_stress);
+        long v = g_counter; v++; g_counter = v;
+        sdk_smp_lock_release(&g_stress);
+    }
+    return NULL;
+}
+static void test_stress_no_lost_updates(void) {
+    pthread_t a, b;
+    g_counter = 0;
+    pthread_create(&a, NULL, worker, (void*)0L);
+    pthread_create(&b, NULL, worker, (void*)1L);
+    pthread_join(a, NULL); pthread_join(b, NULL);
+    assert(g_counter == 200000);
+    printf("test_stress_no_lost_updates OK\n");
+}
+
+int main(void) {
+    test_recursion_balances_irq();
+    test_stress_no_lost_updates();
+    printf("ALL smp_lock tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Generalizes the dual-core task scheduler's executor beyond crypto and routes the one-shot decompression op (`SDK_OP_DECOMPRESS`, `0x0600`) to core 1, backed by a new SMP-safe cross-core heap lock so `malloc` is safe from core 1. This is the **foundation** for moving offload services off the ARM main loop; the one-shot decompress path is the first service to land on it.

## What's in it

- **SMP-safe heap** — recursive, IRQ-safe cross-core lock (LDREX/STREX + CPSID) backing a strong newlib `__malloc_lock`/`__malloc_unlock` override. Crypto never needed this because `sdk_crypto.c` never allocates; every decompress backend does (zlib `inflateInit2` ~40 KB, LZMA `lzma_alloc`), so core-1 `malloc` had to be made safe before any decompress could run there.
- **Generalized executor** — `scheduler_run_slot` no longer hardwires crypto; it calls `sdk_mailbox_run_offload_task(desc, payload, &len)` (opcode switch). Crypto behaviour is byte-identical (compile-asserted result-payload size).
- **Decompress on core 1** — `handle_decompress` refactored to mirror `crypto_dispatch`; the op is classified `TASK_LONG` and enqueued to the scheduler, with an inline core-0 fallback when core 1 is unavailable or the queue is full.
- **Diagnostics** — DIAG_SCHED grows a version-2 payload (16→24 bytes, additive/backward-compatible) exposing `decode_requests` and `decode_us` so the transfer-vs-decode split is measurable.
- **Deadlock-recovery fix** — if core 1 is reset (HW fault or quiesce timeout) while holding the malloc lock, the lock is released during `core1_cold_restart` / early in `record_fault`, preventing an orphaned-lock heap deadlock. (Found by whole-branch review; re-reviewed clean.)

## Hardware validation

`zz9k-inflate` selftest (5× one-shot `0x0600`) on a Zorro-3 + ZZ9000AX + 68060:
- `zz9k-info` → `offload tasks core1=5`, `decode offloads 5 requests, 492 us`.
- All 5 decodes ran on core 1 with real per-call `malloc` and no deadlock — confirms the executor, the SMP-safe heap, the result path, and the v2 counters end-to-end.

## Scope / follow-ups

This covers the **one-shot** decompress op (`gzip` / `lzma-alone` / `7z` / raw `zz9k-inflate`). It does **not** yet accelerate ZIP or LHA archive extraction: ZIP deflate uses the stateful stream/feed ops (`0x0602`–`0x0605`, still synchronous on core 0) and LHA is decoded in 68k software. Routing the stateful stream/feed ops to core 1 (which the SMP-safe heap now makes possible) plus client block-on-IRQ is the next increment.

No SDK/driver wire-ABI change beyond the additive DIAG_SCHED v2 payload; the companion `zz9k-info` v2 reader is a separate SDK PR. Firmware reflash required to pick up the new op routing.

## Testing

- Host tests: `smp_lock_test`, `offload_params_test`, scheduler suite — green.
- ARM build clean (no new warnings on the added units).