### PR TITLE
Add a Zorro 2 host-window heap for SDK shared allocations

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
@@ -39,6 +39,34 @@
 
 #define SDK_LOW_DDR_RESERVED_END     0x08000000
 
+// Host-window heap: the ONLY SDK allocation region a Zorro 2 board can
+// reach. The Z2 autoconfig window is 4 MB, so the shared heap at
+// 0x03000000 (board offset ~46 MB) is unreachable from the host there.
+// The RTG driver frees board 0x3E0000..0x3F0000 for this heap by
+// shrinking Z2 VRAM 64 KB (its template scratch, placed at MemorySize,
+// slides down with it); the AHI/MHI audio scratch starts right above at
+// board 0x3F0000. ARM address = board offset + ADDR_ADJ. Allocations
+// land here only when the client passes SDK_ALLOC_HOST_WINDOW --
+// default allocations stay in the shared heap so Z2 crypto offload
+// keeps failing fast into its software fallback instead of squeezing
+// through this tiny region.
+#define SDK_HOST_WINDOW_HEAP_ADDRESS 0x005D0000
+#define SDK_HOST_WINDOW_HEAP_SIZE    0x00010000
+#define SDK_HOST_WINDOW_HEAP_END \
+    (SDK_HOST_WINDOW_HEAP_ADDRESS + SDK_HOST_WINDOW_HEAP_SIZE)
+
+#if SDK_HOST_WINDOW_HEAP_ADDRESS < FRAMEBUFFER_ADDRESS
+#error "host-window heap must sit inside the board-window DDR region"
+#endif
+// Board offset of the heap end must fit the 4 MB Zorro 2 aperture.
+#if (SDK_HOST_WINDOW_HEAP_END - ADDR_ADJ) > 0x00400000
+#error "host-window heap exceeds the 4 MB Zorro 2 board window"
+#endif
+// Must not reach into the Z2 audio scratch (board 0x3F0000 = ARM 0x5E0000).
+#if SDK_HOST_WINDOW_HEAP_END > (0x003F0000 + ADDR_ADJ)
+#error "host-window heap overlaps the Z2 audio scratch"
+#endif
+
 // SDK v2 host-visible heap. Keep this below the 0x033f0000 scratch area used
 // by the firmware until the SDK owns a formally reserved allocator region.
 // SDK_OP_DECOMPRESS_BATCH decodes entirely inside a host-provided arena

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/memorymap.h
@@ -50,6 +50,15 @@
 // default allocations stay in the shared heap so Z2 crypto offload
 // keeps failing fast into its software fallback instead of squeezing
 // through this tiny region.
+// The placement assumes the STANDARD 4 MB Zorro 2 window. The 2 MB
+// bitstream variants (VARIANT_2MB in mntzorro.v: zorro2-2mb, a500-2mb)
+// cannot reach board offset 0x3E0000, and this ELF cannot tell which
+// bitstream is loaded (RAM_SIZE is an FPGA compile-time constant), so
+// zz9k.library refuses HOST_WINDOW requests when the autoconfig window
+// is smaller than 4 MB (ZZ9K_HOST_WINDOW_MIN_BOARD_SIZE) -- those
+// boards keep the plain software paths. Serving 2 MB variants would
+// need the heap placed window-relative with the host reporting its
+// window size.
 #define SDK_HOST_WINDOW_HEAP_ADDRESS 0x005D0000
 #define SDK_HOST_WINDOW_HEAP_SIZE    0x00010000
 #define SDK_HOST_WINDOW_HEAP_END \

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -42,7 +42,8 @@
 	 SDK_CAP_IMAGE_SCALE | SDK_CAP_AUDIO_DECODE | \
 	 SDK_CAP_AUDIO_PLAYBACK | \
 	 SDK_CAP_MEMORY_OPS | SDK_CAP_CRYPTO | \
