### PR TITLE
Bypass FatFs for HDF block I/O via one-time extent map

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sd_boot.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sd_boot.c
@@ -13,7 +13,9 @@
 
 static uint32_t be32(uint32_t v) { return __builtin_bswap32(v); }
 
-static uint8_t block_buf[512];
+/* 32-byte aligned: sd_storage's raw path DMAs directly into this
+ * buffer, and the cache maintenance works on whole cache lines. */
+static uint8_t block_buf[512] __attribute__((aligned(32)));
 static struct sd_boot_info boot_info;
 static int boot_info_valid = 0;
 #define SD_BOOT_FS_BUF_SIZE (64 * 1024)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sd_storage.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sd_storage.c
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
  * Presents a single HDF file on the SD card (FAT32) as a raw block
- * device. All block I/O from the m68k side funnels through a FatFs
- * f_read/f_write on an open HDF file. The SD peripheral is owned by
+ * device. At init the HDF's cluster chain is resolved into an extent
+ * map; block I/O from the m68k side then goes straight to
+ * disk_read/disk_write at physical LBAs (FatFs f_read/f_write only as
+ * a fallback for unmappable files). The SD peripheral is owned by
  * xilffs' disk_initialize — we do not drive XSdPs directly.
  */
 
 #include <stdio.h>
 #include <string.h>
 #include <ff.h>
+#include <diskio.h>
 #include "xil_cache.h"
 #include "sd_activity_led.h"
 #include "sd_storage.h"
