### PR TITLE
Audio streams on core 1 + AX playback binding (MHI modernization)

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
@@ -29,6 +29,7 @@ XAudioFormatter audio_formatter;
 XAudioFormatter audio_formatter_rx;
 
 static uint8_t* audio_tx_buffer = (uint8_t*)AUDIO_TX_BUFFER_ADDRESS;
+static uint8_t* audio_inited_tx_buffer = NULL;
 static uint8_t* audio_rx_buffer = (uint8_t*)AUDIO_RX_BUFFER_ADDRESS;
 
 int adau_write16(u8 i2c_addr, u16 addr, u16 value) {
@@ -295,6 +296,18 @@ void audio_init_i2s() {
 	printf("[adau] XAudioFormatterDMAStart...\n");
 	XAudioFormatterDMAStart(&audio_formatter);
 	printf("[adau] XAudioFormatterDMAStart done.\n");
+
+	audio_inited_tx_buffer = audio_tx_buffer;
+}
+
+// The TX buffer address the audio formatter DMA was last INITIALIZED
+// with. audio_set_tx_buffer() only moves the CPU-side pointer; the DMA
+// keeps reading the buffer captured at the last audio_init_i2s(). An
+// AHI session repoints the DMA at its own buffer (AP_TX_BUF_OFFS +
+// re-init) and closing AHI does not restore it, so a consumer that
+// needs the default ring must compare against this and re-init.
+uint8_t* audio_get_inited_tx_buffer() {
+	return audio_inited_tx_buffer;
 }
 
 // returns 1 if adau1701 found, otherwise 0

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
@@ -8,6 +8,7 @@
 #include "xi2stx.h"
 #include "xi2srx.h"
 #include "xaudioformatter.h"
+#include "xil_cache.h"
 #include "mntzorro.h"
 #include "interrupt.h"
 #include "sleep.h"
@@ -587,6 +588,10 @@ void audio_set_rx_buffer(uint8_t* addr) {
 
 void audio_silence() {
 	memset(audio_tx_buffer, 0, AUDIO_TX_BUFFER_SIZE);
+	// TX buffers live in plain cacheable DDR and the formatter DMA does
+	// not snoop; push the silence to DRAM so it takes effect this
+	// period rather than on eventual eviction.
+	Xil_DCacheFlushRange((INTPTR)audio_tx_buffer, AUDIO_TX_BUFFER_SIZE);
 	reset_resampling();
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
@@ -409,6 +409,9 @@ void audio_debug_timer(int zdata) {
 
 int isra_count = 0;
 
+// TX-fill half of the SDK playback pump (sdk_mailbox.c); ISR-safe.
+extern void sdk_mailbox_audio_playback_pump_isr(void);
+
 // audio formatter interrupt, triggered whenever a period is completed
 void isr_audio(void *dummy) {
 	uint32_t val = XAudioFormatter_ReadReg(XPAR_XAUDIOFORMATTER_0_BASEADDR, XAUD_FORMATTER_STS + XAUD_FORMATTER_MM2S_OFFSET);
@@ -419,6 +422,12 @@ void isr_audio(void *dummy) {
 	if (isra_count++>100) {
 		isra_count = 0;
 	}
+
+	// Keep the TX ring filled from the bound audio-stream session on a
+	// guaranteed 20 ms cadence: main-loop passes stretched by RTG or
+	// network load previously let the DMA overrun the fill frontier
+	// and glitch MP3 playback. No-op when no session is bound.
+	sdk_mailbox_audio_playback_pump_isr();
 
 	if (interrupt_enabled_audio) {
 		amiga_interrupt_set(AMIGA_INTERRUPT_AUDIO);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
@@ -477,6 +477,14 @@ void audio_set_interrupt_enabled(int en) {
 	audio_silence();
 }
 
+// Whether a legacy/AHI client currently drives the audio output: those
+// clients enable the per-period Amiga interrupt (REG_ZZ_AUDIO_CONFIG=1)
+// for the duration of playback. The SDK playback binding must not
+// steal the formatter while this is set.
+int audio_legacy_output_active() {
+	return interrupt_enabled_audio;
+}
+
 // offset = offset from audio tx buffer
 // returns audio_buffer_collision (1 or 0)
 int audio_swab(uint16_t audio_buf_samples, uint32_t offset, int byteswap) {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.h
@@ -35,6 +35,9 @@ void audio_init_i2s();
 void isr_audio(void *dummy);
 void isr_audio_rx(void *dummy);
 void audio_set_interrupt_enabled(int en);
+/* Nonzero while a legacy/AHI client drives the audio output (it keeps
+ * the per-period Amiga interrupt enabled during playback). */
+int audio_legacy_output_active(void);
 void audio_clear_interrupt();
 uint32_t audio_get_interrupt();
 uint32_t audio_get_dma_transfer_count();

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.h
@@ -41,6 +41,8 @@ uint32_t audio_get_dma_transfer_count();
 int audio_swab(uint16_t audio_buf_samples, uint32_t offset, int byteswap);
 void audio_set_tx_buffer(uint8_t* addr);
 void audio_set_rx_buffer(uint8_t* addr);
+/* TX buffer the formatter DMA was last initialized with (see ax.c). */
+uint8_t* audio_get_inited_tx_buffer(void);
 void resample_s16(int16_t *input, int16_t *output,
 		int in_sample_rate, int out_sample_rate, int output_samples);
 void audio_silence();

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -400,15 +400,6 @@ int main() {
 	int audio_param = 0; // selected parameter
 	int audio_request_init = 0;
 
-	// decoder parameters (mp3 etc)
-	const int ZZ_NUM_DECODER_PARAMS = 8;
-	uint16_t decoder_params[ZZ_NUM_DECODER_PARAMS];
-	int decoder_param = 0; // selected parameter
-	int decoder_bytes_decoded = 0;
-	// legacy register-driven MP3 FIFO decoder state; the SDK DECODE_MP3
-	// paths own their own contexts (sdk_mailbox.c), so the two can no
-	// longer corrupt each other's stream
-	static struct mp3_decode_ctx legacy_mp3_ctx;
 
 	// last time the ethernet state machine was serviced
 	XTime eth_task_last_run = 0;
@@ -1304,71 +1295,12 @@ int main() {
 						audio_adau_set_vol_pan(zdata&0xff, (zdata>>8)&0xff);
 					}
 					break;
-				case REG_ZZ_DECODER_PARAM:
-					if (zdata<ZZ_NUM_DECODER_PARAMS) {
-						decoder_param = zdata;
-					} else {
-						decoder_param = 0;
-					}
-					break;
-				case REG_ZZ_DECODER_VAL:
-					decoder_params[decoder_param] = zdata;
-					break;
-				case REG_ZZ_DECODER_FIFO:
-					fifo_set_write_index(&legacy_mp3_ctx, zdata);
-					break;
-				case REG_ZZ_DECODE:
-					{
-						// DECODER PARAMS:
-						// 0: input buffer offset hi
-						// 1: input buffer offset lo
-						// 2: input buffer size hi
-						// 3: input buffer size lo
-						// 4: output buffer offset hi
-						// 5: output buffer offset lo
-						// 6: output buffer size hi
-						// 7: output buffer size lo
-
-						uint8_t* input_buffer = (uint8_t*)video_state->framebuffer
-								+ ((decoder_params[0]<<16)|decoder_params[1]);
-						size_t input_buffer_size = (decoder_params[2]<<16)|decoder_params[3];
-
-						uint8_t* output_buffer = (uint8_t*)video_state->framebuffer
-								+ ((decoder_params[4]<<16)|decoder_params[5]);
-						size_t output_buffer_size = (decoder_params[6]<<16)|decoder_params[7];
-
-						switch(zdata) {
-							case DECODE_CLEAR:
-								printf("[decode:clear]\n");
-								fifo_clear(&legacy_mp3_ctx);
-							break;
-							case DECODE_INIT:
-								printf("[decode:mp3:%d] %p (%x) -> %p (%x)\n", (int)zdata, input_buffer, input_buffer_size,
-										output_buffer, output_buffer_size);
-								decode_mp3_init_fifo(&legacy_mp3_ctx, input_buffer, input_buffer_size);
-								decoder_bytes_decoded = -1;
-							break;
-							case DECODE_RUN: {
-								int max_samples = output_buffer_size;
-								int mp3_freq = mp3_get_hz(&legacy_mp3_ctx);
-								if (mp3_freq != 48000) {
-									uint8_t* temp_buffer = output_buffer + AUDIO_TX_BUFFER_SIZE; // FIXME hack
-									max_samples = mp3_get_hz(&legacy_mp3_ctx)/50 * 2;
-								
-									decoder_bytes_decoded = decode_mp3_samples(&legacy_mp3_ctx, temp_buffer, max_samples);
-								
-									// resample
-									resample_s16((int16_t*)temp_buffer, (int16_t*)output_buffer,
-											mp3_get_hz(&legacy_mp3_ctx), 48000, AUDIO_BYTES_PER_PERIOD / 4);
-								
-								} else {
-									decoder_bytes_decoded = decode_mp3_samples(&legacy_mp3_ctx, output_buffer, max_samples);
-								}
-							}
-							break;
-						}
-						break;
-					}
+				// REG_ZZ_DECODER_PARAM / _VAL / _FIFO and REG_ZZ_DECODE:
+				// the legacy register-driven MP3 decoder was removed with
+				// the MHI modernization (its only consumer). MP3 decode
+				// runs through the SDK audio-stream sessions on core 1,
+				// with SDK_OP_AUDIO_STREAM_PLAY binding a session to the
+				// AX output. Writes to those registers are ignored.
 				}
 			}
 
@@ -1518,9 +1450,9 @@ int main() {
 						break;
 					}
 					case REG_ZZ_AUDIO_SWAB: {
-						// misc status bits
-						//printf("read 0x70: %d\n", audio_buffer_collision);
-						data = (audio_buffer_collision)<<16 | fifo_get_read_index(&legacy_mp3_ctx);
+						// misc status bits (low word was the legacy MP3
+						// FIFO read index; that decoder is gone)
+						data = (audio_buffer_collision)<<16;
 						break;
 					}
 					case REG_ZZ_AUDIO_CONFIG: {
@@ -1529,8 +1461,8 @@ int main() {
 						break;
 					}
 					case REG_ZZ_DECODER_VAL: {
-						// used to determine if MP3 decoding has finished
-						data = decoder_bytes_decoded;
+						// legacy MP3 decoder removed; reads as 0
+						data = 0;
 						break;
 					}
 					case REG_ZZ_ETH_RX_STATUS: {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -1621,6 +1621,10 @@ int main() {
 				}
 			}
 
+			// keep the AX TX ring fed from a bound audio-stream session
+			// (SDK_OP_AUDIO_STREAM_PLAY); no-op when nothing is bound
+			sdk_mailbox_audio_playback_pump();
+
 			if (sdk_mailbox_register_events) {
 				uint32_t events = sdk_mailbox_register_events;
 				sdk_mailbox_register_events = 0;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
@@ -107,7 +107,18 @@
 #define SDK_IMAGE_SESSIONS_ADDRESS \
     (SDK_TASKQ_REGION_ADDRESS + SDK_IMAGE_SESSIONS_OFFSET)
 #define SDK_IMAGE_SESSIONS_MAX_BYTES \
-    (SDK_TASKQ_REGION_SIZE - SDK_IMAGE_SESSIONS_OFFSET)
+    (SDK_AUDIO_STREAMS_OFFSET - SDK_IMAGE_SESSIONS_OFFSET)
+
+// Audio-stream session table, also inside the coherent region: streams may
+// be core-1-affine (feed/decode on the worker) while core 0 begins/closes
+// them. No heap objects hang off these (the decoder state is embedded), so
+// unlike the image sessions they need no fault-reclaim gating. Size guarded
+// in sdk_mailbox.c.
+#define SDK_AUDIO_STREAMS_OFFSET    0x000C0000
+#define SDK_AUDIO_STREAMS_ADDRESS \
+    (SDK_TASKQ_REGION_ADDRESS + SDK_AUDIO_STREAMS_OFFSET)
+#define SDK_AUDIO_STREAMS_MAX_BYTES \
+    (SDK_TASKQ_REGION_SIZE - SDK_AUDIO_STREAMS_OFFSET)
 
 #if SDK_TASKQ_REGION_ADDRESS < 0x18000000
 #error "task-queue region must sit above the linker-managed DDR (ends 0x18000000)"

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/mp3/decode_mp3.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/mp3/decode_mp3.c
@@ -5,67 +5,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <xil_cache.h>
 #define MINIMP3_IMPLEMENTATION 1
 #include "mp3.h"
-
-#define SWAP16(a) a = __builtin_bswap16(a)
-#define SWAP32(a) a = __builtin_bswap32(a)
-
-static size_t read_cb(void *buf, size_t size, void *user_data) {
-	struct mp3_decode_ctx *ctx = user_data;
-	unsigned long BytesRead = 0;
-	long BytesToRead = size;
-	unsigned char *src = ctx->fifo_addr;
-	unsigned char *dst = buf;
-
-	while(BytesToRead) {
-		// If FiFo is empty then exit the loop.
-		if(ctx->fifo_read_idx == ctx->fifo_write_idx) break;
-		dst[BytesRead++] = src[ctx->fifo_read_idx++];
-		if(ctx->fifo_read_idx >= ctx->fifo_size) ctx->fifo_read_idx = 0;
-		BytesToRead--;
-	}
-
-	return BytesRead;
-}
-
-static int seek_cb(uint64_t position, void *user_data) {
-	struct mp3_decode_ctx *ctx = user_data;
-
-	ctx->fifo_read_idx = position % ctx->fifo_size;
-	return 0;
-}
-
-void fifo_clear(struct mp3_decode_ctx *ctx) {
-	ctx->fifo_read_idx  = 0;
-	ctx->fifo_write_idx = 0;
-}
-
-void fifo_set_write_index(struct mp3_decode_ctx *ctx,
-                          unsigned short aWriteIndex) {
-	ctx->fifo_write_idx = aWriteIndex;
-	// New data has arrived from the 68k size.
-	// We need to invalidate the data cache where the data came in.
-	if(ctx->fifo_write_idx > ctx->old_fifo_write_idx) {
-		// Invalidate range from old til new.
-		Xil_DCacheInvalidateRange((INTPTR)&ctx->fifo_addr[ctx->old_fifo_write_idx],
-		                          ctx->fifo_write_idx-ctx->old_fifo_write_idx);
-	}
-	else {
-		// 1. Invalidate range from old til end.
-		Xil_DCacheInvalidateRange((INTPTR)&ctx->fifo_addr[ctx->old_fifo_write_idx],
-		                          ctx->fifo_size-ctx->old_fifo_write_idx);
-		// 2. Invalidate range from beginning til new.
-		Xil_DCacheInvalidateRange((INTPTR)&ctx->fifo_addr[0],
-		                          ctx->fifo_write_idx);
-	}
-	ctx->old_fifo_write_idx = ctx->fifo_write_idx;
-}
-
-unsigned short fifo_get_read_index(const struct mp3_decode_ctx *ctx) {
-	return ctx->fifo_read_idx;
-}
 
 int decode_mp3_samples(struct mp3_decode_ctx *ctx, void* output_buffer,
                        int max_samples) {
@@ -103,24 +44,6 @@ int decode_mp3_samples(struct mp3_decode_ctx *ctx, void* output_buffer,
 	}
 
 	return total_bytes_decoded;
-}
-
-int decode_mp3_init_fifo(struct mp3_decode_ctx *ctx, uint8_t* input_buffer,
-                         size_t input_buffer_size) {
-	memset(&ctx->frame_info, 0, sizeof(ctx->frame_info));
-
-	ctx->fifo_size   = input_buffer_size;
-	ctx->fifo_addr   = input_buffer;
-	ctx->mp3io.read = read_cb;
-	ctx->mp3io.seek = seek_cb;
-	ctx->mp3io.read_data = ctx->mp3io.seek_data = ctx;
-
-	int ret = mp3dec_ex_open_cb(&ctx->mp3d, &ctx->mp3io, MP3D_DO_NOT_SCAN);
-	if (ret) {
-		printf("mp3dec_ex_open_cb failed: %d\n", ret);
-	}
-
-	return ret;
 }
 
 int decode_mp3_init(struct mp3_decode_ctx *ctx, uint8_t* input_buffer,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/mp3/mp3.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/mp3/mp3.h
@@ -12,40 +12,22 @@
 #include "mp3_backend_config.h"
 #include "minimp3_ex.h"
 
-typedef enum {
-	DECODE_CLEAR,
-	DECODE_INIT,
-	DECODE_RUN
-} DECODE_COMMAND;
-
 /*
- * Per-decoder state. Historically file-global in decode_mp3.c, which made
- * the SDK DECODE_MP3 handler and the legacy register-driven FIFO path
- * (main.c) corrupt each other's stream, and blocked routing the SDK op to
- * core 1. Each caller now owns a context: main.c keeps the legacy FIFO
- * one; sdk_mailbox.c keeps one for the core-0 inline path and one for the
- * core-1 runner. Each context is used by exactly one core, so no cache
- * maintenance is needed on the context itself.
+ * Per-decoder state for the SDK one-shot DECODE_MP3 op. sdk_mailbox.c owns
+ * one context for the core-0 inline path and one for the core-1 runner;
+ * each context is used by exactly one core, so no cache maintenance is
+ * needed on the context itself. (The FIFO/streaming half of this API --
+ * the legacy register-driven decoder -- was removed with the MHI
+ * modernization; streaming MP3 now runs through the SDK audio-stream
+ * sessions and the AX playback pump.)
  */
 struct mp3_decode_ctx {
 	mp3dec_ex_t mp3d;
-	mp3dec_io_t mp3io;
 	mp3dec_frame_info_t frame_info;
-	uint8_t *fifo_addr;
-	unsigned long fifo_size;
-	unsigned short old_fifo_write_idx;
-	unsigned short fifo_write_idx;
-	unsigned short fifo_read_idx;
 };
 
 int decode_mp3_init(struct mp3_decode_ctx *ctx, uint8_t *input_buffer,
                     size_t input_buffer_size);
-int decode_mp3_init_fifo(struct mp3_decode_ctx *ctx, uint8_t *input_buffer,
-                         size_t input_buffer_size);
-void fifo_clear(struct mp3_decode_ctx *ctx);
-void fifo_set_write_index(struct mp3_decode_ctx *ctx,
-                          unsigned short aWriteIndex);
-unsigned short fifo_get_read_index(const struct mp3_decode_ctx *ctx);
 int decode_mp3_samples(struct mp3_decode_ctx *ctx, void *output_buffer,
                        int max_samples);
 int mp3_get_hz(const struct mp3_decode_ctx *ctx);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.c
@@ -261,6 +261,11 @@ taskq_class_t taskq_class_for_opcode(uint32_t opcode, uint32_t in_len)
     /* MUST stay LONG regardless of size: the session codec state lives
      * in core 1's cache, so a core-0 SHORT drain would corrupt it. */
     return TASK_LONG;
+  case TASKQ_OP_AUDIO_STREAM_FEED:
+  case TASKQ_OP_AUDIO_STREAM_READ:
+    /* Same constraint: the stream's mp3 staging ring is cache-owned by
+     * core 1 for core-1-affine streams. */
+    return TASK_LONG;
   default:
     return TASK_LONG;              /* unknown/heavy: never drained on core 0 */
   }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler.h
@@ -49,6 +49,12 @@
 #define TASKQ_OP_IMAGE_SESSION_FEED  0x0405u
 #define TASKQ_OP_IMAGE_SESSION_CLOSE 0x0406u
 
+/* Audio-stream opcodes mirrored from sdk_mailbox.h. A core-1-affine
+ * stream's mp3 staging ring is cache-owned by core 1, so feed/read (both
+ * run the decoder) must ONLY execute there: TASK_LONG unconditionally. */
+#define TASKQ_OP_AUDIO_STREAM_FEED   0x0504u
+#define TASKQ_OP_AUDIO_STREAM_READ   0x0505u
+
 typedef enum {
   TASK_FREE    = 0,
   TASK_QUEUED  = 1,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/scheduler_arm.c
@@ -45,7 +45,9 @@ typedef char sched_image_opcode_drift_check[
      TASKQ_OP_DECODE_JPEG == SDK_OP_DECODE_JPEG &&
      TASKQ_OP_DECODE_MP3 == SDK_OP_DECODE_MP3 &&
      TASKQ_OP_IMAGE_SESSION_FEED == SDK_OP_IMAGE_SESSION_FEED &&
-     TASKQ_OP_IMAGE_SESSION_CLOSE == SDK_OP_IMAGE_SESSION_CLOSE) ? 1 : -1];
+     TASKQ_OP_IMAGE_SESSION_CLOSE == SDK_OP_IMAGE_SESSION_CLOSE &&
+     TASKQ_OP_AUDIO_STREAM_FEED == SDK_OP_AUDIO_STREAM_FEED &&
+     TASKQ_OP_AUDIO_STREAM_READ == SDK_OP_AUDIO_STREAM_READ) ? 1 : -1];
 
 /* The image-session table shares the coherent region with the queue
  * control block; keep them from overlapping. */
@@ -283,8 +285,11 @@ void scheduler_core0_poll(int zorro_pending, int display_pending)
     /* Core-1-affine image sessions lost their codec heap objects with the
      * fault (cold_restart's reclaim frees them; on permanent disable they
      * are parked-unreachable). Drop the dangling references in BOTH
-     * branches so core 0 never destroys against reclaimed memory. */
+     * branches so core 0 never destroys against reclaimed memory. Audio
+     * streams hold no heap objects, but their embedded decoder state may
+     * be mid-frame; mark them faulted so feeds/reads fail cleanly. */
     sdk_image_stream_poison_core1_sessions();
+    sdk_mailbox_poison_core1_audio_streams();
     if (taskq_watchdog_core1_enabled(&g_sched_watchdog)) {
       core1_cold_restart();
     } else {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -5971,6 +5971,51 @@ static uint16_t handle_query_service(volatile struct SDKMailboxEntry *req,
 	return SDK_STATUS_OK;
 }
 
+/*
+ * request_id 0 is the firmware-internal marker for deferred scheduler
+ * tasks that have no client completion to post: the AX playback refill
+ * enqueues with id 0, and sdk_mailbox_post_deferred swallows that
+ * completion (and retires the in-flight marker) instead of writing it to
+ * the client completion ring. A CLIENT request that carries id 0 and
+ * then takes a deferred path collides with that marker -- its completion
+ * would be swallowed (hanging the caller) and it would spuriously retire
+ * the refill marker -- so only opcodes that can defer to core 1 reserve
+ * id 0. Every opcode below routes through post_deferred via one of the
+ * deferral helpers (service_try_defer / crypto_dispatch /
+ * decompress_dispatch / handle_decompress_batch); keep this list in sync
+ * with the handlers that can return SDK_STATUS_QUEUED.
+ *
+ * Inline-only opcodes (NOP, PING, QUERY_*, ALLOC_*, MEM_*, the surface
+ * and audio/decompress control ops, ...) complete synchronously and just
+ * echo the client's request_id, so a client whose request counter starts
+ * at 0 keeps working -- request_id is an echoed token the ABI never
+ * reserved. (zz9k.library's own generator never emits 0 anyway,
+ * including on wrap.)
+ */
+static int opcode_reserves_request_id_zero(uint16_t opcode)
+{
+	switch (opcode) {
+	case SDK_OP_SCALE_IMAGE:
+	case SDK_OP_SCALE_IMAGE_CLIPPED:
+	case SDK_OP_DECODE_JPEG:
+	case SDK_OP_DECODE_MP3:
+	case SDK_OP_AUDIO_STREAM_FEED:
+	case SDK_OP_AUDIO_STREAM_READ:
+	case SDK_OP_IMAGE_SESSION_FEED:
+	case SDK_OP_IMAGE_SESSION_CLOSE:
+	case SDK_OP_DECOMPRESS:
+	case SDK_OP_DECOMPRESS_BATCH:
+	case SDK_OP_CRYPTO_HASH:
+	case SDK_OP_CRYPTO_STREAM:
+	case SDK_OP_CRYPTO_AEAD:
+	case SDK_OP_CRYPTO_KX:
+	case SDK_OP_CRYPTO_VERIFY:
+		return 1;
+	default:
+		return 0;
+	}
+}
+
 static uint16_t handle_request(volatile struct SDKMailboxEntry *req,
                                volatile struct SDKMailboxEntry *comp,
                                uint32_t pending_requests)
@@ -5981,15 +6026,11 @@ static uint16_t handle_request(volatile struct SDKMailboxEntry *req,
 	if (payload_len > sizeof(req->payload))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
 
-	/* request_id 0 is reserved for firmware-internal scheduler tasks
-	 * (the AX playback refill): their deferred completion is swallowed
-	 * by sdk_mailbox_post_deferred instead of being posted to the
-	 * client ring. A client request carrying id 0 that took a deferred
-	 * path would therefore hang its caller and spuriously retire the
-	 * refill marker -- reject it up front so the reservation is
-	 * enforced, not assumed. zz9k.library never emits id 0 (its
-	 * generator skips it, including on wrap). */
-	if (get_be32(req->request_id) == 0U)
+	/* Reserve request_id 0 only for opcodes that can defer to the core-1
+	 * scheduler; inline-only ops accept it as an echoed token (see
+	 * opcode_reserves_request_id_zero). */
+	if (get_be32(req->request_id) == 0U &&
+	    opcode_reserves_request_id_zero(opcode))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
 
 	switch (opcode) {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -665,6 +665,27 @@ typedef char mp3_op_params_size_check[
     (sizeof(struct mp3_op_params) <= TASKQ_OP_PARAM_BYTES) ? 1 : -1];
 
 /*
+ * Native-endian packed parameters for deferred AUDIO_STREAM_FEED/READ
+ * tasks. The stream table lives in the SCU-coherent region (core 1 may
+ * look sessions up directly); the feed source is resolved on core 0.
+ */
+struct audio_feed_op_params {
+	uint32_t session;
+	uint32_t src_addr;      /* resolved src + offset; 0 for EOF-only */
+	uint32_t src_len;
+	uint32_t flags;
+};
+
+struct audio_read_op_params {
+	uint32_t session;
+	uint32_t pcm_read;      /* validated against pcm_used on core 0 */
+};
+
+typedef char audio_op_params_size_check[
+    (sizeof(struct audio_feed_op_params) <= TASKQ_OP_PARAM_BYTES &&
+     sizeof(struct audio_read_op_params) <= TASKQ_OP_PARAM_BYTES) ? 1 : -1];
+
+/*
  * Native-endian packed parameters for deferred IMAGE_SESSION_FEED/CLOSE
  * tasks. The session lives in the SCU-coherent table (visible to both
  * cores); the source shared buffer is resolved on core 0. A core-1-affine
@@ -708,6 +729,17 @@ struct SDKAudioStream {
 	int backpressure;
 	int vbr_checked;
 	int decode_complete;
+	/* Ring addresses resolved from the shared-buffer registry at BEGIN:
+	 * the registry is core-0-only, so core-1 feeds/reads must never
+	 * dereference mp3_ring/pcm_ring -- they use these instead. */
+	uint32_t mp3_ring_addr;
+	uint32_t pcm_ring_addr;
+	/* Fixed at BEGIN: nonzero = feed/read run on the core-1 worker (the
+	 * mp3 staging ring is then cache-owned by core 1). */
+	uint32_t core1_affine;
+	/* Set when a core-1 fault may have left the embedded decoder state
+	 * mid-frame; feeds/reads answer IO_ERROR, close still works. */
+	uint32_t faulted;
 	mp3dec_t decoder;
 	mp3d_sample_t scratch[MINIMP3_MAX_SAMPLES_PER_FRAME];
 };
@@ -890,7 +922,20 @@ static int g_request_is_batch_tail;
 static uint16_t sdk_status;
 static struct SDKSharedBuffer shared_buffers[SDK_MAX_SHARED_BUFFERS];
 static struct SDKSurface surfaces[SDK_MAX_SURFACES];
-static struct SDKAudioStream audio_streams[SDK_MAX_AUDIO_STREAMS];
+
+/*
+ * The audio-stream table lives in the SCU-coherent scheduler region
+ * (SDK_AUDIO_STREAMS_ADDRESS, memorymap.h): core-1-affine streams decode
+ * on the worker while core 0 begins/closes them, and the coherent section
+ * makes the embedded decoder/cursor state visible to both cores without
+ * manual cache maintenance. No heap objects hang off a stream.
+ */
+static struct SDKAudioStream *const audio_streams =
+    (struct SDKAudioStream *)SDK_AUDIO_STREAMS_ADDRESS;
+
+typedef char audio_streams_fit_check[
+    (SDK_MAX_AUDIO_STREAMS * sizeof(struct SDKAudioStream) <=
+     SDK_AUDIO_STREAMS_MAX_BYTES) ? 1 : -1];
 static uint32_t next_shared_handle;
 static uint32_t next_surface_handle;
 static uint32_t next_audio_stream_id;
@@ -2678,6 +2723,16 @@ static void free_audio_stream(struct SDKAudioStream *stream)
 		memset(stream, 0, sizeof(*stream));
 }
 
+void sdk_mailbox_poison_core1_audio_streams(void)
+{
+	uint32_t i;
+
+	for (i = 0; i < SDK_MAX_AUDIO_STREAMS; i++) {
+		if (audio_streams[i].id != 0U && audio_streams[i].core1_affine)
+			audio_streams[i].faulted = 1U;
+	}
+}
+
 static uint32_t audio_stream_pcm_free(const struct SDKAudioStream *stream)
 {
 	if (!stream || stream->pcm_used >= stream->pcm_capacity)
@@ -2706,7 +2761,7 @@ static void flush_audio_pcm_written(const struct SDKAudioStream *stream,
 static void audio_stream_pcm_write(struct SDKAudioStream *stream,
                                    const uint8_t *src, uint32_t bytes)
 {
-	uint8_t *dst = (uint8_t *)(uintptr_t)stream->pcm_ring->address;
+	uint8_t *dst = (uint8_t *)(uintptr_t)stream->pcm_ring_addr;
 	uint32_t first = stream->pcm_capacity - stream->pcm_write;
 
 	if (first > bytes)
@@ -2748,7 +2803,7 @@ static void audio_stream_compact_input(struct SDKAudioStream *stream)
 
 	if (!stream || stream->input_offset == 0U || stream->input_length == 0U)
 		return;
-	input = (uint8_t *)(uintptr_t)stream->mp3_ring->address;
+	input = (uint8_t *)(uintptr_t)stream->mp3_ring_addr;
 	memmove(input, input + stream->input_offset, stream->input_length);
 	stream->input_offset = 0U;
 }
@@ -2832,10 +2887,11 @@ static uint32_t audio_stream_decode(struct SDKAudioStream *stream)
 	uint8_t *input;
 	uint8_t *pcm_dst;
 
-	if (!stream || !stream->mp3_ring || !stream->pcm_ring)
+	if (!stream || stream->mp3_ring_addr == 0U ||
+	    stream->pcm_ring_addr == 0U)
 		return 0;
-	input = (uint8_t *)(uintptr_t)stream->mp3_ring->address;
-	pcm_dst = (uint8_t *)(uintptr_t)stream->pcm_ring->address;
+	input = (uint8_t *)(uintptr_t)stream->mp3_ring_addr;
+	pcm_dst = (uint8_t *)(uintptr_t)stream->pcm_ring_addr;
 	if (stream->decode_complete) {
 		if (stream->input_length != 0U) {
 			audio_stream_discard_input(stream);
@@ -2968,20 +3024,15 @@ static uint32_t audio_stream_result_flags(const struct SDKAudioStream *stream)
 	return flags;
 }
 
-static uint16_t complete_audio_stream_result(
-	volatile struct SDKMailboxEntry *req,
-	volatile struct SDKMailboxEntry *comp,
-	uint16_t status,
-	const struct SDKAudioStream *stream)
+/* Fill a big-endian SDKAudioStreamResultPayload; shared by the inline
+ * completion below and the core-1 runner's deferred result. */
+static void audio_stream_fill_result(uint8_t *dst,
+                                     const struct SDKAudioStream *stream)
 {
-	volatile struct SDKAudioStreamResultPayload *result;
+	struct SDKAudioStreamResultPayload *result =
+	    (struct SDKAudioStreamResultPayload *)dst;
 
-	if (status != SDK_STATUS_OK)
-		return complete_status(req, comp, status);
-
-	write_completion(comp, req, SDK_STATUS_OK, sizeof(*result));
-	memset((void *)comp->payload, 0, sizeof(comp->payload));
-	result = (volatile struct SDKAudioStreamResultPayload *)comp->payload;
+	memset(dst, 0, sizeof(*result));
 	put_be32(result->session, stream->id);
 	put_be32(result->state, audio_stream_state(stream));
 	put_be32(result->sample_rate, stream->sample_rate);
@@ -2994,7 +3045,68 @@ static uint16_t complete_audio_stream_result(
 	put_be32(result->bytes_consumed, stream->bytes_consumed);
 	put_be32(result->bytes_produced, stream->bytes_produced);
 	put_be32(result->flags, audio_stream_result_flags(stream));
+}
+
+static uint16_t complete_audio_stream_result(
+	volatile struct SDKMailboxEntry *req,
+	volatile struct SDKMailboxEntry *comp,
+	uint16_t status,
+	const struct SDKAudioStream *stream)
+{
+	uint8_t local[sizeof(struct SDKAudioStreamResultPayload)];
+
+	if (status != SDK_STATUS_OK)
+		return complete_status(req, comp, status);
+
+	audio_stream_fill_result(local, stream);
+	write_completion(comp, req, SDK_STATUS_OK, sizeof(local));
+	memset((void *)comp->payload, 0, sizeof(comp->payload));
+	memcpy((void *)comp->payload, local, sizeof(local));
 	return SDK_STATUS_OK;
+}
+
+/*
+ * Feed/read compute, shared by the core-0 inline paths and the core-1
+ * runner. Everything here operates on the coherent stream struct, the
+ * stream's cached ring addresses, and the resolved feed source -- no
+ * registry or video state. Cache maintenance (source invalidate, PCM
+ * flush inside audio_stream_decode) runs on whichever core executes.
+ */
+static void audio_stream_feed_compute(struct SDKAudioStream *stream,
+                                      uint32_t src_addr, uint32_t src_length,
+                                      uint32_t flags)
+{
+	uint8_t *dst;
+
+	if (src_length != 0U) {
+		if (src_length > stream->mp3_capacity - stream->input_length) {
+			/* Result reflects backpressure; EOF/decode skipped,
+			 * exactly as the pre-scheduler handler behaved. */
+			stream->backpressure = 1;
+			return;
+		}
+		if (stream->input_offset + stream->input_length + src_length >
+		    stream->mp3_capacity) {
+			audio_stream_compact_input(stream);
+		}
+		Xil_DCacheInvalidateRange((INTPTR)src_addr, src_length);
+		dst = (uint8_t *)(uintptr_t)stream->mp3_ring_addr;
+		memcpy(dst + stream->input_offset + stream->input_length,
+		       (const void *)(uintptr_t)src_addr, src_length);
+		stream->input_length += src_length;
+		stream->backpressure = 0;
+	}
+	if ((flags & SDK_AUDIO_STREAM_FEED_EOF) != 0U)
+		stream->eof = 1;
+	audio_stream_decode(stream);
+}
+
+static void audio_stream_read_compute(struct SDKAudioStream *stream,
+                                      uint32_t pcm_read)
+{
+	stream->pcm_read = (stream->pcm_read + pcm_read) % stream->pcm_capacity;
+	stream->pcm_used -= pcm_read;
+	audio_stream_decode(stream);
 }
 
 static uint16_t handle_audio_stream_begin(volatile struct SDKMailboxEntry *req,
@@ -3049,11 +3161,18 @@ static uint16_t handle_audio_stream_begin(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_NO_MEMORY);
 	stream->mp3_ring = mp3_ring;
 	stream->pcm_ring = pcm_ring;
+	/* Resolved once here: core-1 feeds/reads use these instead of the
+	 * core-0-only shared-buffer registry entries above. */
+	stream->mp3_ring_addr = mp3_ring->address;
+	stream->pcm_ring_addr = pcm_ring->address;
 	stream->mp3_capacity = mp3_capacity;
 	stream->pcm_capacity = pcm_capacity & ~1UL;
 	stream->low_water_bytes = low_water_bytes;
 	stream->high_water_bytes = high_water_bytes & ~1UL;
 	stream->sample_format = output_format;
+	/* Affinity is fixed for the stream's whole life: the mp3 staging
+	 * ring becomes cache-owned by whichever core runs the decoder. */
+	stream->core1_affine = scheduler_core1_available() ? 1U : 0U;
 	mp3dec_init(&stream->decoder);
 	stream->initialized = 1;
 	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, stream);
@@ -3070,7 +3189,6 @@ static uint16_t handle_audio_stream_feed(volatile struct SDKMailboxEntry *req,
 	uint32_t src_offset;
 	uint32_t src_length;
 	uint32_t flags;
-	uint8_t *dst;
 
 	if (payload_len < sizeof(*payload))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
@@ -3084,33 +3202,37 @@ static uint16_t handle_audio_stream_feed(volatile struct SDKMailboxEntry *req,
 	flags = get_be32(payload->flags);
 	if ((flags & ~SDK_AUDIO_STREAM_FEED_EOF) != 0U)
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+	if (stream->faulted)
+		return complete_status(req, comp, SDK_STATUS_IO_ERROR);
+	src_offset = 0U;
 	if (src_length != 0U) {
 		src = find_shared_buffer(get_be32(payload->src_handle));
 		src_offset = get_be32(payload->src_offset);
 		if (!src || !buffer_range_valid(src, src_offset, src_length))
 			return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
-		if (src_length > stream->mp3_capacity - stream->input_length) {
-			stream->backpressure = 1;
-			return complete_audio_stream_result(req, comp,
-			                                   SDK_STATUS_OK,
-			                                   stream);
-		}
-		if (stream->input_offset + stream->input_length + src_length >
-		    stream->mp3_capacity) {
-			audio_stream_compact_input(stream);
-		}
-		Xil_DCacheInvalidateRange((INTPTR)(src->address + src_offset),
-		                          src_length);
-		dst = (uint8_t *)(uintptr_t)stream->mp3_ring->address;
-		memcpy(dst + stream->input_offset + stream->input_length,
-		       (const void *)(uintptr_t)(src->address + src_offset),
-		       src_length);
-		stream->input_length += src_length;
-		stream->backpressure = 0;
+		src_offset += src->address;   /* resolved source address */
 	}
-	if ((flags & SDK_AUDIO_STREAM_FEED_EOF) != 0U)
-		stream->eof = 1;
-	audio_stream_decode(stream);
+
+	if (stream->core1_affine && scheduler_core1_available()) {
+		struct audio_feed_op_params p;
+
+		p.session = session;
+		p.src_addr = (src_length != 0U) ? src_offset : 0U;
+		p.src_len = src_length;
+		p.flags = flags;
+		if (service_try_defer(SDK_OP_AUDIO_STREAM_FEED, req, &p,
+		                      sizeof(p), src_length) ==
+		    SDK_STATUS_QUEUED)
+			return SDK_STATUS_QUEUED;
+		/* A core-1-affine stream cannot decode on core 0 (its mp3
+		 * staging ring is cache-owned by core 1). The sole synchronous
+		 * client sends stream ops singly, so a refused defer means a
+		 * full queue -- transient; answer BUSY rather than corrupt. */
+		return complete_status(req, comp, SDK_STATUS_BUSY);
+	}
+	/* Core-0-affine stream: inline, as the pre-scheduler firmware did. */
+	audio_stream_feed_compute(stream, (src_length != 0U) ? src_offset : 0U,
+	                          src_length, flags);
 	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, stream);
 }
 
@@ -3135,9 +3257,23 @@ static uint16_t handle_audio_stream_read(volatile struct SDKMailboxEntry *req,
 	flags = get_be32(payload->flags);
 	if (flags != 0U || pcm_read > stream->pcm_used)
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
-	stream->pcm_read = (stream->pcm_read + pcm_read) % stream->pcm_capacity;
-	stream->pcm_used -= pcm_read;
-	audio_stream_decode(stream);
+	if (stream->faulted)
+		return complete_status(req, comp, SDK_STATUS_IO_ERROR);
+
+	if (stream->core1_affine && scheduler_core1_available()) {
+		struct audio_read_op_params p;
+
+		p.session = session;
+		p.pcm_read = pcm_read;
+		if (service_try_defer(SDK_OP_AUDIO_STREAM_READ, req, &p,
+		                      sizeof(p), 0U) == SDK_STATUS_QUEUED)
+			return SDK_STATUS_QUEUED;
+		/* See the feed path: never run the decoder on core 0 for a
+		 * core-1-affine stream. */
+		return complete_status(req, comp, SDK_STATUS_BUSY);
+	}
+	/* Core-0-affine stream: inline, as the pre-scheduler firmware did. */
+	audio_stream_read_compute(stream, pcm_read);
 	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, stream);
 }
 
@@ -4005,6 +4141,37 @@ uint16_t sdk_mailbox_run_offload_task(const taskq_desc_t *d,
 
 		*result_len = 0;
 		return sdk_image_stream_close(p->session);
+	}
+	case SDK_OP_AUDIO_STREAM_FEED: {
+		const struct audio_feed_op_params *p =
+		    (const struct audio_feed_op_params *)d->op_params;
+		struct SDKAudioStream *stream = find_audio_stream(p->session);
+
+		*result_len = 0;
+		if (!stream)
+			return SDK_STATUS_BAD_HANDLE;
+		if (stream->faulted)
+			return SDK_STATUS_IO_ERROR;
+		audio_stream_feed_compute(stream, p->src_addr, p->src_len,
+		                          p->flags);
+		audio_stream_fill_result(result_payload, stream);
+		*result_len = sizeof(struct SDKAudioStreamResultPayload);
+		return SDK_STATUS_OK;
+	}
+	case SDK_OP_AUDIO_STREAM_READ: {
+		const struct audio_read_op_params *p =
+		    (const struct audio_read_op_params *)d->op_params;
+		struct SDKAudioStream *stream = find_audio_stream(p->session);
+
+		*result_len = 0;
+		if (!stream)
+			return SDK_STATUS_BAD_HANDLE;
+		if (stream->faulted)
+			return SDK_STATUS_IO_ERROR;
+		audio_stream_read_compute(stream, p->pcm_read);
+		audio_stream_fill_result(result_payload, stream);
+		*result_len = sizeof(struct SDKAudioStreamResultPayload);
+		return SDK_STATUS_OK;
 	}
 	case SDK_OP_DECOMPRESS: {
 		const struct decompress_op_params *p =
@@ -5456,7 +5623,15 @@ void sdk_mailbox_init(void)
 	timing_decode_us = 0;
 	memset(shared_buffers, 0, sizeof(shared_buffers));
 	memset(surfaces, 0, sizeof(surfaces));
-	memset(audio_streams, 0, sizeof(audio_streams));
+	/* Pointer into the coherent region, not an array: size explicitly.
+	 * Flush so the zeroed table is in DRAM whatever MMU attributes the
+	 * lines were filled under (this can run before the scheduler stamps
+	 * the coherent attributes on the section). */
+	memset(audio_streams, 0,
+	       SDK_MAX_AUDIO_STREAMS * sizeof(struct SDKAudioStream));
+	Xil_DCacheFlushRange((INTPTR)(uintptr_t)audio_streams,
+	                     SDK_MAX_AUDIO_STREAMS *
+	                     sizeof(struct SDKAudioStream));
 	sdk_decompress_stream_reset_all();
 	/* A vanished client (Amiga reboot/crash) can leave core-1-affine image
 	 * sessions open with no task in flight; the quiesce above does not

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -4658,6 +4658,18 @@ uint16_t sdk_mailbox_run_offload_task(const taskq_desc_t *d,
 			return SDK_STATUS_IO_ERROR;
 		audio_stream_feed_compute(stream, p->src_addr, p->src_len,
 		                          p->flags);
+		/* This worker runs on core 1, which owns the mp3 staging ring's
+		 * cache (see core1_affine). Only the FEED path writes that ring
+		 * (feed_compute's memcpy + audio_stream_compact_input); a READ or
+		 * the internal refill just reads it. Clean+invalidate the ring
+		 * here so core 1 leaves no dirty lines behind: CLOSE/free runs on
+		 * core 0 and cannot reach core 1's L1, so without this a later
+		 * eviction of stale compressed data could clobber whatever reuses
+		 * the freed shared buffer. */
+		if (stream->mp3_ring_addr != 0U && stream->mp3_capacity != 0U)
+			Xil_DCacheFlushRange(
+				(INTPTR)(uintptr_t)stream->mp3_ring_addr,
+				stream->mp3_capacity);
 		audio_stream_fill_result(result_payload, stream);
 		*result_len = sizeof(struct SDKAudioStreamResultPayload);
 		return SDK_STATUS_OK;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3335,10 +3335,15 @@ static uint16_t handle_audio_stream_play(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
 	if (stream->faulted)
 		return complete_status(req, comp, SDK_STATUS_IO_ERROR);
+	if (g_audio_playback.session == session) {
+		/* Already playing this session: idempotent, no re-init (the
+		 * client may use this as a cheap status probe). */
+		return complete_audio_stream_result(req, comp, SDK_STATUS_OK,
+		                                    stream);
+	}
 	if (stream->sample_rate == 0U)   /* client must prebuffer first */
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
-	if (g_audio_playback.session != 0U &&
-	    g_audio_playback.session != session)
+	if (g_audio_playback.session != 0U)
 		return complete_status(req, comp, SDK_STATUS_BUSY);
 
 	/* Deterministic output target: the standard TX ring (an earlier AHI

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -678,7 +678,7 @@ struct audio_feed_op_params {
 
 struct audio_read_op_params {
 	uint32_t session;
-	uint32_t pcm_read;      /* validated against pcm_used on core 0 */
+	uint32_t pcm_read;      /* validated against consumer-visible used */
 };
 
 typedef char audio_op_params_size_check[
@@ -712,9 +712,22 @@ struct SDKAudioStream {
 	uint32_t pcm_capacity;
 	uint32_t input_offset;
 	uint32_t input_length;
-	uint32_t pcm_read;
-	uint32_t pcm_write;
-	uint32_t pcm_used;
+	/*
+	 * PCM ring cursors as monotonic byte totals, u32 wrap-safe, each with
+	 * exactly ONE writer so no atomics are needed (the table is in the
+	 * SCU-coherent region):
+	 *  - pcm_written_total: decode side (core 1 for affine streams),
+	 *    advanced per frame; producer-internal ring geometry.
+	 *  - pcm_ready_total: decode side, published AFTER the PCM cache
+	 *    flush (Xil_DCacheFlushRange ends in a DSB, ordering the store)
+	 *    -- consumers may only read ring bytes below this total.
+	 *  - pcm_consumed_total: the consumer -- the AUDIO_STREAM_READ path
+	 *    for unbound streams, the AX playback pump for bound ones (a
+	 *    bound stream rejects READ, so the writer is always unique).
+	 */
+	uint32_t pcm_written_total;
+	uint32_t pcm_ready_total;
+	uint32_t pcm_consumed_total;
 	uint32_t low_water_bytes;
 	uint32_t high_water_bytes;
 	uint32_t sample_rate;
@@ -2733,11 +2746,24 @@ void sdk_mailbox_poison_core1_audio_streams(void)
 	}
 }
 
+/* Consumer-visible bytes in the ring (flushed and safe to read). */
+static uint32_t audio_stream_pcm_used(const struct SDKAudioStream *stream)
+{
+	return stream->pcm_ready_total - stream->pcm_consumed_total;
+}
+
+/* Producer's free space: against written_total (conservative -- counts
+ * frames not yet published by the end-of-decode flush too). */
 static uint32_t audio_stream_pcm_free(const struct SDKAudioStream *stream)
 {
-	if (!stream || stream->pcm_used >= stream->pcm_capacity)
+	uint32_t used;
+
+	if (!stream)
 		return 0;
-	return stream->pcm_capacity - stream->pcm_used;
+	used = stream->pcm_written_total - stream->pcm_consumed_total;
+	if (used >= stream->pcm_capacity)
+		return 0;
+	return stream->pcm_capacity - used;
 }
 
 static void flush_audio_pcm_written(const struct SDKAudioStream *stream,
@@ -2762,15 +2788,15 @@ static void audio_stream_pcm_write(struct SDKAudioStream *stream,
                                    const uint8_t *src, uint32_t bytes)
 {
 	uint8_t *dst = (uint8_t *)(uintptr_t)stream->pcm_ring_addr;
-	uint32_t first = stream->pcm_capacity - stream->pcm_write;
+	uint32_t offset = stream->pcm_written_total % stream->pcm_capacity;
+	uint32_t first = stream->pcm_capacity - offset;
 
 	if (first > bytes)
 		first = bytes;
-	memcpy(dst + stream->pcm_write, src, first);
+	memcpy(dst + offset, src, first);
 	if (bytes > first)
 		memcpy(dst, src + first, bytes - first);
-	stream->pcm_write = (stream->pcm_write + bytes) % stream->pcm_capacity;
-	stream->pcm_used += bytes;
+	stream->pcm_written_total += bytes;
 	stream->bytes_produced += bytes;
 }
 
@@ -2905,7 +2931,7 @@ static uint32_t audio_stream_decode(struct SDKAudioStream *stream)
 		max_pcm_this_call = stream->pcm_capacity;
 	if (max_pcm_this_call < frame_pcm_bytes)
 		max_pcm_this_call = frame_pcm_bytes;
-	pcm_flush_start = stream->pcm_write;
+	pcm_flush_start = stream->pcm_written_total % stream->pcm_capacity;
 
 	while (stream->input_length > 0U &&
 	       audio_stream_pcm_free(stream) >= frame_pcm_bytes) {
@@ -2986,9 +3012,14 @@ static uint32_t audio_stream_decode(struct SDKAudioStream *stream)
 		}
 	}
 
-	if (produced_this_call != 0U)
+	if (produced_this_call != 0U) {
 		flush_audio_pcm_written(stream, pcm_dst, pcm_flush_start,
 		                        produced_this_call);
+		/* Publish only after the flush: Xil_DCacheFlushRange ends in
+		 * a DSB, so consumers that see the new ready total also see
+		 * the PCM bytes in DRAM. */
+		stream->pcm_ready_total = stream->pcm_written_total;
+	}
 	return progress;
 }
 
@@ -2996,12 +3027,13 @@ static uint32_t audio_stream_state(const struct SDKAudioStream *stream)
 {
 	if (!stream)
 		return SDK_AUDIO_STREAM_STATE_ERROR;
-	if (stream->eof && stream->input_length == 0U && stream->pcm_used == 0U)
+	if (stream->eof && stream->input_length == 0U &&
+	    audio_stream_pcm_used(stream) == 0U)
 		return SDK_AUDIO_STREAM_STATE_DONE;
 	if (audio_stream_needs_more_input(stream))
 		return SDK_AUDIO_STREAM_STATE_NEED_INPUT;
 	if (stream->input_length == 0U &&
-	    stream->pcm_used < stream->pcm_capacity)
+	    audio_stream_pcm_used(stream) < stream->pcm_capacity)
 		return SDK_AUDIO_STREAM_STATE_NEED_INPUT;
 	return SDK_AUDIO_STREAM_STATE_STREAMING;
 }
@@ -3012,12 +3044,12 @@ static uint32_t audio_stream_result_flags(const struct SDKAudioStream *stream)
 
 	if (!stream)
 		return 0;
-	if (stream->pcm_used != 0U)
+	if (audio_stream_pcm_used(stream) != 0U)
 		flags |= SDK_AUDIO_STREAM_RESULT_PCM_READY;
 	if (audio_stream_needs_more_input(stream))
 		flags |= SDK_AUDIO_STREAM_RESULT_NEED_INPUT;
 	if (stream->eof && stream->input_length == 0U &&
-	    stream->pcm_used == 0U)
+	    audio_stream_pcm_used(stream) == 0U)
 		flags |= SDK_AUDIO_STREAM_RESULT_DONE;
 	if (stream->backpressure)
 		flags |= SDK_AUDIO_STREAM_RESULT_BACKPRESSURE;
@@ -3039,8 +3071,10 @@ static void audio_stream_fill_result(uint8_t *dst,
 	put_be32(result->channels, stream->channels);
 	put_be32(result->sample_format, stream->sample_format);
 	put_be32(result->mp3_read, stream->bytes_consumed);
-	put_be32(result->pcm_write, stream->pcm_write);
-	put_be32(result->pcm_read, stream->pcm_read);
+	put_be32(result->pcm_write,
+	         stream->pcm_ready_total % stream->pcm_capacity);
+	put_be32(result->pcm_read,
+	         stream->pcm_consumed_total % stream->pcm_capacity);
 	put_be32(result->frames_decoded, stream->frames_decoded);
 	put_be32(result->bytes_consumed, stream->bytes_consumed);
 	put_be32(result->bytes_produced, stream->bytes_produced);
@@ -3104,8 +3138,7 @@ static void audio_stream_feed_compute(struct SDKAudioStream *stream,
 static void audio_stream_read_compute(struct SDKAudioStream *stream,
                                       uint32_t pcm_read)
 {
-	stream->pcm_read = (stream->pcm_read + pcm_read) % stream->pcm_capacity;
-	stream->pcm_used -= pcm_read;
+	stream->pcm_consumed_total += pcm_read;
 	audio_stream_decode(stream);
 }
 
@@ -3255,7 +3288,7 @@ static uint16_t handle_audio_stream_read(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
 	pcm_read = get_be32(payload->pcm_read);
 	flags = get_be32(payload->flags);
-	if (flags != 0U || pcm_read > stream->pcm_used)
+	if (flags != 0U || pcm_read > audio_stream_pcm_used(stream))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
 	if (stream->faulted)
 		return complete_status(req, comp, SDK_STATUS_IO_ERROR);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -726,6 +726,11 @@ struct SDKAudioStream {
 	 *  - pcm_consumed_total: the consumer -- the AUDIO_STREAM_READ path
 	 *    for unbound streams, the AX playback pump for bound ones (a
 	 *    bound stream rejects READ, so the writer is always unique).
+	 * DIFFERENCES of these totals stay correct across the u32 wrap, but
+	 * `total % pcm_capacity` (ring offsets) does not once a total passes
+	 * 2^32 for a non-power-of-2 capacity: a single session degrades
+	 * after 4 GiB of PCM (~6 h of continuous 48 kHz stereo). Accepted --
+	 * sessions are per-file/per-track in every current client.
 	 */
 	uint32_t pcm_written_total;
 	uint32_t pcm_ready_total;
@@ -3253,9 +3258,11 @@ void sdk_mailbox_audio_playback_pump(void)
 	pos_period -= pos_period % AUDIO_PUMP_PERIOD_BYTES;
 
 	/* If the DMA caught up with (or passed) the fill frontier, restart
-	 * one period ahead of it. */
-	ahead = (g_audio_playback.fill_offset - pos_period) %
-	        AUDIO_PUMP_RING_BYTES;
+	 * one period ahead of it. Circular distance: bias by the ring size
+	 * BEFORE the modulo -- a plain u32 (fill - pos) % RING is wrong on
+	 * wrap because 2^32 is not a multiple of the 30720-byte ring. */
+	ahead = (g_audio_playback.fill_offset + AUDIO_PUMP_RING_BYTES -
+	         pos_period) % AUDIO_PUMP_RING_BYTES;
 	if (ahead == 0U || ahead > AUDIO_PUMP_TARGET_AHEAD) {
 		g_audio_playback.fill_offset =
 		    (pos_period + AUDIO_PUMP_PERIOD_BYTES) %
@@ -3264,9 +3271,17 @@ void sdk_mailbox_audio_playback_pump(void)
 
 	guard = AUDIO_PUMP_RING_BYTES / AUDIO_PUMP_PERIOD_BYTES;
 	while (guard--) {
-		ahead = (g_audio_playback.fill_offset - pos_period) %
-		        AUDIO_PUMP_RING_BYTES;
-		if (ahead > AUDIO_PUMP_TARGET_AHEAD)
+		ahead = (g_audio_playback.fill_offset + AUDIO_PUMP_RING_BYTES -
+		         pos_period) % AUDIO_PUMP_RING_BYTES;
+		/* Stop AT the target, never past it: the frontier must stay
+		 * inside [PERIOD, TARGET_AHEAD] so the caught-up reset above
+		 * only fires on a genuine DMA overrun. Filling one period past
+		 * the target (the '>' variant of this check) made every pump
+		 * pass look caught-up, re-basing the frontier and re-filling
+		 * the ring at main-loop speed -- consuming PCM thousands of
+		 * times faster than playback, which defeated FEED
+		 * backpressure entirely. */
+		if (ahead >= AUDIO_PUMP_TARGET_AHEAD)
 			break;   /* frontier far enough ahead */
 		audio_pump_fill_period(stream,
 		                       tx + g_audio_playback.fill_offset);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -5913,6 +5913,17 @@ static uint16_t handle_request(volatile struct SDKMailboxEntry *req,
 	if (payload_len > sizeof(req->payload))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
 
+	/* request_id 0 is reserved for firmware-internal scheduler tasks
+	 * (the AX playback refill): their deferred completion is swallowed
+	 * by sdk_mailbox_post_deferred instead of being posted to the
+	 * client ring. A client request carrying id 0 that took a deferred
+	 * path would therefore hang its caller and spuriously retire the
+	 * refill marker -- reject it up front so the reservation is
+	 * enforced, not assumed. zz9k.library never emits id 0 (its
+	 * generator skips it, including on wrap). */
+	if (get_be32(req->request_id) == 0U)
+		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+
 	switch (opcode) {
 	case SDK_OP_NOP:
 		write_completion(comp, req, SDK_STATUS_OK, 0);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -43,7 +43,14 @@
 	 SDK_CAP_AUDIO_PLAYBACK | \
 	 SDK_CAP_MEMORY_OPS | SDK_CAP_CRYPTO | \
 	 SDK_CAP_DIAGNOSTICS | SDK_CAP_SURFACE_OPS | SDK_CAP_COMPRESSION)
-#define SDK_AUDIO_STREAM_MIN_INPUT_BYTES (16U * 1024U)
+/* Decode proceeds only with at least this much undecoded input (unless
+ * EOF): enough for the largest legal MP3 frame (~1.4K, 2.3K free-format)
+ * plus sync lookahead. It must stay WELL below any client's input-ring
+ * size -- at the old 16K, a client with a 16K input ring could only
+ * decode with the ring full to the byte, and once decode freed a
+ * non-chunk-multiple of space the client's fixed-size feeds never fit
+ * again: a permanent stall. */
+#define SDK_AUDIO_STREAM_MIN_INPUT_BYTES (4U * 1024U)
 
 typedef char SDKMailbox_must_fit_legacy_io_window[
 	((SDK_MAILBOX_WINDOW_OFFSET + SDK_MAILBOX_TOTAL_SIZE) <= 0x00010000U) ?
@@ -3299,7 +3306,12 @@ void sdk_mailbox_audio_playback_pump(void)
 	 * the scheduler was down) refills inline, matching the legacy CPU
 	 * profile of that degraded mode. */
 	if (stream->input_length != 0U && !stream->faulted &&
+	    !audio_stream_needs_more_input(stream) &&
 	    audio_stream_pcm_used(stream) <= stream->low_water_bytes) {
+		/* needs_more_input guard: a refill FEED would no-op below the
+		 * decoder's minimum-input gate, and the pump runs every main
+		 * loop pass -- without the guard the sub-minimum tail of a
+		 * stream turns into a core-1 task storm. */
 		if (stream->core1_affine && scheduler_core1_available()) {
 			if (!g_audio_playback.refill_pending) {
 				struct audio_feed_op_params p;
@@ -3442,7 +3454,12 @@ static uint16_t handle_audio_stream_begin(volatile struct SDKMailboxEntry *req,
 	    (MINIMP3_MAX_SAMPLES_PER_FRAME * sizeof(mp3d_sample_t)) ||
 	    mp3_capacity > mp3_ring->length ||
 	    pcm_capacity > pcm_ring->length ||
-	    low_water_bytes >= mp3_capacity ||
+	    /* Both water marks are PCM-ring thresholds: low_water is the
+	     * playback pump's refill trigger, high_water caps decode
+	     * output per pass. (Validating low_water against the mp3 ring
+	     * here rejected any BEGIN whose input ring was smaller than
+	     * the PCM refill mark.) */
+	    low_water_bytes >= pcm_capacity ||
 	    high_water_bytes >= pcm_capacity) {
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
 	}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3469,6 +3469,14 @@ static uint16_t handle_audio_stream_play(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_UNSUPPORTED);
 	if (g_audio_playback.session != 0U)
 		return complete_status(req, comp, SDK_STATUS_BUSY);
+	/* A legacy/AHI client owning the output is just as busy as another
+	 * SDK session: binding now would repoint the formatter DMA away
+	 * from the buffer that client configured (AP_TX_BUF_OFFS) and
+	 * steal its playback. On the Amiga side MHI and AHI already
+	 * exclude each other via the interrupt-server ownership token;
+	 * this enforces the same exclusion for raw SDK clients. */
+	if (audio_legacy_output_active())
+		return complete_status(req, comp, SDK_STATUS_BUSY);
 
 	/* Deterministic output target: the standard TX ring. An AHI session
 	 * repoints the FORMATTER DMA at its own buffer (AP_TX_BUF_OFFS +

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -767,6 +767,13 @@ struct SDKAudioStream {
 	/* Set when a core-1 fault may have left the embedded decoder state
 	 * mid-frame; feeds/reads answer IO_ERROR, close still works. */
 	uint32_t faulted;
+	/* Bound-playback tail guard: the AX pump advances pcm_consumed_total
+	 * when it STAGES PCM into the TX ring, which runs up to
+	 * AUDIO_PUMP_TARGET_AHEAD ahead of the DMA. Set while staged audio is
+	 * still queued for the DMA so end-of-stream (DONE / PCM_READY-clear)
+	 * waits for it to actually play out. Managed by the pump; always 0 for
+	 * unbound streams (the READ consumer hears bytes immediately). */
+	uint8_t pump_tail_pending;
 	mp3dec_t decoder;
 	mp3d_sample_t scratch[MINIMP3_MAX_SAMPLES_PER_FRAME];
 };
@@ -3042,8 +3049,14 @@ static uint32_t audio_stream_state(const struct SDKAudioStream *stream)
 	if (!stream)
 		return SDK_AUDIO_STREAM_STATE_ERROR;
 	if (stream->eof && stream->input_length == 0U &&
-	    audio_stream_pcm_used(stream) == 0U)
+	    audio_stream_pcm_used(stream) == 0U) {
+		/* Source exhausted, but a bound pump may still be playing the
+		 * staged tail out of the TX ring -- report STREAMING until it
+		 * drains so DONE does not race ahead of the DMA. */
+		if (stream->pump_tail_pending)
+			return SDK_AUDIO_STREAM_STATE_STREAMING;
 		return SDK_AUDIO_STREAM_STATE_DONE;
+	}
 	if (audio_stream_needs_more_input(stream))
 		return SDK_AUDIO_STREAM_STATE_NEED_INPUT;
 	if (stream->input_length == 0U &&
@@ -3058,12 +3071,12 @@ static uint32_t audio_stream_result_flags(const struct SDKAudioStream *stream)
 
 	if (!stream)
 		return 0;
-	if (audio_stream_pcm_used(stream) != 0U)
+	if (audio_stream_pcm_used(stream) != 0U || stream->pump_tail_pending)
 		flags |= SDK_AUDIO_STREAM_RESULT_PCM_READY;
 	if (audio_stream_needs_more_input(stream))
 		flags |= SDK_AUDIO_STREAM_RESULT_NEED_INPUT;
 	if (stream->eof && stream->input_length == 0U &&
-	    audio_stream_pcm_used(stream) == 0U)
+	    audio_stream_pcm_used(stream) == 0U && !stream->pump_tail_pending)
 		flags |= SDK_AUDIO_STREAM_RESULT_DONE;
 	if (stream->backpressure)
 		flags |= SDK_AUDIO_STREAM_RESULT_BACKPRESSURE;
@@ -3185,6 +3198,9 @@ static struct {
 	uint32_t refill_pending;  /* internal core-1 refill task in flight */
 	uint32_t refill_session;  /* session that refill targets (valid while
 	                             refill_pending; survives an unbind) */
+	uint32_t silence_run;     /* consecutive pump ISR periods (one DMA
+	                             period each) that staged only silence;
+	                             a full ring means the DMA played the tail */
 } g_audio_playback;
 
 static int16_t g_pump_src[AUDIO_PUMP_PERIOD_BYTES / 2];
@@ -3248,11 +3264,28 @@ static void pump_resample_s16(const int16_t *input, int16_t *output,
 
 	g_pump_rs_prev_l = input[2 * ip2];
 	g_pump_rs_prev_r = input[2 * ip2 + 1];
-	g_pump_rs_cur = cur & 0xFFFFU;
+	/* Carry phase relative to the block just consumed, not the raw low
+	 * 16 bits. Each period feeds a fresh block of in_frames source frames,
+	 * so the next period's phase is (cur - in_frames). The 16.16 step is
+	 * truncated, so for the common rates cur lands a hair BELOW
+	 * in_frames<<16 (44.1k: 881.997 not 882.0); keeping cur&0xFFFF would
+	 * restart near phase 1.0 and jump ~1 source sample every 20 ms period.
+	 * ax.c's double resampler avoids this only because in_rate/48000*960
+	 * is an exact integer for those rates -- the truncated fixed-point
+	 * step is not. Clamp a tiny undershoot to the block boundary (matching
+	 * the double's exact 0.0) and keep the cursor non-negative so the
+	 * unsigned indexing above stays valid. */
+	{
+		int32_t carry = (int32_t)cur - (int32_t)(in_frames << 16);
+		g_pump_rs_cur = (carry > 0) ? (uint32_t)carry : 0U;
+	}
 }
 
-static void audio_pump_fill_period(struct SDKAudioStream *stream,
-                                   uint8_t *slot)
+/* Returns 1 if a period of real (decoded) PCM was staged, 0 for silence
+ * (underrun, fault, or drained end-of-stream). The ISR pump uses this to
+ * track when the DMA has played the last real audio out of the TX ring. */
+static int audio_pump_fill_period(struct SDKAudioStream *stream,
+                                  uint8_t *slot)
 {
 	uint32_t rate;
 	uint32_t channels;
@@ -3320,9 +3353,10 @@ static void audio_pump_fill_period(struct SDKAudioStream *stream,
 		pump_resample_s16(pcm, (int16_t *)slot, rate, src_frames,
 		                  AUDIO_PUMP_PERIOD_BYTES / 4);
 	}
-	return;
+	return 1;
 silence:
 	memset(slot, 0, AUDIO_PUMP_PERIOD_BYTES);
+	return 0;
 }
 
 /* TX-fill half: called from isr_audio (audio-formatter period IRQ,
@@ -3335,6 +3369,8 @@ void sdk_mailbox_audio_playback_pump_isr(void)
 	uint32_t pos_period;
 	uint32_t ahead;
 	uint32_t guard;
+	uint32_t ring_periods = AUDIO_PUMP_RING_BYTES / AUDIO_PUMP_PERIOD_BYTES;
+	int staged_real = 0;
 
 	if (g_audio_playback.session == 0U)
 		return;
@@ -3373,8 +3409,9 @@ void sdk_mailbox_audio_playback_pump_isr(void)
 		 * backpressure entirely. */
 		if (ahead >= AUDIO_PUMP_TARGET_AHEAD)
 			break;   /* frontier far enough ahead */
-		audio_pump_fill_period(stream,
-		                       tx + g_audio_playback.fill_offset);
+		if (audio_pump_fill_period(stream,
+		                           tx + g_audio_playback.fill_offset))
+			staged_real = 1;
 		/* The TX ring is plain cacheable DDR (no TLB override) and
 		 * the audio formatter DMA does not snoop: push the period to
 		 * DRAM before the frontier advances over it. ~120 lines,
@@ -3385,6 +3422,23 @@ void sdk_mailbox_audio_playback_pump_isr(void)
 		g_audio_playback.fill_offset =
 		    (g_audio_playback.fill_offset + AUDIO_PUMP_PERIOD_BYTES) %
 		    AUDIO_PUMP_RING_BYTES;
+	}
+
+	/* Play-out tail tracking. This ISR fires once per formatter period,
+	 * so each call is one DMA period elapsed. While real PCM is flowing,
+	 * pump_tail_pending stays armed; once the source is exhausted the loop
+	 * only stages silence, and after a whole ring of silence periods the
+	 * DMA has played the last real audio out of the TX ring. Only then may
+	 * end-of-stream drop (see audio_stream_result_flags / audio_stream_
+	 * state), so a client that stops on DONE does not truncate the tail. */
+	if (staged_real) {
+		g_audio_playback.silence_run = 0U;
+		stream->pump_tail_pending = 1U;
+	} else if (stream->pump_tail_pending) {
+		if (g_audio_playback.silence_run < ring_periods)
+			g_audio_playback.silence_run++;
+		if (g_audio_playback.silence_run >= ring_periods)
+			stream->pump_tail_pending = 0U;
 	}
 }
 
@@ -3508,6 +3562,10 @@ static uint16_t handle_audio_stream_play(volatile struct SDKMailboxEntry *req,
 	pos -= pos % AUDIO_PUMP_PERIOD_BYTES;
 	g_audio_playback.fill_offset =
 	    (pos + AUDIO_PUMP_PERIOD_BYTES) % AUDIO_PUMP_RING_BYTES;
+	/* Fresh tail guard for this binding; the pump arms it on the first
+	 * real period it stages. */
+	g_audio_playback.silence_run = 0U;
+	stream->pump_tail_pending = 0U;
 	/* Publish the session LAST: the ISR pump gates on it, and the same
 	 * core observes these stores in program order. Filling starts on
 	 * the next period interrupt (<= 20 ms). */
@@ -3538,6 +3596,9 @@ static uint16_t handle_audio_stream_stop(volatile struct SDKMailboxEntry *req,
 	if (g_audio_playback.session == session) {
 		g_audio_playback.session = 0U;
 		audio_silence();
+		/* audio_silence() wiped the TX ring: no tail is left to play. */
+		stream->pump_tail_pending = 0U;
+		g_audio_playback.silence_run = 0U;
 	}
 	/* Idempotent: stopping an unbound session is OK (MHI pause/stop). */
 	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, stream);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -4672,6 +4672,16 @@ uint16_t sdk_mailbox_run_offload_task(const taskq_desc_t *d,
 			return SDK_STATUS_BAD_HANDLE;
 		if (stream->faulted)
 			return SDK_STATUS_IO_ERROR;
+		/* Re-validate against the LIVE used count. p->pcm_read was
+		 * checked on core 0 against audio_stream_pcm_used() at intake,
+		 * but an earlier queued READ for this stream may have advanced
+		 * pcm_consumed_total since -- the snapshot is stale. Consuming
+		 * blindly would overshoot pcm_ready_total and underflow
+		 * audio_stream_pcm_used(), letting decode/pump work overwrite
+		 * still-unread PCM. Reject (consume nothing), matching the
+		 * inline intake path's over-read behavior. */
+		if (p->pcm_read > audio_stream_pcm_used(stream))
+			return SDK_STATUS_BAD_REQUEST;
 		audio_stream_read_compute(stream, p->pcm_read);
 		audio_stream_fill_result(result_payload, stream);
 		*result_len = sizeof(struct SDKAudioStreamResultPayload);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -21,6 +21,7 @@
 #include "memorymap.h"
 #include "scheduler.h"
 #include "core2.h"
+#include "ax.h"
 #include "interrupt.h"
 #include "video.h"
 #include "mp3/mp3.h"
@@ -39,6 +40,7 @@
 	 SDK_CAP_SHARED_ALLOC | SDK_CAP_SURFACES | \
 	 SDK_CAP_FRAMEBUFFER_SURFACE | SDK_CAP_IMAGE_DECODE | \
 	 SDK_CAP_IMAGE_SCALE | SDK_CAP_AUDIO_DECODE | \
+	 SDK_CAP_AUDIO_PLAYBACK | \
 	 SDK_CAP_MEMORY_OPS | SDK_CAP_CRYPTO | \
 	 SDK_CAP_DIAGNOSTICS | SDK_CAP_SURFACE_OPS | SDK_CAP_COMPRESSION)
 #define SDK_AUDIO_STREAM_MIN_INPUT_BYTES (16U * 1024U)
@@ -3142,6 +3144,204 @@ static void audio_stream_read_compute(struct SDKAudioStream *stream,
 	audio_stream_decode(stream);
 }
 
+/*
+ * ---- AX playback pump (MHI modernization) ----
+ * One audio-stream session at a time may be bound to the AX output
+ * (SDK_OP_AUDIO_STREAM_PLAY). The core-0 main loop calls the pump every
+ * pass; it keeps the standard AX TX ring filled ahead of the
+ * audio-formatter DMA from the session's PCM ring, one 3840-byte period
+ * (20 ms of 48 kHz stereo S16LE) at a time. Underrun, a faulted session
+ * or an unusable stream geometry produce silence. Non-48k sources go
+ * through the existing resample_s16 path with the legacy DECODE_RUN
+ * source math (rate/50 frames per period, integer truncation and its
+ * slight drift included); mono sources are duplicated to stereo. The
+ * pump is the CONSUMER of a bound session -- the single writer of
+ * pcm_consumed_total -- so AUDIO_STREAM_READ is rejected while bound.
+ */
+#define AUDIO_PUMP_PERIOD_BYTES  AUDIO_BYTES_PER_PERIOD
+#define AUDIO_PUMP_RING_BYTES    AUDIO_TX_BUFFER_SIZE
+#define AUDIO_PUMP_TARGET_AHEAD \
+	(AUDIO_PUMP_RING_BYTES - 2U * AUDIO_PUMP_PERIOD_BYTES)
+
+static struct {
+	uint32_t session;       /* 0 = unbound */
+	uint32_t fill_offset;   /* next TX-ring byte to fill, period-aligned */
+} g_audio_playback;
+
+static int16_t g_pump_src[AUDIO_PUMP_PERIOD_BYTES / 2];
+static int16_t g_pump_stereo[AUDIO_PUMP_PERIOD_BYTES / 2];
+
+static void audio_pump_fill_period(struct SDKAudioStream *stream,
+                                   uint8_t *slot)
+{
+	uint32_t rate;
+	uint32_t channels;
+	uint32_t src_frames;
+	uint32_t src_bytes;
+	uint32_t offset;
+	uint32_t first;
+	uint8_t *ring;
+	int16_t *pcm;
+	uint32_t i;
+
+	if (!stream || stream->faulted)
+		goto silence;
+	rate = stream->sample_rate;
+	channels = stream->channels;
+	if (rate == 0U || channels == 0U || channels > 2U)
+		goto silence;
+	src_frames = rate / 50U;
+	if (src_frames == 0U || src_frames > (AUDIO_PUMP_PERIOD_BYTES / 4U))
+		goto silence;
+	src_bytes = src_frames * channels * 2U;
+	if ((stream->pcm_ready_total - stream->pcm_consumed_total) < src_bytes)
+		goto silence;   /* underrun: a whole period of silence */
+
+	/* Pull one period's source from the PCM ring. The decode side
+	 * flushed these bytes before publishing pcm_ready_total, so a
+	 * reader-side invalidate makes them visible on this core. */
+	ring = (uint8_t *)(uintptr_t)stream->pcm_ring_addr;
+	offset = stream->pcm_consumed_total % stream->pcm_capacity;
+	first = stream->pcm_capacity - offset;
+	if (first > src_bytes)
+		first = src_bytes;
+	Xil_DCacheInvalidateRange((INTPTR)(ring + offset), first);
+	memcpy(g_pump_src, ring + offset, first);
+	if (src_bytes > first) {
+		Xil_DCacheInvalidateRange((INTPTR)ring, src_bytes - first);
+		memcpy((uint8_t *)g_pump_src + first, ring, src_bytes - first);
+	}
+	stream->pcm_consumed_total += src_bytes;
+
+	pcm = g_pump_src;
+	if (channels == 1U) {
+		for (i = 0; i < src_frames; i++) {
+			g_pump_stereo[2U * i] = g_pump_src[i];
+			g_pump_stereo[2U * i + 1U] = g_pump_src[i];
+		}
+		pcm = g_pump_stereo;
+	}
+	if (rate == 48000U) {
+		memcpy(slot, pcm, AUDIO_PUMP_PERIOD_BYTES);
+	} else {
+		resample_s16(pcm, (int16_t *)slot, (int)rate, 48000,
+		             AUDIO_PUMP_PERIOD_BYTES / 4);
+	}
+	return;
+silence:
+	memset(slot, 0, AUDIO_PUMP_PERIOD_BYTES);
+}
+
+void sdk_mailbox_audio_playback_pump(void)
+{
+	struct SDKAudioStream *stream;
+	uint8_t *tx = (uint8_t *)AUDIO_TX_BUFFER_ADDRESS;
+	uint32_t pos_period;
+	uint32_t ahead;
+	uint32_t guard;
+
+	if (g_audio_playback.session == 0U)
+		return;
+	stream = find_audio_stream(g_audio_playback.session);
+	if (!stream) {
+		g_audio_playback.session = 0U;   /* closed under us */
+		return;
+	}
+
+	pos_period = (audio_get_dma_transfer_count() % AUDIO_PUMP_RING_BYTES);
+	pos_period -= pos_period % AUDIO_PUMP_PERIOD_BYTES;
+
+	/* If the DMA caught up with (or passed) the fill frontier, restart
+	 * one period ahead of it. */
+	ahead = (g_audio_playback.fill_offset - pos_period) %
+	        AUDIO_PUMP_RING_BYTES;
+	if (ahead == 0U || ahead > AUDIO_PUMP_TARGET_AHEAD) {
+		g_audio_playback.fill_offset =
+		    (pos_period + AUDIO_PUMP_PERIOD_BYTES) %
+		    AUDIO_PUMP_RING_BYTES;
+	}
+
+	guard = AUDIO_PUMP_RING_BYTES / AUDIO_PUMP_PERIOD_BYTES;
+	while (guard--) {
+		ahead = (g_audio_playback.fill_offset - pos_period) %
+		        AUDIO_PUMP_RING_BYTES;
+		if (ahead > AUDIO_PUMP_TARGET_AHEAD)
+			break;   /* frontier far enough ahead */
+		audio_pump_fill_period(stream,
+		                       tx + g_audio_playback.fill_offset);
+		g_audio_playback.fill_offset =
+		    (g_audio_playback.fill_offset + AUDIO_PUMP_PERIOD_BYTES) %
+		    AUDIO_PUMP_RING_BYTES;
+	}
+}
+
+static uint16_t handle_audio_stream_play(volatile struct SDKMailboxEntry *req,
+                                         volatile struct SDKMailboxEntry *comp,
+                                         uint16_t payload_len)
+{
+	volatile struct SDKAudioStreamClosePayload *payload;
+	struct SDKAudioStream *stream;
+	uint32_t session;
+	uint32_t flags;
+	uint32_t pos;
+
+	if (payload_len < sizeof(*payload))
+		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+	payload = (volatile struct SDKAudioStreamClosePayload *)req->payload;
+	session = get_be32(payload->session);
+	flags = get_be32(payload->flags);
+	if (flags != 0U)
+		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+	stream = find_audio_stream(session);
+	if (!stream)
+		return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
+	if (stream->faulted)
+		return complete_status(req, comp, SDK_STATUS_IO_ERROR);
+	if (stream->sample_rate == 0U)   /* client must prebuffer first */
+		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+	if (g_audio_playback.session != 0U &&
+	    g_audio_playback.session != session)
+		return complete_status(req, comp, SDK_STATUS_BUSY);
+
+	/* Deterministic output target: the standard TX ring (an earlier AHI
+	 * session may have repointed it). */
+	audio_set_tx_buffer((uint8_t *)AUDIO_TX_BUFFER_ADDRESS);
+	g_audio_playback.session = session;
+	pos = audio_get_dma_transfer_count() % AUDIO_PUMP_RING_BYTES;
+	pos -= pos % AUDIO_PUMP_PERIOD_BYTES;
+	g_audio_playback.fill_offset =
+	    (pos + AUDIO_PUMP_PERIOD_BYTES) % AUDIO_PUMP_RING_BYTES;
+	sdk_mailbox_audio_playback_pump();   /* prefill */
+	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, stream);
+}
+
+static uint16_t handle_audio_stream_stop(volatile struct SDKMailboxEntry *req,
+                                         volatile struct SDKMailboxEntry *comp,
+                                         uint16_t payload_len)
+{
+	volatile struct SDKAudioStreamClosePayload *payload;
+	struct SDKAudioStream *stream;
+	uint32_t session;
+	uint32_t flags;
+
+	if (payload_len < sizeof(*payload))
+		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+	payload = (volatile struct SDKAudioStreamClosePayload *)req->payload;
+	session = get_be32(payload->session);
+	flags = get_be32(payload->flags);
+	if (flags != 0U)
+		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+	stream = find_audio_stream(session);
+	if (!stream)
+		return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
+	if (g_audio_playback.session == session) {
+		g_audio_playback.session = 0U;
+		audio_silence();
+	}
+	/* Idempotent: stopping an unbound session is OK (MHI pause/stop). */
+	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, stream);
+}
+
 static uint16_t handle_audio_stream_begin(volatile struct SDKMailboxEntry *req,
                                           volatile struct SDKMailboxEntry *comp,
                                           uint16_t payload_len)
@@ -3292,6 +3492,9 @@ static uint16_t handle_audio_stream_read(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
 	if (stream->faulted)
 		return complete_status(req, comp, SDK_STATUS_IO_ERROR);
+	/* A bound stream's consumer is the AX playback pump. */
+	if (g_audio_playback.session == session)
+		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
 
 	if (stream->core1_affine && scheduler_core1_available()) {
 		struct audio_read_op_params p;
@@ -3330,6 +3533,11 @@ static uint16_t handle_audio_stream_close(volatile struct SDKMailboxEntry *req,
 	stream = find_audio_stream(session);
 	if (!stream)
 		return complete_status(req, comp, SDK_STATUS_BAD_HANDLE);
+	if (g_audio_playback.session == session) {
+		/* Closing a bound stream implies stop. */
+		g_audio_playback.session = 0U;
+		audio_silence();
+	}
 	snapshot = *stream;
 	free_audio_stream(stream);
 	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, &snapshot);
@@ -5564,6 +5772,10 @@ static uint16_t handle_request(volatile struct SDKMailboxEntry *req,
 		return handle_audio_stream_read(req, comp, payload_len);
 	case SDK_OP_AUDIO_STREAM_CLOSE:
 		return handle_audio_stream_close(req, comp, payload_len);
+	case SDK_OP_AUDIO_STREAM_PLAY:
+		return handle_audio_stream_play(req, comp, payload_len);
+	case SDK_OP_AUDIO_STREAM_STOP:
+		return handle_audio_stream_stop(req, comp, payload_len);
 	case SDK_OP_IMAGE_SESSION_BEGIN:
 		return handle_image_session_begin(req, comp, payload_len);
 	case SDK_OP_IMAGE_SESSION_FEED:
@@ -5656,6 +5868,8 @@ void sdk_mailbox_init(void)
 	timing_decode_us = 0;
 	memset(shared_buffers, 0, sizeof(shared_buffers));
 	memset(surfaces, 0, sizeof(surfaces));
+	/* Unbind AX playback before the table goes away. */
+	g_audio_playback.session = 0U;
 	/* Pointer into the coherent region, not an array: size explicitly.
 	 * Flush so the zeroed table is in DRAM whatever MMU attributes the
 	 * lines were filled under (this can run before the scheduler stamps

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -1064,13 +1064,13 @@ static const struct SDKServiceDescriptor sdk_services[] = {
 	},
 	{
 		SDK_SERVICE_AUDIO,
-		0x00020000U,
-		SDK_CAP_AUDIO_DECODE,
+		0x00020001U,
+		SDK_CAP_AUDIO_DECODE | SDK_CAP_AUDIO_PLAYBACK,
 		SDK_SERVICE_FLAG_FIRMWARE |
 			SDK_SERVICE_FLAG_AUDIO_MP3_DECODE |
 			SDK_SERVICE_FLAG_AUDIO_MP3_STREAM,
 		SDK_SERVICE_AUDIO,
-		7,
+		9,	/* 0x0500..0x0508 incl. AUDIO_STREAM_PLAY/STOP */
 		"audio"
 	},
 	{
@@ -3360,6 +3360,13 @@ void sdk_mailbox_audio_playback_pump_isr(void)
 			break;   /* frontier far enough ahead */
 		audio_pump_fill_period(stream,
 		                       tx + g_audio_playback.fill_offset);
+		/* The TX ring is plain cacheable DDR (no TLB override) and
+		 * the audio formatter DMA does not snoop: push the period to
+		 * DRAM before the frontier advances over it. ~120 lines,
+		 * microseconds, once per 20 ms. */
+		Xil_DCacheFlushRange(
+		    (INTPTR)(tx + g_audio_playback.fill_offset),
+		    AUDIO_PUMP_PERIOD_BYTES);
 		g_audio_playback.fill_offset =
 		    (g_audio_playback.fill_offset + AUDIO_PUMP_PERIOD_BYTES) %
 		    AUDIO_PUMP_RING_BYTES;
@@ -3451,6 +3458,11 @@ static uint16_t handle_audio_stream_play(volatile struct SDKMailboxEntry *req,
 	}
 	if (stream->sample_rate == 0U)   /* client must prebuffer first */
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+	/* The AX DMA consumes native little-endian samples and the pump
+	 * copies the PCM ring verbatim; an S16BE session (the READ-path
+	 * byte order) would play byte-swapped noise. */
+	if (stream->sample_format != SDK_AUDIO_SAMPLE_FORMAT_S16LE)
+		return complete_status(req, comp, SDK_STATUS_UNSUPPORTED);
 	if (g_audio_playback.session != 0U)
 		return complete_status(req, comp, SDK_STATUS_BUSY);
 
@@ -3706,6 +3718,21 @@ static uint16_t handle_audio_stream_close(volatile struct SDKMailboxEntry *req,
 		/* Closing a bound stream implies stop. */
 		g_audio_playback.session = 0U;
 		audio_silence();
+	}
+	/* An internal PCM-refill FEED (request_id 0) may still be queued or
+	 * running on core 1 against this stream's coherent slot -- it was
+	 * enqueued for the bound session, which a prior STOP may already
+	 * have unbound, so it must be drained here regardless of the
+	 * binding above. Freeing the slot under the worker would zero the
+	 * decoder state mid-decode. The flag clears when the task's
+	 * deferred completion is reaped; pump the scheduler until then
+	 * (bounded: one decode pass; the guard covers a wedged core 1,
+	 * whose fault path poisons the stream anyway). */
+	if (g_audio_playback.refill_pending) {
+		uint32_t drain_guard = 10000000U;
+
+		while (g_audio_playback.refill_pending && drain_guard--)
+			scheduler_core0_poll(0, 0);
 	}
 	snapshot = *stream;
 	free_audio_stream(stream);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3164,8 +3164,9 @@ static void audio_stream_read_compute(struct SDKAudioStream *stream,
 	(AUDIO_PUMP_RING_BYTES - 2U * AUDIO_PUMP_PERIOD_BYTES)
 
 static struct {
-	uint32_t session;       /* 0 = unbound */
-	uint32_t fill_offset;   /* next TX-ring byte to fill, period-aligned */
+	uint32_t session;         /* 0 = unbound */
+	uint32_t fill_offset;     /* next TX-ring byte to fill, period-aligned */
+	uint32_t refill_pending;  /* internal core-1 refill task in flight */
 } g_audio_playback;
 
 static int16_t g_pump_src[AUDIO_PUMP_PERIOD_BYTES / 2];
@@ -3272,6 +3273,43 @@ void sdk_mailbox_audio_playback_pump(void)
 		g_audio_playback.fill_offset =
 		    (g_audio_playback.fill_offset + AUDIO_PUMP_PERIOD_BYTES) %
 		    AUDIO_PUMP_RING_BYTES;
+	}
+
+	/* Keep the decoder ahead of the pump. Session FEEDs drive decode, but
+	 * once the client has fed everything it just waits -- so when the PCM
+	 * ring is at/below the low-water mark and undecoded input remains,
+	 * kick a refill: a FEED with no new bytes. For core-1-affine streams
+	 * it goes through the queue as an INTERNAL task (request_id 0 -> no
+	 * client completion is posted); a core-0-affine stream (begun while
+	 * the scheduler was down) refills inline, matching the legacy CPU
+	 * profile of that degraded mode. */
+	if (stream->input_length != 0U && !stream->faulted &&
+	    audio_stream_pcm_used(stream) <= stream->low_water_bytes) {
+		if (stream->core1_affine && scheduler_core1_available()) {
+			if (!g_audio_playback.refill_pending) {
+				struct audio_feed_op_params p;
+				taskq_shared_t *sh = scheduler_shared();
+				int slot;
+
+				p.session = g_audio_playback.session;
+				p.src_addr = 0U;
+				p.src_len = 0U;
+				p.flags = 0U;
+				slot = taskq_enqueue(&sh->queue,
+				                     SDK_OP_AUDIO_STREAM_FEED,
+				                     TASK_LONG, 0u, 0u, 0u, 0u,
+				                     0u, 0u, &p, sizeof(p));
+				if (slot >= 0) {
+					g_task_generation[slot] =
+					    sdk_mailbox_generation;
+					__asm__ __volatile__("dsb ish\n\tsev"
+					                     ::: "memory");
+					g_audio_playback.refill_pending = 1U;
+				}
+			}
+		} else if (!stream->core1_affine) {
+			audio_stream_feed_compute(stream, 0U, 0U, 0U);
+		}
 	}
 }
 
@@ -5870,6 +5908,7 @@ void sdk_mailbox_init(void)
 	memset(surfaces, 0, sizeof(surfaces));
 	/* Unbind AX playback before the table goes away. */
 	g_audio_playback.session = 0U;
+	g_audio_playback.refill_pending = 0U;
 	/* Pointer into the coherent region, not an array: size explicitly.
 	 * Flush so the zeroed table is in DRAM whatever MMU attributes the
 	 * lines were filled under (this can run before the scheduler stamps
@@ -6076,6 +6115,13 @@ int sdk_mailbox_post_deferred(uint32_t request_id, uint32_t user_cookie,
 	uint32_t comp_head;
 	uint32_t comp_tail;
 	uint32_t next_comp_tail;
+
+	if (request_id == 0U) {
+		/* Internal task (AX playback refill): no client completion to
+		 * post; just retire the in-flight marker. */
+		g_audio_playback.refill_pending = 0U;
+		return 1;
+	}
 
 	if (!sdk_mailbox_active)
 		return 0;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3258,6 +3258,7 @@ static void audio_pump_fill_period(struct SDKAudioStream *stream,
 	uint32_t channels;
 	uint32_t src_frames;
 	uint32_t src_bytes;
+	uint32_t pull;
 	uint32_t offset;
 	uint32_t first;
 	uint8_t *ring;
@@ -3274,24 +3275,36 @@ static void audio_pump_fill_period(struct SDKAudioStream *stream,
 	if (src_frames == 0U || src_frames > (AUDIO_PUMP_PERIOD_BYTES / 4U))
 		goto silence;
 	src_bytes = src_frames * channels * 2U;
-	if ((stream->pcm_ready_total - stream->pcm_consumed_total) < src_bytes)
+	pull = stream->pcm_ready_total - stream->pcm_consumed_total;
+	if (pull >= src_bytes) {
+		pull = src_bytes;
+	} else if (!(stream->eof && stream->input_length == 0U) ||
+	           pull == 0U) {
 		goto silence;   /* underrun: a whole period of silence */
+	}
+	/* else: true end of stream (EOF fed, input fully consumed) with a
+	 * final PCM tail shorter than one 20 ms period -- MP3 frames owe
+	 * no alignment to rate/50. Drain it zero-padded; refusing partial
+	 * pulls would pin used above zero and the stream could never
+	 * report DONE. */
 
-	/* Pull one period's source from the PCM ring. The decode side
-	 * flushed these bytes before publishing pcm_ready_total, so a
-	 * reader-side invalidate makes them visible on this core. */
+	/* Pull the source from the PCM ring. The decode side flushed these
+	 * bytes before publishing pcm_ready_total, so a reader-side
+	 * invalidate makes them visible on this core. */
 	ring = (uint8_t *)(uintptr_t)stream->pcm_ring_addr;
 	offset = stream->pcm_consumed_total % stream->pcm_capacity;
 	first = stream->pcm_capacity - offset;
-	if (first > src_bytes)
-		first = src_bytes;
+	if (first > pull)
+		first = pull;
 	Xil_DCacheInvalidateRange((INTPTR)(ring + offset), first);
 	memcpy(g_pump_src, ring + offset, first);
-	if (src_bytes > first) {
-		Xil_DCacheInvalidateRange((INTPTR)ring, src_bytes - first);
-		memcpy((uint8_t *)g_pump_src + first, ring, src_bytes - first);
+	if (pull > first) {
+		Xil_DCacheInvalidateRange((INTPTR)ring, pull - first);
+		memcpy((uint8_t *)g_pump_src + first, ring, pull - first);
 	}
-	stream->pcm_consumed_total += src_bytes;
+	if (pull < src_bytes)
+		memset((uint8_t *)g_pump_src + pull, 0, src_bytes - pull);
+	stream->pcm_consumed_total += pull;
 
 	pcm = g_pump_src;
 	if (channels == 1U) {
@@ -3712,6 +3725,36 @@ static uint16_t handle_audio_stream_read(volatile struct SDKMailboxEntry *req,
 	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, stream);
 }
 
+/* True while a deferred FEED/READ for this session is still queued or
+ * executing on the scheduler. Both op-param structs start with the
+ * session word, and params are packed native-endian by core 0. A DONE
+ * slot is deliberately not counted: the worker has finished with the
+ * stream and its result payload already lives in the task slot, so
+ * only the (harmless) completion post remains. */
+static int audio_stream_tasks_inflight(uint32_t session)
+{
+	taskq_shared_t *sh;
+	uint32_t i;
+
+	if (!scheduler_core1_available())
+		return 0;
+	sh = scheduler_shared();
+	for (i = 0; i < TASKQ_CAPACITY; i++) {
+		volatile taskq_desc_t *d = &sh->queue.descs[i];
+		uint32_t st = d->state;
+
+		if (st != TASK_QUEUED && st != TASK_CLAIMED)
+			continue;
+		if (d->opcode != SDK_OP_AUDIO_STREAM_FEED &&
+		    d->opcode != SDK_OP_AUDIO_STREAM_READ)
+			continue;
+		if (((const struct audio_feed_op_params *)
+		         (uintptr_t)d->op_params)->session == session)
+			return 1;
+	}
+	return 0;
+}
+
 static uint16_t handle_audio_stream_close(volatile struct SDKMailboxEntry *req,
                                           volatile struct SDKMailboxEntry *comp,
                                           uint16_t payload_len)
@@ -3750,6 +3793,13 @@ static uint16_t handle_audio_stream_close(volatile struct SDKMailboxEntry *req,
 	 * between requests within milliseconds and the client retries. */
 	if (g_audio_playback.refill_pending &&
 	    g_audio_playback.refill_session == session)
+		return complete_status(req, comp, SDK_STATUS_BUSY);
+	/* Same hazard from the client side: an async caller can enqueue
+	 * CLOSE while its own deferred FEED/READ is still queued or
+	 * executing against this slot. (A synchronous caller cannot -- it
+	 * waits out each op -- so this only gates misuse of the async
+	 * API.) */
+	if (audio_stream_tasks_inflight(session))
 		return complete_status(req, comp, SDK_STATUS_BUSY);
 	snapshot = *stream;
 	free_audio_stream(stream);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3183,6 +3183,8 @@ static struct {
 	uint32_t session;         /* 0 = unbound */
 	uint32_t fill_offset;     /* next TX-ring byte to fill, period-aligned */
 	uint32_t refill_pending;  /* internal core-1 refill task in flight */
+	uint32_t refill_session;  /* session that refill targets (valid while
+	                             refill_pending; survives an unbind) */
 } g_audio_playback;
 
 static int16_t g_pump_src[AUDIO_PUMP_PERIOD_BYTES / 2];
@@ -3420,6 +3422,8 @@ void sdk_mailbox_audio_playback_pump(void)
 					__asm__ __volatile__("dsb ish\n\tsev"
 					                     ::: "memory");
 					g_audio_playback.refill_pending = 1U;
+					g_audio_playback.refill_session =
+					    g_audio_playback.session;
 				}
 			}
 		} else if (!stream->core1_affine) {
@@ -3728,18 +3732,17 @@ static uint16_t handle_audio_stream_close(volatile struct SDKMailboxEntry *req,
 	/* An internal PCM-refill FEED (request_id 0) may still be queued or
 	 * running on core 1 against this stream's coherent slot -- it was
 	 * enqueued for the bound session, which a prior STOP may already
-	 * have unbound, so it must be drained here regardless of the
+	 * have unbound, so refill_session is checked rather than the
 	 * binding above. Freeing the slot under the worker would zero the
-	 * decoder state mid-decode. The flag clears when the task's
-	 * deferred completion is reaped; pump the scheduler until then
-	 * (bounded: one decode pass; the guard covers a wedged core 1,
-	 * whose fault path poisons the stream anyway). */
-	if (g_audio_playback.refill_pending) {
-		uint32_t drain_guard = 10000000U;
-
-		while (g_audio_playback.refill_pending && drain_guard--)
-			scheduler_core0_poll(0, 0);
-	}
+	 * decoder state mid-decode. Draining it HERE is not an option:
+	 * that would nest scheduler_core0_poll inside a handler, and a
+	 * harvested foreign task would post its deferred completion into
+	 * the ring slot the outer dispatcher already reserved for THIS
+	 * request. Answer BUSY instead -- the main loop drains the refill
+	 * between requests within milliseconds and the client retries. */
+	if (g_audio_playback.refill_pending &&
+	    g_audio_playback.refill_session == session)
+		return complete_status(req, comp, SDK_STATUS_BUSY);
 	snapshot = *stream;
 	free_audio_stream(stream);
 	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, &snapshot);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3454,9 +3454,18 @@ static uint16_t handle_audio_stream_play(volatile struct SDKMailboxEntry *req,
 	if (g_audio_playback.session != 0U)
 		return complete_status(req, comp, SDK_STATUS_BUSY);
 
-	/* Deterministic output target: the standard TX ring (an earlier AHI
-	 * session may have repointed it). */
+	/* Deterministic output target: the standard TX ring. An AHI session
+	 * repoints the FORMATTER DMA at its own buffer (AP_TX_BUF_OFFS +
+	 * re-init) and closing AHI does not restore it -- and moving the
+	 * CPU-side pointer alone moves nothing, the DMA keeps reading the
+	 * buffer captured at the last audio_init_i2s(). Without the
+	 * re-init below, a bind after any AHI session plays silence: the
+	 * pump fills the default ring while the DMA reads AHI's dead one.
+	 * Safe here: PLAY runs in the main loop, and the ISR pump stays
+	 * gated off until the session publishes below. */
 	audio_set_tx_buffer((uint8_t *)AUDIO_TX_BUFFER_ADDRESS);
+	if (audio_get_inited_tx_buffer() != (uint8_t *)AUDIO_TX_BUFFER_ADDRESS)
+		audio_init_i2s();
 	pump_resample_reset();
 	pos = audio_get_dma_transfer_count() % AUDIO_PUMP_RING_BYTES;
 	pos -= pos % AUDIO_PUMP_PERIOD_BYTES;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3639,9 +3639,15 @@ static uint16_t handle_audio_stream_feed(volatile struct SDKMailboxEntry *req,
 		    SDK_STATUS_QUEUED)
 			return SDK_STATUS_QUEUED;
 		/* A core-1-affine stream cannot decode on core 0 (its mp3
-		 * staging ring is cache-owned by core 1). The sole synchronous
-		 * client sends stream ops singly, so a refused defer means a
-		 * full queue -- transient; answer BUSY rather than corrupt. */
+		 * staging ring is cache-owned by core 1), so a refused defer
+		 * answers BUSY rather than corrupt. Two refusal causes, both
+		 * retryable by contract: a full task queue (transient), and a
+		 * FEED that is not the batch tail -- deferring mid-batch would
+		 * let a later inline op in the same batch (PLAY/STOP/CLOSE)
+		 * execute before the queued decode, so ordering demands the
+		 * client resubmit. Every current client (zz9k.library sync
+		 * calls, mpega, the MHI feeder) sends stream ops singly and
+		 * never sees the batch case. */
 		return complete_status(req, comp, SDK_STATUS_BUSY);
 	}
 	/* Core-0-affine stream: inline, as the pre-scheduler firmware did. */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -3159,16 +3159,20 @@ static void audio_stream_read_compute(struct SDKAudioStream *stream,
 /*
  * ---- AX playback pump (MHI modernization) ----
  * One audio-stream session at a time may be bound to the AX output
- * (SDK_OP_AUDIO_STREAM_PLAY). The core-0 main loop calls the pump every
- * pass; it keeps the standard AX TX ring filled ahead of the
- * audio-formatter DMA from the session's PCM ring, one 3840-byte period
- * (20 ms of 48 kHz stereo S16LE) at a time. Underrun, a faulted session
- * or an unusable stream geometry produce silence. Non-48k sources go
- * through the existing resample_s16 path with the legacy DECODE_RUN
- * source math (rate/50 frames per period, integer truncation and its
- * slight drift included); mono sources are duplicated to stereo. The
- * pump is the CONSUMER of a bound session -- the single writer of
- * pcm_consumed_total -- so AUDIO_STREAM_READ is rejected while bound.
+ * (SDK_OP_AUDIO_STREAM_PLAY). The TX-fill half runs from the audio
+ * formatter's period INTERRUPT (sdk_mailbox_audio_playback_pump_isr,
+ * called by isr_audio every 20 ms) so heavy main-loop passes -- RTG
+ * blits, image-decode dispatch, network bursts -- can no longer let
+ * the DMA overrun the ~120 ms TX frontier and glitch the audio. Only
+ * the core-1 refill kick stays in the main loop (it enqueues scheduler
+ * tasks, which the ISR must not). The ISR path is integer-only: the
+ * standalone BSP does not save VFP state across interrupts, so non-48k
+ * sources go through a fixed-point mirror of the legacy resampler
+ * (same rate/50 source math, truncation drift included); mono sources
+ * are duplicated to stereo. Underrun, a faulted session or an unusable
+ * stream geometry produce silence. The ISR pump is the CONSUMER of a
+ * bound session -- the single writer of pcm_consumed_total -- so
+ * AUDIO_STREAM_READ is rejected while bound.
  */
 #define AUDIO_PUMP_PERIOD_BYTES  AUDIO_BYTES_PER_PERIOD
 #define AUDIO_PUMP_RING_BYTES    AUDIO_TX_BUFFER_SIZE
@@ -3183,6 +3187,67 @@ static struct {
 
 static int16_t g_pump_src[AUDIO_PUMP_PERIOD_BYTES / 2];
 static int16_t g_pump_stereo[AUDIO_PUMP_PERIOD_BYTES / 2];
+
+/*
+ * Fixed-point (16.16) linear resampler for the ISR pump -- a faithful
+ * integer mirror of ax.c's resample_s16 (which uses doubles and is
+ * therefore unusable in IRQ context), including its quirks: the
+ * fractional position keeps only its fraction across periods and the
+ * final source index is clamped, so pitch and boundary behavior match
+ * the long-proven main-loop path. State is reset when a session binds.
+ */
+static uint32_t g_pump_rs_cur;     /* 16.16 fractional source position */
+static int16_t g_pump_rs_prev_l;
+static int16_t g_pump_rs_prev_r;
+
+static void pump_resample_reset(void)
+{
+	g_pump_rs_cur = 0;
+	g_pump_rs_prev_l = 0;
+	g_pump_rs_prev_r = 0;
+}
+
+static void pump_resample_s16(const int16_t *input, int16_t *output,
+                              uint32_t in_rate, uint32_t in_frames,
+                              uint32_t out_frames)
+{
+	uint32_t step = (in_rate << 16) / 48000U;
+	uint32_t cur = g_pump_rs_cur;
+	int32_t inmax = (int32_t)in_frames - 1;
+	int32_t ip2 = 0;
+	uint32_t i;
+
+	for (i = 0; i < out_frames; i++) {
+		int32_t ip1;
+		uint32_t frac = cur & 0xFFFFU;
+		int32_t s1l, s1r;
+
+		ip2 = (int32_t)(cur >> 16);
+		ip1 = ip2 - 1;
+		if (ip2 > inmax) {
+			ip2 = inmax;
+			ip1 = inmax - 1;
+		}
+		if (ip1 < 0) {
+			s1l = g_pump_rs_prev_l;
+			s1r = g_pump_rs_prev_r;
+		} else {
+			s1l = input[2 * ip1];
+			s1r = input[2 * ip1 + 1];
+		}
+		output[2 * i] = (int16_t)((s1l * (int32_t)(65536U - frac) +
+		                           (int32_t)input[2 * ip2] *
+		                               (int32_t)frac) >> 16);
+		output[2 * i + 1] = (int16_t)((s1r * (int32_t)(65536U - frac) +
+		                               (int32_t)input[2 * ip2 + 1] *
+		                                   (int32_t)frac) >> 16);
+		cur += step;
+	}
+
+	g_pump_rs_prev_l = input[2 * ip2];
+	g_pump_rs_prev_r = input[2 * ip2 + 1];
+	g_pump_rs_cur = cur & 0xFFFFU;
+}
 
 static void audio_pump_fill_period(struct SDKAudioStream *stream,
                                    uint8_t *slot)
@@ -3237,15 +3302,18 @@ static void audio_pump_fill_period(struct SDKAudioStream *stream,
 	if (rate == 48000U) {
 		memcpy(slot, pcm, AUDIO_PUMP_PERIOD_BYTES);
 	} else {
-		resample_s16(pcm, (int16_t *)slot, (int)rate, 48000,
-		             AUDIO_PUMP_PERIOD_BYTES / 4);
+		pump_resample_s16(pcm, (int16_t *)slot, rate, src_frames,
+		                  AUDIO_PUMP_PERIOD_BYTES / 4);
 	}
 	return;
 silence:
 	memset(slot, 0, AUDIO_PUMP_PERIOD_BYTES);
 }
 
-void sdk_mailbox_audio_playback_pump(void)
+/* TX-fill half: called from isr_audio (audio-formatter period IRQ,
+ * every 20 ms) so main-loop load cannot starve the TX frontier.
+ * Integer-only; no scheduler/taskq/printf access from here. */
+void sdk_mailbox_audio_playback_pump_isr(void)
 {
 	struct SDKAudioStream *stream;
 	uint8_t *tx = (uint8_t *)AUDIO_TX_BUFFER_ADDRESS;
@@ -3295,6 +3363,19 @@ void sdk_mailbox_audio_playback_pump(void)
 		g_audio_playback.fill_offset =
 		    (g_audio_playback.fill_offset + AUDIO_PUMP_PERIOD_BYTES) %
 		    AUDIO_PUMP_RING_BYTES;
+	}
+}
+
+void sdk_mailbox_audio_playback_pump(void)
+{
+	struct SDKAudioStream *stream;
+
+	if (g_audio_playback.session == 0U)
+		return;
+	stream = find_audio_stream(g_audio_playback.session);
+	if (!stream) {
+		g_audio_playback.session = 0U;   /* closed under us */
+		return;
 	}
 
 	/* Keep the decoder ahead of the pump. Session FEEDs drive decode, but
@@ -3376,12 +3457,16 @@ static uint16_t handle_audio_stream_play(volatile struct SDKMailboxEntry *req,
 	/* Deterministic output target: the standard TX ring (an earlier AHI
 	 * session may have repointed it). */
 	audio_set_tx_buffer((uint8_t *)AUDIO_TX_BUFFER_ADDRESS);
-	g_audio_playback.session = session;
+	pump_resample_reset();
 	pos = audio_get_dma_transfer_count() % AUDIO_PUMP_RING_BYTES;
 	pos -= pos % AUDIO_PUMP_PERIOD_BYTES;
 	g_audio_playback.fill_offset =
 	    (pos + AUDIO_PUMP_PERIOD_BYTES) % AUDIO_PUMP_RING_BYTES;
-	sdk_mailbox_audio_playback_pump();   /* prefill */
+	/* Publish the session LAST: the ISR pump gates on it, and the same
+	 * core observes these stores in program order. Filling starts on
+	 * the next period interrupt (<= 20 ms). */
+	__asm__ __volatile__("" ::: "memory");
+	g_audio_playback.session = session;
 	return complete_audio_stream_result(req, comp, SDK_STATUS_OK, stream);
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -40,6 +40,7 @@
 #define SDK_CAP_IMAGE_SCALE            (1U << 6)
 #define SDK_CAP_AUDIO_DECODE           (1U << 7)
 #define SDK_CAP_CRYPTO                 (1U << 8)
+#define SDK_CAP_AUDIO_PLAYBACK         (1U << 9)
 #define SDK_CAP_MEMORY_OPS             (1U << 10)
 #define SDK_CAP_DIAGNOSTICS            (1U << 11)
 #define SDK_CAP_DOORBELL               (1U << 12)
@@ -149,6 +150,8 @@
 #define SDK_OP_AUDIO_STREAM_FEED       0x0504U
 #define SDK_OP_AUDIO_STREAM_READ       0x0505U
 #define SDK_OP_AUDIO_STREAM_CLOSE      0x0506U
+#define SDK_OP_AUDIO_STREAM_PLAY       0x0507U
+#define SDK_OP_AUDIO_STREAM_STOP       0x0508U
 
 #define SDK_OP_DECOMPRESS              0x0600U
 #define SDK_OP_DECOMPRESS_TEST         0x0601U
@@ -393,6 +396,10 @@ uint32_t sdk_mailbox_address(void);
 /* After a core-1 fault: mark core-1-affine audio streams faulted so their
  * feeds/reads fail cleanly (the embedded decoder may be mid-frame). */
 void sdk_mailbox_poison_core1_audio_streams(void);
+/* AX playback pump: keeps the audio TX ring filled from the bound
+ * audio-stream session (SDK_OP_AUDIO_STREAM_PLAY). Call from the core-0
+ * main loop every pass; no-op when nothing is bound. */
+void sdk_mailbox_audio_playback_pump(void);
 
 /*
  * Run a crypto task's compute on the calling core. op_params points at one of

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -390,6 +390,9 @@ void sdk_mailbox_irq_disable(void);
 void sdk_mailbox_task(void);
 uint16_t sdk_mailbox_status(void);
 uint32_t sdk_mailbox_address(void);
+/* After a core-1 fault: mark core-1-affine audio streams faulted so their
+ * feeds/reads fail cleanly (the embedded decoder may be mid-frame). */
+void sdk_mailbox_poison_core1_audio_streams(void);
 
 /*
  * Run a crypto task's compute on the calling core. op_params points at one of

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -40,7 +40,7 @@
 #define SDK_CAP_IMAGE_SCALE            (1U << 6)
 #define SDK_CAP_AUDIO_DECODE           (1U << 7)
 #define SDK_CAP_CRYPTO                 (1U << 8)
-#define SDK_CAP_AUDIO_PLAYBACK         (1U << 9)
+#define SDK_CAP_AUDIO_PLAYBACK         (1U << 19)
 #define SDK_CAP_MEMORY_OPS             (1U << 10)
 #define SDK_CAP_DIAGNOSTICS            (1U << 11)
 #define SDK_CAP_DOORBELL               (1U << 12)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -396,10 +396,15 @@ uint32_t sdk_mailbox_address(void);
 /* After a core-1 fault: mark core-1-affine audio streams faulted so their
  * feeds/reads fail cleanly (the embedded decoder may be mid-frame). */
 void sdk_mailbox_poison_core1_audio_streams(void);
-/* AX playback pump: keeps the audio TX ring filled from the bound
- * audio-stream session (SDK_OP_AUDIO_STREAM_PLAY). Call from the core-0
- * main loop every pass; no-op when nothing is bound. */
+/* AX playback pump, split in two:
+ *  - sdk_mailbox_audio_playback_pump_isr: TX-fill half, called from the
+ *    audio-formatter period interrupt (isr_audio, every 20 ms) so
+ *    main-loop load cannot starve the TX frontier. Integer-only.
+ *  - sdk_mailbox_audio_playback_pump: core-1 refill kick, call from the
+ *    core-0 main loop every pass.
+ * Both are no-ops when nothing is bound. */
 void sdk_mailbox_audio_playback_pump(void);
+void sdk_mailbox_audio_playback_pump_isr(void);
 
 /*
  * Run a crypto task's compute on the calling core. op_params points at one of


### PR DESCRIPTION
Moves MP3 audio streaming onto the dual-core scheduler and gives the SDK audio-stream sessions a direct playback path to the ZZ9000AX output, replacing the legacy register-driven decoder that froze the system when driven through the MHI library.

## Firmware side of the MHI modernization (bench-complete, 11 HW rounds)

- **Core-1 routing**: AUDIO_STREAM FEED/READ run as scheduler tasks with the established session-affinity pattern; PCM ring cursors split into single-writer monotonic totals so decode (core 1) and the consumer never share a writer.
- **AX playback binding**: `AUDIO_STREAM_PLAY`/`STOP` (0x0507/0x0508) bind one session to the AX output. The firmware pump feeds the audio DMA straight from the session's PCM ring — PCM never crosses Zorro and the 68k does no per-period work.
- **Interrupt-driven TX fill**: the pump's TX-fill half runs from the audio-formatter period IRQ (20 ms guaranteed), so RTG/image/network load on the main loop can no longer overrun the ~120 ms TX frontier. IRQ context gets a fixed-point mirror of the resampler (the BSP doesn't save VFP state in interrupts). Only the core-1 refill kick stays in the main loop.
- **Legacy decoder removed**: the ZZ_REG_DECODE register family reads as 0; streaming MP3 is sessions-only. The shipped SDK mpega.library is unaffected (one-shot/session ops).
- **Fixes found at the bench**: pump frontier off-by-one-period that defeated FEED backpressure, u32 ring-distance wrap bias, BEGIN low-water validated against the wrong ring, 16K minimum-input decode gate that deadlocked small input rings, and a core-1 refill-task storm guard.
- `SDK_CAP_AUDIO_PLAYBACK` = bit 19.

Ships together with zz9000-sdk#audio-playback-op (library 2.25) and zz9000-drivers#mhi-sdk-sessions (driver rewrite). SDK_REF bump deferred to the next tagged release as agreed.

Bench: AmigaAMP + HippoPlayer transport/format matrix, MHI→AHI warm handover (the historic trap 0x80000006 scenario), AHI-active refusal, load robustness (browser + PNG/JPEG decode + disk I/O), zz9k-info core-1 counters — all PASS on Z3/68060/ZZ9000AX.