### PR TITLE
Replace the leaking RTG surface bump allocator with a real allocator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
         run: make -C test/scheduler test
       - name: ZZ9000.CFG parser suite
         run: make -C test/config test
+      - name: Surface allocator suite
+        run: make -C test/allocator test
 
   build:
     name: Build & package firmware

--- a/ZZ9000.CFG
+++ b/ZZ9000.CFG
@@ -57,6 +57,16 @@
 #int2 = on
 
 # ---------------------------------------------------------------------
+# offscreen_bitmaps: let P96 place off-screen bitmaps (window backing
+# store, double buffers) in card VRAM so blits between them and the
+# screen run on the card instead of the CPU. Zorro 3 only.
+#   on (default) | off
+# The drivers query this value; ENV:ZZ9000-NO-OFFSCREEN and the
+# ZZ9000.card OFFSCREENBITMAPS tooltype take precedence over it.
+# ---------------------------------------------------------------------
+#offscreen_bitmaps = on
+
+# ---------------------------------------------------------------------
 # mac: override the ethernet MAC address (replaces ENV:ZZ9K_MAC).
 # ---------------------------------------------------------------------
 #mac = 68:82:F2:12:34:56

--- a/ZZ9000_proto.sdk/ZZ9000OS/Makefile
+++ b/ZZ9000_proto.sdk/ZZ9000OS/Makefile
@@ -111,6 +111,7 @@ C_SRCS = \
 	$(SRC_DIR)/sdk_decode_reclaim_arm.c \
 	$(SRC_DIR)/dma_acc.c \
 	$(SRC_DIR)/dma_rtg.c \
+	$(SRC_DIR)/surface_allocator.c \
 	$(SRC_DIR)/usb.c \
 	$(SRC_DIR)/mp3/decode_mp3.c \
 	$(SRC_DIR)/compression/audio/adpcm.c \

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/dma_acc.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/dma_acc.c
@@ -8,10 +8,11 @@
 #include "memorymap.h"
 #include <xil_types.h>
 #include "xil_printf.h"
+#include "xil_cache.h"
 #include "compression/compression.h"
+#include "surface_allocator.h"
 #include "xtime_l.h"
 
-extern unsigned int cur_mem_offset;
 extern uint8_t imc_tables_initialized;
 int current_c37_encoder = -1;
 
@@ -155,50 +156,32 @@ void handle_acc_op(uint16_t zdata)
 
             }
 
-            unsigned int barf = sfc_size % 256;
-            if (barf)
-                sfc_size += (256 - barf);
-
-            if (data->u8_user[1] == 1) {
-                printf ("Alloc requested for %d bytes.\n", data->offset[1]);
-            }
-            else {
-                printf ("Alloc requested for %dx%d surface, %.2X bytes per pixel, %d bytes.\n", data->x[0], data->y[0], data->u8_user[0], sfc_size);
-            }
             if (!sfc_size) {
                 printf("Refusing to allocate 0 bytes for you.\n");
                 break;
             }