-	 SDK_CAP_DIAGNOSTICS | SDK_CAP_SURFACE_OPS | SDK_CAP_COMPRESSION)
+	 SDK_CAP_DIAGNOSTICS | SDK_CAP_SURFACE_OPS | SDK_CAP_COMPRESSION | \
+	 SDK_CAP_HOST_WINDOW_HEAP)
 /* Decode proceeds only with at least this much undecoded input (unless
  * EOF): enough for the largest legal MP3 frame (~1.4K, 2.3K free-format)
  * plus sync lookahead. It must stay WELL below any client's input-ring
@@ -95,7 +96,8 @@ struct SDKCapsPayload {
 	uint8_t firmware_version[4];
 	uint8_t request_ring_entries[4];
 	uint8_t completion_ring_entries[4];
-	uint8_t reserved[12];
+	uint8_t host_window_heap_size[4];
+	uint8_t reserved[8];
 };
 
 struct SDKQueryServicePayload {
@@ -1382,12 +1384,21 @@ static int local_surface_range_valid(uint32_t address, uint32_t length)
 	                   SDK_LOCAL_SURFACE_HEAP_SIZE);
 }
 
+static int host_window_range_valid(uint32_t address, uint32_t length)
+{
+	return range_valid(address, length,
+	                   SDK_HOST_WINDOW_HEAP_ADDRESS,
+	                   SDK_HOST_WINDOW_HEAP_SIZE);
+}
+
 static int shared_buffer_live(const struct SDKSharedBuffer *buffer)
 {
 	if (!buffer || !buffer->in_use)
 		return 0;
 	if (buffer->handle == 0 || buffer->handle == SDK_INVALID_HANDLE)
 		return 0;
+	if ((buffer->flags & SDK_ALLOC_HOST_WINDOW) != 0U)
+		return host_window_range_valid(buffer->address, buffer->length);
 	return heap_range_valid(buffer->address, buffer->length);
 }
 
@@ -1794,6 +1805,16 @@ static uint32_t find_free_local_surface_region(uint32_t length,
 	                           length, alignment, 1);
 }
 
+static uint32_t find_free_host_window_region(uint32_t length,
+                                             uint32_t alignment)
+{
+	/* Shared-heap blocks can never overlap a candidate here (disjoint
+	 * regions), so the region-agnostic overlap scan is reusable. */
+	return find_free_region_in(SDK_HOST_WINDOW_HEAP_ADDRESS,
+	                           SDK_HOST_WINDOW_HEAP_SIZE,
+	                           length, alignment, 0);
+}
+
 static uint16_t handle_alloc_shared(volatile struct SDKMailboxEntry *req,
                                     volatile struct SDKMailboxEntry *comp,
                                     uint16_t payload_len)
@@ -1815,9 +1836,15 @@ static uint16_t handle_alloc_shared(volatile struct SDKMailboxEntry *req,
 	flags = get_be32(payload->flags);
 	if (alignment == 0)
 		alignment = 16U;
-	if (length == 0 || length > SDK_SHARED_HEAP_SIZE ||
-	    !is_power_of_two(alignment))
+	if (length == 0 || !is_power_of_two(alignment))
 		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+	if ((flags & SDK_ALLOC_HOST_WINDOW) != 0U) {
+		if (length > SDK_HOST_WINDOW_HEAP_SIZE)
+			return complete_status(req, comp,
+			                       SDK_STATUS_BAD_REQUEST);
+	} else if (length > SDK_SHARED_HEAP_SIZE) {
+		return complete_status(req, comp, SDK_STATUS_BAD_REQUEST);
+	}
 
 	sanitize_allocator_metadata();
 	slot = find_free_buffer_slot();
@@ -1825,7 +1852,10 @@ static uint16_t handle_alloc_shared(volatile struct SDKMailboxEntry *req,
 		return complete_status(req, comp, SDK_STATUS_NO_MEMORY);
 	memset(slot, 0, sizeof(*slot));
 
-	address = find_free_region(length, alignment);
+	if ((flags & SDK_ALLOC_HOST_WINDOW) != 0U)
+		address = find_free_host_window_region(length, alignment);
+	else
+		address = find_free_region(length, alignment);
 	if (address == 0)
 		return complete_status(req, comp, SDK_STATUS_NO_MEMORY);
 
@@ -6129,6 +6159,7 @@ static uint16_t handle_request(volatile struct SDKMailboxEntry *req,
 		put_be32(caps->firmware_version, 0);
 		put_be32(caps->request_ring_entries, SDK_MAILBOX_RING_ENTRIES);
 		put_be32(caps->completion_ring_entries, SDK_MAILBOX_RING_ENTRIES);
+		put_be32(caps->host_window_heap_size, SDK_HOST_WINDOW_HEAP_SIZE);
 		return SDK_STATUS_OK;
 	}
 	case SDK_OP_QUERY_SERVICE:

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -56,6 +56,11 @@
 // host-window heap so a Zorro 2 host can map it; CARD_ONLY is a
 // host-side declaration ("the 68k never touches this buffer") that the
 // firmware merely stores and echoes.
+// The firmware honors HOST_WINDOW on any bus and window size --
+// zz9k.library is the enforcement point: it strips the bit on Zorro 3
+// (where the heap region lies inside P96 VRAM) and refuses it on
+// sub-4 MB Zorro 2 windows (2 MB bitstream variants, which cannot
+// reach the heap's board offset).
 #define SDK_ALLOC_HOST_WINDOW     (1U << 0)
 #define SDK_ALLOC_CARD_ONLY       (1U << 1)
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.h
@@ -48,6 +48,16 @@
 #define SDK_CAP_SERVICE_DISCOVERY      (1U << 14)
 #define SDK_CAP_SURFACE_OPS            (1U << 15)
 #define SDK_CAP_COMPRESSION            (1U << 16)
+// Firmware serves SDK_ALLOC_HOST_WINDOW allocations from the small
+// board-window-reachable heap (Zorro 2 support; see memorymap.h).
+#define SDK_CAP_HOST_WINDOW_HEAP       (1U << 20)
+
+// SDK_OP_ALLOC_SHARED flags. HOST_WINDOW places the buffer in the
+// host-window heap so a Zorro 2 host can map it; CARD_ONLY is a
+// host-side declaration ("the 68k never touches this buffer") that the
+// firmware merely stores and echoes.
+#define SDK_ALLOC_HOST_WINDOW     (1U << 0)
+#define SDK_ALLOC_CARD_ONLY       (1U << 1)
 
 #ifndef SDK_ENABLE_HDL_TRANSPORT
 #define SDK_ENABLE_HDL_TRANSPORT       0

--- a/util/test_sdk_mailbox_cache_policy.c
+++ b/util/test_sdk_mailbox_cache_policy.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 	ok &= expect_contains(source, "uint32_t input_offset;");
 	ok &= expect_contains(source, "static void audio_stream_compact_input");
 	ok &= expect_contains(
-		source, "#define SDK_AUDIO_STREAM_MIN_INPUT_BYTES (16U * 1024U)");
+		source, "#define SDK_AUDIO_STREAM_MIN_INPUT_BYTES (4U * 1024U)");
 	ok &= expect_contains(source, "static int audio_stream_needs_more_input");
 	ok &= expect_contains(
 		source, "stream->input_length < SDK_AUDIO_STREAM_MIN_INPUT_BYTES");

--- a/util/test_sdk_memory_map.c
+++ b/util/test_sdk_memory_map.c
@@ -115,6 +115,14 @@ int main(int argc, char **argv)
 	                      "SDK_LOCAL_SURFACE_HEAP_END > SDK_LOW_DDR_RESERVED_END");
 	ok &= expect_not_contains(memorymap, "memorymap.h",
 	                          "#define SDK_LOCAL_SURFACE_HEAP_ADDRESS 0x03400000");