@@ -37,7 +40,147 @@ static const char* hdf_path(void) {
 static FATFS fatfs;
 static FIL   hdf_file;
 static int   hdf_open = 0;
+static int   hdf_read_only = 0;
 static uint32_t hdf_capacity_blocks = 0;
+
+/* Raw block I/O fast path.
+ *
+ * Going through f_lseek/f_read/f_write for every guest request is
+ * pathologically slow: the BSP's FatFs is built with FF_USE_FASTSEEK=0,
+ * so any seek to a lower file offset rewinds to the file's first
+ * cluster and re-walks the whole FAT chain through the one-sector
+ * fs->win cache — hundreds of SD commands per seek on a multi-GB HDF,
+ * and Amiga filesystems seek backwards (bitmap <-> data) all the time.
+ *
+ * Instead we resolve the HDF's cluster chain once at init into a table
+ * of contiguous extents and service all block I/O with direct
+ * multi-sector disk_read()/disk_write() at physical LBAs. The HDF is
+ * opened FA_OPEN_EXISTING and never grows, so raw data writes touch no
+ * FAT/directory metadata and need no f_sync. If the chain can't be
+ * mapped (FAT12, corrupt chain, or more extents than the table) we
+ * fall back to the old FatFs path. */
+#define HDF_MAX_EXTENTS 1024
+struct hdf_extent {
+    uint32_t vblock;  /* first logical 512-byte block of this extent */
+    uint32_t lba;     /* physical sector on the SD card */
+    uint32_t count;   /* extent length in sectors */
+};
+static struct hdf_extent hdf_extents[HDF_MAX_EXTENTS];
+static uint32_t hdf_extent_count = 0;
+static uint8_t  hdf_pdrv = 0;
+static int      hdf_raw = 0;
+
+/* FAT window for the one-time chain walk; 32 sectors per disk_read
+ * keeps the walk to a handful of SD commands even for large FATs. */
+#define FAT_WIN_SECTORS 32
+static uint8_t fat_win[FAT_WIN_SECTORS * SD_BLOCK_SIZE] __attribute__((aligned(32)));
+
+static int fat_next(FATFS *fs, uint32_t fat_win_state[2], uint32_t clst, uint32_t *next) {
+    uint32_t entry_bytes = (fs->fs_type == FS_FAT32) ? 4 : 2;
+    uint32_t byte_off = clst * entry_bytes;
+    uint32_t sect = fs->fatbase + byte_off / SD_BLOCK_SIZE;
+    uint32_t win_sect = fat_win_state[0];
+    uint32_t win_count = fat_win_state[1];
+
+    if (win_count == 0 || sect < win_sect || sect >= win_sect + win_count) {
+        uint32_t fat_end = fs->fatbase + fs->fsize;
+        uint32_t n = FAT_WIN_SECTORS;
+        if (sect >= fat_end) return -1;
+        if (sect + n > fat_end) n = fat_end - sect;
+        if (disk_read(fs->pdrv, fat_win, sect, n) != RES_OK) return -1;
+        fat_win_state[0] = win_sect = sect;
+        fat_win_state[1] = win_count = n;
+    }
+
+    const uint8_t *p = fat_win + (sect - win_sect) * SD_BLOCK_SIZE
+                     + (byte_off % SD_BLOCK_SIZE);
+    if (fs->fs_type == FS_FAT32) {
+        *next = ((uint32_t)p[0] | (uint32_t)p[1] << 8 |
+                 (uint32_t)p[2] << 16 | (uint32_t)p[3] << 24) & 0x0FFFFFFF;
+    } else {
+        *next = (uint32_t)p[0] | (uint32_t)p[1] << 8;
+    }
+    return 0;
+}
+
+static int hdf_push_extent(FATFS *fs, uint32_t run_first, uint32_t run_len,
+                           uint32_t *covered) {
+    if (hdf_extent_count >= HDF_MAX_EXTENTS) return -1;
+    struct hdf_extent *e = &hdf_extents[hdf_extent_count++];
+    e->vblock = *covered;
+    e->lba = fs->database + (run_first - 2) * fs->csize;
+    e->count = run_len * fs->csize;
+    *covered += e->count;
+    return 0;
+}
+
+static int hdf_build_extent_map(void) {
+    FATFS *fs = hdf_file.obj.fs;
+    uint32_t fat_win_state[2] = {0, 0};
+
+    hdf_extent_count = 0;
+
+    if (fs->fs_type != FS_FAT16 && fs->fs_type != FS_FAT32) return -1;
+
+    uint32_t clst = hdf_file.obj.sclust;
+    if (clst < 2 || clst >= fs->n_fatent) return -1;
+
+    uint32_t covered = 0;      /* logical sectors mapped so far */
+    uint32_t run_first = clst; /* first cluster of the current run */
+    uint32_t run_len = 1;      /* clusters in the current run */
+
+    while (covered + run_len * fs->csize < hdf_capacity_blocks) {
+        uint32_t next;
+        if (fat_next(fs, fat_win_state, clst, &next)) return -1;
+        if (next == clst + 1 && next < fs->n_fatent) {
+            run_len++;
+            clst = next;
+            continue;
+        }
+        if (hdf_push_extent(fs, run_first, run_len, &covered)) return -1;
+        /* Chain must continue — the file size says more clusters follow. */
+        if (next < 2 || next >= fs->n_fatent) return -1;
+        run_first = next;
+        run_len = 1;
+        clst = next;
+    }
+    if (hdf_push_extent(fs, run_first, run_len, &covered)) return -1;
+
+    hdf_pdrv = fs->pdrv;
+    return 0;
+}
+
+static uint32_t hdf_raw_io(uint32_t block, uint32_t num_blocks, uint8_t *buffer,
+                           int is_write) {
+    while (num_blocks) {
+        /* Binary search for the extent containing `block` (extents are
+         * sorted by vblock and cover the whole HDF). */
+        uint32_t lo = 0, hi = hdf_extent_count - 1;
+        while (lo < hi) {
+            uint32_t mid = (lo + hi + 1) / 2;
+            if (hdf_extents[mid].vblock <= block) lo = mid; else hi = mid - 1;
+        }
+        struct hdf_extent *e = &hdf_extents[lo];
+        uint32_t off = block - e->vblock;
+        uint32_t n = e->count - off;
+        if (n > num_blocks) n = num_blocks;
+
+        DRESULT dr = is_write
+            ? disk_write(hdf_pdrv, buffer, e->lba + off, n)
+            : disk_read(hdf_pdrv, buffer, e->lba + off, n);
+        if (dr != RES_OK) {
+            printf("[SD] raw %s(block=%lu count=%lu lba=%lu) failed: %d\n",
+                   is_write ? "write" : "read",
+                   (unsigned long)block, (unsigned long)n,
+                   (unsigned long)(e->lba + off), (int)dr);
+            return 0xFD;
+        }
+        block += n;
+        buffer += n * SD_BLOCK_SIZE;
+        num_blocks -= n;
+    }
+    return 0;
+}
 
 int sd_storage_init(void) {
     FRESULT fr;
@@ -46,6 +189,8 @@ int sd_storage_init(void) {
         f_close(&hdf_file);
     }
     hdf_open = 0;
+    hdf_read_only = 0;
+    hdf_raw = 0;
     hdf_capacity_blocks = 0;
 
     fr = f_mount(&fatfs, HDF_VOLUME "/", 1);
@@ -67,6 +212,7 @@ int sd_storage_init(void) {
             return 0;
         }
         printf("[SD] HDF opened read-only\n");
+        hdf_read_only = 1;
     }
 
     FSIZE_t size_bytes = f_size(&hdf_file);
@@ -85,6 +231,16 @@ int sd_storage_init(void) {
            (unsigned long)hdf_capacity_blocks,
            (unsigned long)(hdf_capacity_blocks / 2048));
 
+    if (hdf_build_extent_map() == 0) {
+        hdf_raw = 1;
+        printf("[SD] HDF extent map: %lu extent(s), raw block I/O enabled\n",
+               (unsigned long)hdf_extent_count);
+    } else {
+        printf("[SD] HDF not extent-mappable (FAT12/fragmented/corrupt chain), "
+               "using FatFs I/O — expect degraded speed. Re-copying the HDF "
+               "onto a freshly formatted card restores the fast path.\n");
+    }
+
     return 0;
 }
 