-            if (cur_mem_offset >= LEGACY_SURFACE_HEAP_END ||
-                sfc_size > (LEGACY_SURFACE_HEAP_END - cur_mem_offset)) {
+
+            uint32_t sfc_addr = surface_allocator_alloc(sfc_size);
+            if (!sfc_addr) {
                 printf("not enough legacy surface heap for %d bytes.\n", sfc_size);
                 break;
             }
 
-            //uint8_t *p = malloc(sfc_size);
-            //memset(p, 0x00, sfc_size);
-            //allocated_surfaces++;
-            //printf ("Surface allocated at offset %.8X, or %.8X on the Amiga side.\n", cur_mem_offset, cur_mem_offset - ADDR_ADJ);
-
-            data->offset[0] = cur_mem_offset - ADDR_ADJ;
-            memset((void *)cur_mem_offset, 0x00, sfc_size);
-            cur_mem_offset += sfc_size;
+            sfc_size = surface_allocator_block_size(sfc_addr);
+            memset((void *)sfc_addr, 0x00, sfc_size);
+            Xil_DCacheFlushRange((INTPTR)sfc_addr, sfc_size);
+            data->offset[0] = sfc_addr - ADDR_ADJ;
             SWAP32(data->offset[0]);
             break;
         }
         case ACC_OP_FREE_SURFACE: {
             SWAP32(data->offset[0]);
             data->offset[0] += ADDR_ADJ;
-            void *ape = (void*)data->offset[0];
-            if (data->u8_user[0]) {
-                printf("[%s] Freeing surface at %p... Not really.\n", data->clut2, ape);
+            if (surface_allocator_free(data->offset[0]) != 0) {
+                printf("Ignoring free of unknown surface at %p.\n",
+                       (void *)data->offset[0]);
             }
-            //else
-                //printf("Freeing surface at %p... Not really.\n", ape);
             data->offset[0] = 0;
-
-            //free(ape);
-            //printf(" freed!\n");
             break;
         }
         case ACC_OP_SET_BPP_CONVERSION_TABLE: {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -65,8 +65,11 @@ void Xil_AssertNonVoid() {}
 #include "sdk_mailbox.h"
 #include "surface_allocator.h"
 
+/* 2.4: RTG surface allocator with a real free — ZZ9000.card gates the
+ * P96 off-screen bitmap hooks on this revision (older firmware would
+ * leak legacy surface heap on every bitmap free). */
 #define REVISION_MAJOR 2
-#define REVISION_MINOR 3
+#define REVISION_MINOR 4
 
 #ifndef ZZ9000_SKIP_INITIAL_MEDIA_INIT
 #define ZZ9000_SKIP_INITIAL_MEDIA_INIT 0

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -63,6 +63,7 @@ void Xil_AssertNonVoid() {}
 #include "zz_config.h"
 #include "usb_proxy.h"
 #include "sdk_mailbox.h"
+#include "surface_allocator.h"
 
 #define REVISION_MAJOR 2
 #define REVISION_MINOR 3
@@ -115,12 +116,6 @@ static u32 blitter_dst_offset = 0;
 static u32 blitter_src_offset = 0;
 
 struct ZZ_VIDEO_STATE* video_state;
-
-// FIXME
-// This is the absolute offset in ZZ9000 RAM for the "framebuffer transfer register",
-// which can be replaced by the DMA acceleration functionality entirely, but some
-// software still relies on this legacy register.
-unsigned int cur_mem_offset = LEGACY_SURFACE_HEAP_ADDRESS;
 
 static char usb_storage_available = 0;
 #if ENABLE_LEGACY_USB_BLOCK_STORAGE
@@ -267,8 +262,8 @@ void handle_amiga_reset(enum amiga_reset_mode mode) {
 	audio_set_interrupt_enabled(0);
 	interrupt_enabled_vblank = 0;
 
-	// FIXME document
-	cur_mem_offset = LEGACY_SURFACE_HEAP_ADDRESS;
+	// drop all RTG off-screen surfaces; P96 re-allocates after reboot
+	surface_allocator_init(LEGACY_SURFACE_HEAP_ADDRESS, LEGACY_SURFACE_HEAP_SIZE);
 
 	// FIXME
 	memset((u32 *)Z3_SCRATCH_ADDR, 0, sizeof(struct GFXData));
@@ -355,6 +350,8 @@ int main() {
 	// RTG rect ops may write anywhere in framebuffer + legacy surface
 	// memory, but never past it into the SDK heaps and beyond
 	set_fb_limit((uint8_t *)(uintptr_t)LEGACY_SURFACE_HEAP_END);
+
+	surface_allocator_init(LEGACY_SURFACE_HEAP_ADDRESS, LEGACY_SURFACE_HEAP_SIZE);
 
 	xadc_init();
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/surface_allocator.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/surface_allocator.c
@@ -1,0 +1,98 @@
+/*
+ * MNT ZZ9000 Amiga Graphics and ARM Coprocessor Card Operating System
+ * (ZZ9000OS)
+ *
+ * RTG surface allocator: first-fit over a block table kept sorted by
+ * address. Free space is implicit in the gaps between blocks, so a free
+ * is just a table removal and no coalescing pass is ever needed.
+ *
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <string.h>
+#include "surface_allocator.h"
+
+struct sa_block {
+    uint32_t addr;
+    uint32_t size;
+};
+
+static struct sa_block sa_blocks[SURFACE_ALLOCATOR_MAX_BLOCKS];
+static uint32_t sa_count;
+static uint32_t sa_base;
+static uint32_t sa_end;
+static uint32_t sa_used;
+
+void surface_allocator_init(uint32_t base, uint32_t size) {
+    sa_base = base;
+    sa_end = base + size;
+    sa_count = 0;
+    sa_used = 0;
+}
+
+/* Index of the block at exactly `addr`, or -1. */
+static int sa_find(uint32_t addr) {
+    uint32_t lo = 0, hi = sa_count;
+    while (lo < hi) {
+        uint32_t mid = (lo + hi) / 2;
+        if (sa_blocks[mid].addr < addr)
+            lo = mid + 1;
+        else
+            hi = mid;
+    }
+    if (lo < sa_count && sa_blocks[lo].addr == addr)
+        return (int)lo;
+    return -1;
+}
+
+uint32_t surface_allocator_alloc(uint32_t size) {
+    if (!size || sa_count >= SURFACE_ALLOCATOR_MAX_BLOCKS)
+        return 0;
+
+    uint32_t rounded = (size + SURFACE_ALLOCATOR_ALIGNMENT - 1) &
+                       ~(SURFACE_ALLOCATOR_ALIGNMENT - 1);
+    if (!rounded || rounded > sa_end - sa_base)
+        return 0;
+
+    /* First fit: try the gap before each block, then the tail gap. */
+    uint32_t candidate = sa_base;
+    uint32_t insert_at = sa_count;
+    for (uint32_t i = 0; i < sa_count; i++) {
+        if (sa_blocks[i].addr - candidate >= rounded) {
+            insert_at = i;
+            break;
+        }
+        candidate = sa_blocks[i].addr + sa_blocks[i].size;
+    }
+    if (insert_at == sa_count && sa_end - candidate < rounded)
+        return 0;
+
+    memmove(&sa_blocks[insert_at + 1], &sa_blocks[insert_at],
+            (sa_count - insert_at) * sizeof(struct sa_block));
+    sa_blocks[insert_at].addr = candidate;
+    sa_blocks[insert_at].size = rounded;
+    sa_count++;
+    sa_used += rounded;
+    return candidate;
+}
+
+int surface_allocator_free(uint32_t addr) {
+    int i = sa_find(addr);
+    if (i < 0)
+        return -1;
+    sa_used -= sa_blocks[i].size;
+    memmove(&sa_blocks[i], &sa_blocks[i + 1],
+            (sa_count - (uint32_t)i - 1) * sizeof(struct sa_block));
+    sa_count--;
+    return 0;
+}
+
+uint32_t surface_allocator_block_size(uint32_t addr) {
+    int i = sa_find(addr);
+    return (i < 0) ? 0 : sa_blocks[i].size;
+}
+
+uint32_t surface_allocator_used_bytes(void) {
+    return sa_used;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/surface_allocator.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/surface_allocator.h
@@ -1,0 +1,43 @@
+/*
+ * MNT ZZ9000 Amiga Graphics and ARM Coprocessor Card Operating System
+ * (ZZ9000OS)
+ *
+ * RTG surface allocator: manages the legacy surface heap that backs
+ * P96 off-screen bitmaps (ACC_OP_ALLOC_SURFACE / ACC_OP_FREE_SURFACE).
+ *
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef SURFACE_ALLOCATOR_H
+#define SURFACE_ALLOCATOR_H
+
+#include <stdint.h>
+
+/* The ACC alloc ABI guarantees 256-byte aligned surfaces. */
+#define SURFACE_ALLOCATOR_ALIGNMENT 256u
+
+/* P96 allocates a bitmap per Workbench window/icon backing store, so
+ * size the table for hundreds of concurrent bitmaps. 8 bytes per entry. */
+#define SURFACE_ALLOCATOR_MAX_BLOCKS 1024u
+
+/* Initialize (or reset) the allocator over [base, base+size). Drops all
+ * existing allocations; called at boot and on Amiga reset. */
+void surface_allocator_init(uint32_t base, uint32_t size);
+
+/* Allocate `size` bytes (rounded up to the alignment). Returns the block
+ * address, or 0 on failure (zero size, no gap large enough, table full). */
+uint32_t surface_allocator_alloc(uint32_t size);
+
+/* Free the block starting exactly at `addr`. Returns 0 on success, -1 if
+ * `addr` is not a live block start (double free, mid-block, unknown) —
+ * in which case no state changes. */
+int surface_allocator_free(uint32_t addr);
+
+/* Rounded size of the live block at `addr`, or 0 if unknown. */
+uint32_t surface_allocator_block_size(uint32_t addr);
+
+/* Total bytes currently allocated (rounded sizes). */
+uint32_t surface_allocator_used_bytes(void);
+
+#endif /* SURFACE_ALLOCATOR_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/zz_config.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/zz_config.c
@@ -146,6 +146,13 @@ static int apply_key(const char *key, const char *value) {
 		cfg.mac_present = 1;
 		return 0;
 	}
+	if (token_eq(key, "offscreen_bitmaps")) {
+		int v = parse_onoff(value);
+		if (v < 0) return -1;
+		cfg.offscreen_bitmaps = (uint16_t)v;
+		cfg.offscreen_bitmaps_present = 1;
+		return 0;
+	}
 	if (token_eq(key, "hdf")) {
 		if (!hdf_name_valid(value)) return -1;
 		cfg.hdf_path[0] = '0';
@@ -328,6 +335,10 @@ uint16_t zz_config_query(uint16_t key, uint16_t *present) {
 	case ZZ_CONFIG_KEY_MAC_LO:
 		p = cfg.mac_present;
 		v = (uint16_t)(cfg.mac[4] << 8 | cfg.mac[5]);
+		break;
+	case ZZ_CONFIG_KEY_OFFSCREEN_BITMAPS:
+		p = cfg.offscreen_bitmaps_present;
+		v = cfg.offscreen_bitmaps;
 		break;
 	default:
 		break;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/zz_config.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/zz_config.h
@@ -36,6 +36,7 @@ enum zz_config_key {
 	ZZ_CONFIG_KEY_MAC_HI          = 6,  /* mac[0]<<8 | mac[1] */
 	ZZ_CONFIG_KEY_MAC_MID         = 7,  /* mac[2]<<8 | mac[3] */
 	ZZ_CONFIG_KEY_MAC_LO          = 8,  /* mac[4]<<8 | mac[5] */
+	ZZ_CONFIG_KEY_OFFSCREEN_BITMAPS = 9, /* 0=off 1=on, informational (drivers query it) */
 	ZZ_CONFIG_KEY_NUM
 };
 
@@ -62,6 +63,9 @@ struct zz_config {
 
 	uint8_t hdf_present;
 	char hdf_path[ZZ_CONFIG_HDF_NAME_MAX + 4]; /* "0:/" + name + NUL */
+
+	uint8_t offscreen_bitmaps_present;
+	uint16_t offscreen_bitmaps;     /* 0-1, informational (drivers query it) */
 };
 
 /* Status codes for the REG_ZZ_CONFIG_FILE raw-read command. */

--- a/test/allocator/Makefile
+++ b/test/allocator/Makefile
@@ -1,0 +1,23 @@
+CC ?= cc
+CFLAGS ?= -O2 -g -Wall -Wextra
+
+SRC_DIR := ../../ZZ9000_proto.sdk/ZZ9000OS/src
+BUILD_DIR := build
+TARGET := $(BUILD_DIR)/allocator_test
+
+CPPFLAGS += -I$(SRC_DIR)
+
+SOURCES := allocator_test.c $(SRC_DIR)/surface_allocator.c
+DEPS := $(SRC_DIR)/surface_allocator.h
+
+.PHONY: test clean
+
+test: $(TARGET)
+	$(TARGET)
+
+$(TARGET): $(SOURCES) $(DEPS)
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ $(SOURCES)
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/test/allocator/allocator_test.c
+++ b/test/allocator/allocator_test.c
@@ -1,0 +1,305 @@
+/*
+ * Host unit tests for the RTG surface allocator (surface_allocator.c).
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Build/run: make -C test/allocator test
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include "surface_allocator.h"
+
+/* Fake heap: addresses are never dereferenced by the allocator. */
+#define HEAP_BASE 0x03500000u
+#define HEAP_SIZE 0x00100000u /* 1 MB keeps exhaustion tests fast */
+#define ALIGN     SURFACE_ALLOCATOR_ALIGNMENT
+
+/* ---- tiny test harness --------------------------------------------- */
+
+static int failures = 0;
+static int checks = 0;
+
+#define CHECK(cond) do { \
+    checks++; \
+    if (!(cond)) { \
+        failures++; \
+        printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+    } \
+} while (0)
+
+/* ---- tests ---------------------------------------------------------- */
+
+static void test_basic_alloc(void) {
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    uint32_t a = surface_allocator_alloc(100);
+    uint32_t b = surface_allocator_alloc(256);
+    uint32_t c = surface_allocator_alloc(257);
+    CHECK(a == HEAP_BASE);
+    CHECK(a % ALIGN == 0);
+    CHECK(b == a + ALIGN);              /* 100 rounded up to 256 */
+    CHECK(c == b + ALIGN);
+    CHECK(surface_allocator_block_size(a) == ALIGN);
+    CHECK(surface_allocator_block_size(b) == ALIGN);
+    CHECK(surface_allocator_block_size(c) == 2 * ALIGN); /* 257 -> 512 */
+    CHECK(surface_allocator_used_bytes() == 4 * ALIGN);
+}
+
+static void test_zero_size(void) {
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    CHECK(surface_allocator_alloc(0) == 0);
+    CHECK(surface_allocator_used_bytes() == 0);
+}
+
+static void test_whole_heap(void) {
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    uint32_t a = surface_allocator_alloc(HEAP_SIZE);
+    CHECK(a == HEAP_BASE);
+    CHECK(surface_allocator_block_size(a) == HEAP_SIZE);
+    CHECK(surface_allocator_alloc(ALIGN) == 0); /* full */
+    CHECK(surface_allocator_free(a) == 0);
+    CHECK(surface_allocator_alloc(HEAP_SIZE + 1) == 0); /* one over */
+    CHECK(surface_allocator_used_bytes() == 0);
+    /* boundary block ends exactly at base+size */
+    uint32_t b = surface_allocator_alloc(HEAP_SIZE - ALIGN);
+    uint32_t c = surface_allocator_alloc(ALIGN);
+    CHECK(b == HEAP_BASE);
+    CHECK(c == HEAP_BASE + HEAP_SIZE - ALIGN);
+    CHECK(surface_allocator_alloc(ALIGN) == 0);
+}
+
+static void test_free_realloc_reuse(void) {
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    uint32_t a = surface_allocator_alloc(4096);
+    uint32_t b = surface_allocator_alloc(4096);
+    CHECK(a && b);
+    CHECK(surface_allocator_free(a) == 0);
+    uint32_t a2 = surface_allocator_alloc(4096);
+    CHECK(a2 == a); /* first fit lands back in the hole */
+    (void)b;
+}
+
+static void test_fragmentation(void) {
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    uint32_t a = surface_allocator_alloc(0x10000);
+    uint32_t b = surface_allocator_alloc(0x10000);
+    uint32_t c = surface_allocator_alloc(0x10000);
+    CHECK(a && b && c);
+    CHECK(surface_allocator_free(b) == 0);
+    /* smaller-than-hole alloc lands in the hole */
+    uint32_t d = surface_allocator_alloc(0x8000);
+    CHECK(d == b);
+    /* bigger-than-hole alloc lands after c */
+    uint32_t e = surface_allocator_alloc(0x20000);
+    CHECK(e == c + 0x10000);
+    /* total free suffices but no single gap does -> 0 (non-compacting) */
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    uint32_t half = HEAP_SIZE / 2;
+    uint32_t f = surface_allocator_alloc(half - ALIGN);
+    uint32_t g = surface_allocator_alloc(2 * ALIGN);
+    uint32_t h = surface_allocator_alloc(half - 3 * ALIGN);
+    CHECK(f && g && h);
+    CHECK(surface_allocator_free(f) == 0);
+    CHECK(surface_allocator_free(h) == 0);
+    /* free = whole heap minus the 2*ALIGN block in the middle, but split */
+    CHECK(surface_allocator_alloc(HEAP_SIZE - 2 * ALIGN) == 0);
+    CHECK(surface_allocator_alloc(half - ALIGN) != 0);
+}
+
+static void test_exhaustion_recovery(void) {
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    uint32_t blocks[16];
+    uint32_t chunk = HEAP_SIZE / 16;
+    for (int i = 0; i < 16; i++) {
+        blocks[i] = surface_allocator_alloc(chunk);
+        CHECK(blocks[i] != 0);
+    }
+    CHECK(surface_allocator_alloc(ALIGN) == 0);
+    CHECK(surface_allocator_free(blocks[7]) == 0);
+    CHECK(surface_allocator_alloc(chunk) == blocks[7]);
+}
+
+static void test_double_free(void) {
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    uint32_t a = surface_allocator_alloc(512);
+    uint32_t b = surface_allocator_alloc(512);
+    CHECK(a && b);
+    uint32_t used = surface_allocator_used_bytes();
+    CHECK(surface_allocator_free(a) == 0);
+    CHECK(surface_allocator_free(a) == -1); /* double free */
+    CHECK(surface_allocator_used_bytes() == used - 512);
+    CHECK(surface_allocator_block_size(b) == 512);
+}
+
+static void test_free_unknown(void) {
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    uint32_t a = surface_allocator_alloc(4096);
+    CHECK(a != 0);
+    uint32_t used = surface_allocator_used_bytes();
+    CHECK(surface_allocator_free(0) == -1);
+    CHECK(surface_allocator_free(a + ALIGN) == -1);      /* mid-block */
+    CHECK(surface_allocator_free(HEAP_BASE + HEAP_SIZE) == -1); /* out of range */
+    CHECK(surface_allocator_free(a + 1) == -1);          /* misaligned */
+    CHECK(surface_allocator_used_bytes() == used);
+    CHECK(surface_allocator_block_size(a) == 4096);
+}
+
+static void test_slot_exhaustion(void) {
+    /* heap big enough for more blocks than the table can track */
+    surface_allocator_init(HEAP_BASE, (SURFACE_ALLOCATOR_MAX_BLOCKS + 8) * ALIGN);
+    uint32_t first = 0, last = 0;
+    for (uint32_t i = 0; i < SURFACE_ALLOCATOR_MAX_BLOCKS; i++) {
+        uint32_t a = surface_allocator_alloc(ALIGN);
+        CHECK(a != 0);
+        if (i == 0) first = a;
+        last = a;
+    }
+    CHECK(surface_allocator_alloc(ALIGN) == 0); /* table full, space left */
+    CHECK(surface_allocator_free(first) == 0);
+    CHECK(surface_allocator_alloc(ALIGN) == first); /* slot recovered */
+    (void)last;
+}
+
+static void test_reset(void) {
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    CHECK(surface_allocator_alloc(1024) != 0);
+    CHECK(surface_allocator_alloc(1024) != 0);
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    CHECK(surface_allocator_used_bytes() == 0);
+    CHECK(surface_allocator_alloc(1024) == HEAP_BASE);
+}
+
+/* ---- randomized churn against a naive occupancy-bitmap oracle ------- */
+
+#define UNITS (HEAP_SIZE / ALIGN)
+
+static uint8_t  oracle_used[UNITS];       /* 256-byte-granularity occupancy */
+static uint32_t oracle_size[UNITS];       /* rounded size, indexed by start unit */
+static uint32_t oracle_used_bytes;
+
+static int oracle_alloc_check(uint32_t addr, uint32_t rounded) {
+    if (addr < HEAP_BASE || addr % ALIGN ||
+        addr + rounded > HEAP_BASE + HEAP_SIZE)
+        return 0;
+    uint32_t u = (addr - HEAP_BASE) / ALIGN;
+    for (uint32_t i = 0; i < rounded / ALIGN; i++)
+        if (oracle_used[u + i])
+            return 0; /* overlaps a live block */
+    for (uint32_t i = 0; i < rounded / ALIGN; i++)
+        oracle_used[u + i] = 1;
+    oracle_size[u] = rounded;
+    oracle_used_bytes += rounded;
+    return 1;
+}
+
+static int oracle_free(uint32_t addr) {
+    if (addr < HEAP_BASE || addr % ALIGN || addr >= HEAP_BASE + HEAP_SIZE)
+        return -1;
+    uint32_t u = (addr - HEAP_BASE) / ALIGN;
+    if (!oracle_size[u])
+        return -1; /* not a live block start */
+    for (uint32_t i = 0; i < oracle_size[u] / ALIGN; i++)
+        oracle_used[u + i] = 0;
+    oracle_used_bytes -= oracle_size[u];
+    oracle_size[u] = 0;
+    return 0;
+}
+
+static uint32_t rng_state;
+static uint32_t rng(void) { /* xorshift32 */
+    uint32_t x = rng_state;
+    x ^= x << 13; x ^= x >> 17; x ^= x << 5;
+    return rng_state = x;
+}
+
+static void test_churn(void) {
+    const uint32_t seed = 0xC0FFEE42u;
+    rng_state = seed;
+    surface_allocator_init(HEAP_BASE, HEAP_SIZE);
+    memset(oracle_used, 0, sizeof oracle_used);
+    memset(oracle_size, 0, sizeof oracle_size);
+    oracle_used_bytes = 0;
+
+    uint32_t live[512];
+    uint32_t nlive = 0;
+    int bad = 0;
+
+    for (int op = 0; op < 100000 && !bad; op++) {
+        if ((rng() & 3) != 0 || nlive == 0) { /* 75% alloc */
+            /* biased small; occasionally huge */
+            uint32_t size = (rng() % 16 == 0) ? (rng() % HEAP_SIZE)
+                                              : (rng() % 8192) + 1;
+            uint32_t rounded = (size + ALIGN - 1) & ~(uint32_t)(ALIGN - 1);
+            uint32_t a = surface_allocator_alloc(size);
+            if (a) {
+                if (!oracle_alloc_check(a, rounded)) {
+                    printf("FAIL churn(seed=%08x) op=%d: bad alloc %08x size %u\n",
+                           seed, op, a, size);
+                    bad = 1;
+                } else if (nlive < 512) {
+                    live[nlive++] = a;
+                } else {
+                    /* keep the working set bounded: forget by freeing */
+                    uint32_t victim = rng() % nlive;
+                    if (surface_allocator_free(live[victim]) != 0 ||
+                        oracle_free(live[victim]) != 0) {
+                        printf("FAIL churn(seed=%08x) op=%d: evict free\n", seed, op);
+                        bad = 1;
+                    }
+                    live[victim] = a;
+                }
+            }
+        } else { /* 25% free, half valid / half bogus */
+            if (rng() & 1) {
+                uint32_t victim = rng() % nlive;
+                int r = surface_allocator_free(live[victim]);
+                int o = oracle_free(live[victim]);
+                if (r != 0 || o != 0) {
+                    printf("FAIL churn(seed=%08x) op=%d: valid free r=%d o=%d\n",
+                           seed, op, r, o);
+                    bad = 1;
+                }
+                live[victim] = live[--nlive];
+            } else {
+                uint32_t addr = HEAP_BASE + (rng() % HEAP_SIZE);
+                int r = surface_allocator_free(addr);
+                int o = oracle_free(addr);
+                if (r != o) {
+                    printf("FAIL churn(seed=%08x) op=%d: free %08x r=%d o=%d\n",
+                           seed, op, addr, r, o);
+                    bad = 1;
+                }
+                if (o == 0) { /* randomly hit a live block: drop it */
+                    for (uint32_t i = 0; i < nlive; i++)
+                        if (live[i] == addr) { live[i] = live[--nlive]; break; }
+                }
+            }
+        }
+        if (surface_allocator_used_bytes() != oracle_used_bytes) {
+            printf("FAIL churn(seed=%08x) op=%d: used %u != oracle %u\n",
+                   seed, op, surface_allocator_used_bytes(), oracle_used_bytes);
+            bad = 1;
+        }
+    }
+    CHECK(!bad);
+}
+
+/* ---------------------------------------------------------------------- */
+
+int main(void) {
+    test_basic_alloc();
+    test_zero_size();
+    test_whole_heap();
+    test_free_realloc_reuse();
+    test_fragmentation();
+    test_exhaustion_recovery();
+    test_double_free();
+    test_free_unknown();
+    test_slot_exhaustion();
+    test_reset();
+    test_churn();
+
+    printf("%d checks, %d failures\n", checks, failures);
+    return failures ? 1 : 0;
+}

--- a/test/config/config_test.c
+++ b/test/config/config_test.c
@@ -79,9 +79,10 @@ static void test_full_valid_file(void) {
         "scanline_parity = 1\n"
         "int2 = on\n"
         "mac = 68:82:F2:12:34:56\n"
-        "hdf = games.hdf\n");
+        "hdf = games.hdf\n"
+        "offscreen_bitmaps = off\n");
     const struct zz_config *c = zz_config_get();
-    CHECK(n == 7);
+    CHECK(n == 8);
     CHECK(c->videocap_mode_present && c->videocap_mode == ZZVMODE_720x576);
     CHECK(c->ns_vsync_present && c->ns_vsync == 1);
     CHECK(c->scanline_mode_present && c->scanline_mode == 2);
@@ -91,6 +92,7 @@ static void test_full_valid_file(void) {
     CHECK(c->mac[0] == 0x68 && c->mac[1] == 0x82 && c->mac[2] == 0xF2);
     CHECK(c->mac[3] == 0x12 && c->mac[4] == 0x34 && c->mac[5] == 0x56);
     CHECK(c->hdf_present && strcmp(c->hdf_path, "0:/games.hdf") == 0);
+    CHECK(c->offscreen_bitmaps_present && c->offscreen_bitmaps == 0);
 }
 
 static void test_defaults_absent(void) {
@@ -104,6 +106,7 @@ static void test_defaults_absent(void) {
     CHECK(!c->int2_present);
     CHECK(!c->mac_present);
     CHECK(!c->hdf_present);
+    CHECK(!c->offscreen_bitmaps_present);
 }
 
 static void test_case_whitespace_comments(void) {
@@ -145,6 +148,7 @@ static void test_bad_values_skipped(void) {
         "scanline_parity = 2\n"         /* out of range */
         "scanline_mode = -1\n"          /* negative */
         "int2 = maybe\n"
+        "offscreen_bitmaps = maybe\n"
         "mac = 68:82:F2:12:34\n"        /* five octets */
         "mac = gg:82:F2:12:34:56\n"     /* not hex */
         "hdf = ../etc/passwd\n"         /* path escape */
@@ -163,6 +167,7 @@ static void test_bad_values_skipped(void) {
     CHECK(!c->int2_present);
     CHECK(!c->mac_present);
     CHECK(!c->hdf_present);
+    CHECK(!c->offscreen_bitmaps_present);
 }
 
 static void test_last_value_wins(void) {
@@ -231,11 +236,13 @@ static void test_query_interface(void) {
     const char *text =
         "nonstandard_vsync = ntsc\n"
         "int2 = on\n"
+        "offscreen_bitmaps = off\n"
         "mac = 68:82:F2:12:34:56\n";
     parse_str(text);
 
     CHECK(zz_config_query(ZZ_CONFIG_KEY_NS_VSYNC, &present) == 2 && present);
     CHECK(zz_config_query(ZZ_CONFIG_KEY_INT2, &present) == 1 && present);
+    CHECK(zz_config_query(ZZ_CONFIG_KEY_OFFSCREEN_BITMAPS, &present) == 0 && present);
     CHECK(zz_config_query(ZZ_CONFIG_KEY_MAC_HI, &present) == 0x6882 && present);
     CHECK(zz_config_query(ZZ_CONFIG_KEY_MAC_MID, &present) == 0xF212 && present);
     CHECK(zz_config_query(ZZ_CONFIG_KEY_MAC_LO, &present) == 0x3456 && present);


### PR DESCRIPTION
## Problem

`ACC_OP_ALLOC_SURFACE` only ever grew `cur_mem_offset` and `ACC_OP_FREE_SURFACE` was a no-op ("Freeing surface... Not really."), so the P96 `AllocBitMap`/`FreeBitMap` driver hooks could never be enabled: every Workbench window open/close would leak legacy surface heap (43 MB at 0x03500000–0x06000000) until allocation failed.

## Changes

- **New `surface_allocator.c/h`**: first-fit allocator over a 1024-entry block table kept sorted by address. Free space is implicit in the gaps between blocks, so free is a table removal and no coalescing pass is needed. Free of an unknown/double-freed offset is rejected with a warning and changes nothing, keeping driver/firmware version skew harmless.
- **ACC register ABI unchanged**: byte-size and geometry alloc modes, 256-byte alignment, board-relative offset out, 0 as the failure sentinel, free by offset. Old `ZZ9000.card` + this firmware behaves exactly as today.
- The alloc path now **cache-flushes** the zeroed surface (`Xil_DCacheFlushRange`) — the Zorro window reads DDR through the FPGA AXI port, not the ARM caches, so the old memset-without-flush was a latent bug in this (previously dead) path.
- The allocator resets on Amiga reset where `cur_mem_offset` was reset before; per-alloc printf spam dropped (failure prints kept).
- **New `offscreen_bitmaps` ZZ9000.CFG key** (`on`/`off`, default on): queried by the companion driver PR as its kill switch. Documented in the ZZ9000.CFG template.

## Tests

New `test/allocator` host suite (1094 checks): alignment/rounding, whole-heap boundaries, free→realloc reuse, fragmentation behavior, exhaustion+recovery, double free, free-of-unknown/mid-block, slot-table exhaustion, reset, and a 100k-op randomized churn run against an independent occupancy-bitmap oracle. Wired into the CI host-tests job. `test/config` extended for the new key. Full ARM build green.

## Companion PR

Driver side (hooks + `GetBitMapAttr` + kill switch): BlitterStudio/zz9000-drivers — merge this firmware PR first; the driver PR only helps once the board runs this allocator. **No bitstream change** — ARM code only, existing bitstream works.

## Hardware validation (Z3 + 68060, after both merge)

Workbench window/icon churn and dragging, long-session fragmentation, VRAM exhaustion (P96 should silently fall back to system RAM), warm reboot, kill-switch toggle, before/after window-drag benchmark; watch serial for "Ignoring free of unknown surface" warnings.