+	ok &= expect_contains(memorymap, "memorymap.h",
+	                      "#define SDK_HOST_WINDOW_HEAP_ADDRESS 0x005D0000");
+	ok &= expect_contains(memorymap, "memorymap.h",
+	                      "#define SDK_HOST_WINDOW_HEAP_SIZE    0x00010000");
+	ok &= expect_contains(memorymap, "memorymap.h",
+	                      "(SDK_HOST_WINDOW_HEAP_END - ADDR_ADJ) > 0x00400000");
+	ok &= expect_contains(memorymap, "memorymap.h",
+	                      "SDK_HOST_WINDOW_HEAP_END > (0x003F0000 + ADDR_ADJ)");
 
 	ok &= expect_contains(main_source, "main.c",
 	                      "cur_mem_offset = LEGACY_SURFACE_HEAP_ADDRESS");


### PR DESCRIPTION
Part of the fix for **BlitterStudio/zz9000-drivers#33** (Zorro 2: MP3 dead after the MHI modernization).

## Problem

The SDK shared heap at ARM `0x03000000` sits at board offset ~46 MB — far outside the 4 MB Zorro 2 window. Every host-visible `SDK_OP_ALLOC_SHARED` result was unmappable on Z2, so the SDK-session audio path (MHI/mpega MP3) could never start there. The legacy register decoder is gone since the MHI modernization, so there was no fallback.

## Changes

- **64 KB host-window heap at ARM `0x005D0000`** (board offset `0x3E0000`). Z2 board layout after the companion RTG carve: VRAM `0x10000–0x3D0000`, template scratch `0x3D0000–0x3E0000` (slides down with `MemorySize`), **this heap `0x3E0000–0x3F0000`**, AHI/MHI audio scratch `0x3F0000–0x400000`. `#if` guards pin it inside the 4 MB aperture and clear of the audio scratch.
- **`SDK_ALLOC_HOST_WINDOW`** (bit 0) allocates from the new heap; **`SDK_ALLOC_CARD_ONLY`** (bit 1) is stored/echoed for the host library. Buffer validation is region-aware via the stored flags (`host_window_range_valid`, mirroring the ARM-local surface-heap pattern); the free-region scan is reused as-is (regions are disjoint).
- **QUERY_CAPS** advertises `SDK_CAP_HOST_WINDOW_HEAP` (bit 20) + `host_window_heap_size` in previously-reserved payload bytes — payload stays 48 bytes, old parsers ignore it.
- Source-guard updates: new region in `test_sdk_memory_map`; fixed the stale 16K→4K `SDK_AUDIO_STREAM_MIN_INPUT_BYTES` expectation in `test_sdk_mailbox_cache_policy` (stale since #44).

**No cache-policy changes needed**: all DDR is write-back cacheable and every SDK data path already does explicit invalidate/flush maintenance regardless of region.

**Compatibility**: old clients pass `flags=0` → identical behavior. Plain allocations still land in the default heap, so Z2 crypto offload keeps failing fast into its software fallback (the settled #33 crypto decision) instead of squeezing through the tiny host window.

## Validation

- `ZZ9000OS.elf` builds in the Docker toolchain.
- All `util/` source guards pass; `check-abi-mirror.sh` against the companion SDK branch is clean.
- Hardware validation on a real Z2 machine goes through the #33 reporter once CI artifacts are ready.

## Companion PRs (merge order per RELEASING.md)

- zz9000-sdk#11 (alloc flags + leak fix + mpega)
- zz9000-drivers: RTG 64 KB Z2 VRAM carve + MHI alloc flags

⚠️ Skew note: an **old ZZ9000.card with this firmware** still places its template scratch over the new heap — ship bundled (documented in drivers RELEASING.md).