### PR TITLE
Document ENV-over-config precedence and ZZTop editing for ZZ9000.CFG

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,13 @@ sample; the copy at the repo root documents every option:
 
 Unknown keys and invalid values are logged on the debug UART and
 skipped. Runtime mechanisms (driver register writes, ZZTop) still
-override config values until the next power cycle.
+override config values until the next power cycle. For the
+driver-consumed options (`int2`, `mac`, `videocap_mode`,
+`nonstandard_vsync`), an existing `ENV:` variable takes precedence
+over the config file — remove the ENV variables when migrating.
+ZZTop 2.3+ can edit this file in place from AmigaOS (Project menu →
+Settings), writing it back over the FWUP path with a `ZZ9000.bak`
+backup of the previous version.
 
 Amiga-side software can query parsed values through the
 `REG_ZZ_CONFIG_KEY` register (`0xE8`): write a key id from

--- a/ZZ9000.CFG
+++ b/ZZ9000.CFG
@@ -8,6 +8,12 @@
 # Lines starting with # or ; are comments. All options are optional;
 # a missing option keeps the firmware's built-in default. Keys and
 # values are case-insensitive.
+#
+# The options marked "replaces ENV:..." are also consulted by the
+# Amiga drivers (firmware 2.3+ drivers). If the old ENV: variable
+# still exists, it takes precedence over this file - remove the ENV
+# variable when migrating. ZZTop 2.3+ edits this file in place
+# (Project menu -> Settings).
 
 # ---------------------------------------------------------------------
 # videocap_mode: HDMI output mode used for Amiga native (chipset) video


### PR DESCRIPTION
Docs-only follow-up to #47: now that the Amiga drivers (zz9000-drivers PR #37) and the SDK (zz9000-sdk PR #12) consult ZZ9000.CFG, document that an existing ENV: variable takes precedence over the config file for driver-consumed options, and that ZZTop 2.3+ edits the file in place over the FWUP path.