@@ -95,6 +251,14 @@ uint32_t sd_storage_read_blocks(uint32_t block, uint32_t num_blocks, void *buffe
 
     uint32_t status = 0;
     sd_activity_led_begin();
+
+    if (hdf_raw) {
+        /* XSdPs DMAs straight into DDR and invalidates the ARM D-cache
+         * range itself, so the Zorro AXI read path sees fresh bytes
+         * without an explicit flush here. */
+        status = hdf_raw_io(block, num_blocks, buffer, 0);
+        goto out;
+    }
 
     FRESULT fr = f_lseek(&hdf_file, (FSIZE_t)block * SD_BLOCK_SIZE);
     if (fr != FR_OK) {
@@ -133,6 +297,20 @@ uint32_t sd_storage_write_blocks(uint32_t block, uint32_t num_blocks, void *buff
 
     uint32_t status = 0;
     sd_activity_led_begin();
+
+    if (hdf_raw) {
+        if (hdf_read_only) {
+            status = 0xFD;
+            goto out;
+        }
+        /* The buffer was filled by ARM CPU stores (Zorro write
+         * servicing); XSdPs flushes the range to DDR itself before the
+         * DMA. Raw writes only touch data sectors inside the HDF's own
+         * extents — no FAT or directory metadata changes — so there is
+         * nothing to f_sync and a power loss can't tear the FAT. */
+        status = hdf_raw_io(block, num_blocks, buffer, 1);
+        goto out;
+    }
 
     Xil_DCacheFlushRange((UINTPTR)buffer, num_blocks * SD_BLOCK_SIZE);
 


### PR DESCRIPTION
## Problem

SD-hosted hardfile performance was terrible. Every guest block request went through `f_lseek` + `f_read`/`f_write` on the HDF file, and the BSP's FatFs is built with `FF_USE_FASTSEEK=0`:

- Any seek to a **lower** file offset than the current position rewinds to the file's first cluster and re-walks the entire FAT chain through the one-sector `fs->win` cache — hundreds of SD commands per seek on a multi-GB image. Amiga filesystems constantly alternate between low blocks (bitmap/root) and high blocks (data), so nearly every other request paid this cost.
- Every write ended with `f_sync()` — a directory-sector read + write each time, protecting metadata that never actually changes (the HDF never grows).
- FatFs split transfers at cluster boundaries instead of issuing one multi-sector SD command.

## Fix

`sd_storage.c` now resolves the HDF's cluster chain **once at init** into a table of contiguous extents (walking the FAT in 16 KB windows, so the walk itself is a handful of SD commands). Runtime I/O binary-searches the extent table and goes straight to `disk_read`/`disk_write` at physical LBAs:

- One multi-sector ADMA2 DMA command per 24 KB chunk; cache coherency is handled by the XSdPs driver (invalidate before/after read DMA, flush before write DMA).
- No `f_sync` in the fast path — raw writes only touch data sectors inside the HDF's own extents, so there is no FAT/directory metadata to tear on power loss.
- A request that previously cost potentially hundreds of SD transactions now costs exactly one.

## Fallback & safety

- FAT12 volumes, corrupt chains, or files fragmented beyond 1024 extents fall back to the existing FatFs path with a console warning (re-copying the HDF onto a freshly formatted card restores the fast path).
- HDFs opened read-only now explicitly reject raw writes.
- `sd_boot.c`'s `block_buf` is 32-byte aligned since it is now a direct DMA target.
- The `zzsd.device` driver and Zorro register protocol are unchanged — this drops in with a firmware update alone.

Boot console now reports the mapping result: `[SD] HDF extent map: N extent(s), raw block I/O enabled` (a normally-copied HDF is 1 extent).

## Testing

- Full clean Docker firmware build plus incremental rebuild of both touched files: zero compiler warnings, links successfully.
- Not yet tested on hardware.

## Notes

The remaining throughput ceiling is the Zorro side, not the SD side: Z2 reads of the shared buffer are FPGA-serviced per 16-bit word, and Z2 writes to it trap to the ARM poll loop per word. Routing the 0xA000–0xFFFF window writes through the same DMA path as framebuffer writes would be the next lever, but that requires a bitstream change.