### PR TITLE
Add OP_WRITE_YUV: packed 4:2:2 YUV→RGB rect conversion

### DIFF
--- a/ZZ9000.CFG
+++ b/ZZ9000.CFG
@@ -67,6 +67,15 @@
 #offscreen_bitmaps = on
 
 # ---------------------------------------------------------------------
+# yuv_rect: accelerate P96 picture-in-picture YUV rendering (video
+# players using p96PIP) on the card instead of the CPU. Zorro 3 only.
+#   on (default) | off
+# The drivers query this value; ENV:ZZ9000-NO-YUV and the ZZ9000.card
+# YUVRECT tooltype take precedence over it.
+# ---------------------------------------------------------------------
+#yuv_rect = on
+
+# ---------------------------------------------------------------------
 # mac: override the ethernet MAC address (replaces ENV:ZZ9K_MAC).
 # ---------------------------------------------------------------------
 #mac = 68:82:F2:12:34:56

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/dma_rtg.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/dma_rtg.c
@@ -160,6 +160,27 @@ void handle_blitter_dma_op(struct ZZ_VIDEO_STATE* vs, uint16_t zdata)
             break;
         }
 
+        case OP_WRITE_YUV: {
+            SWAP16(data->x[0]);		SWAP16(data->x[1]);		SWAP16(data->x[2]);
+            SWAP16(data->y[1]);		SWAP16(data->y[2]);
+
+            SWAP16(data->pitch[0]);		SWAP16(data->pitch[1]);
+            SWAP32(data->offset[0]);	SWAP32(data->offset[1]);
+
+            uint8_t* yuv_data = (uint8_t*) ((u32)vs->framebuffer
+                    + data->offset[1]);
+
+            set_fb((uint32_t*) ((u32)vs->framebuffer + data->offset[0]),
+                    data->pitch[0]);
+
+            yuv422_to_rgb_rect((int16_t)data->x[0], (int16_t)data->x[1],
+                    (int16_t)data->y[1], (int16_t)data->x[2], (int16_t)data->y[2],
+                    data->u8_user[GFXDATA_U8_YUV_VARIANT],
+                    data->u8_user[GFXDATA_U8_COLORMODE],
+                    data->pitch[1], yuv_data);
+            break;
+        }
+
         case OP_INVERTRECT:
             SWAP16(data->x[0]);		SWAP16(data->x[1]);
             SWAP16(data->y[0]);		SWAP16(data->y[1]);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.c
@@ -958,16 +958,22 @@ void p2c_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy, int16_t w, int16_t
 }
 
 /* Packed 4:2:2 macropixel byte positions of Y0/Y1/U/V, indexed by
- * enum yuv422_variant. Orders are memory byte orders as documented in
- * Picasso96.h (e.g. YUV422CGX = Y0-V-Y1-U). */
+ * enum yuv422_variant. The Picasso96.h comments describe these orders
+ * with U and V interchanged - a documentation defect fixed in P96
+ * V3.6.3 ("the documentation on the 422 modes was incorrect and U and
+ * V were interchanged", wiki.icomp.de/wiki/P96). The corrected orders
+ * used here are also the industry-standard ones (CGX = YUY2,
+ * 422PC = UYVY). If PIP colors ever come out red/blue-swapped against
+ * WriteYUVRectDefault on hardware, swapping the u/v columns is the
+ * knob. */
 static const struct {
 	uint8_t y0, y1, u, v;
 } yuv422_layout[YUV422_VARIANT_NUM] = {
-	{ 0, 2, 3, 1 }, /* CGX:  Y0 V  Y1 U  */
-	{ 2, 0, 1, 3 }, /* STD:  Y1 U  Y0 V  */
-	{ 1, 3, 2, 0 }, /* PC:   V  Y0 U  Y1 */
-	{ 0, 1, 3, 2 }, /* PA:   Y0 Y1 V  U  */
-	{ 3, 2, 0, 1 }, /* PAPC: U  V  Y1 Y0 */
+	{ 0, 2, 1, 3 }, /* CGX:  Y0 U  Y1 V  (YUY2) */
+	{ 2, 0, 3, 1 }, /* STD:  Y1 V  Y0 U  */
+	{ 1, 3, 0, 2 }, /* PC:   U  Y0 V  Y1 (UYVY) */
+	{ 0, 1, 2, 3 }, /* PA:   Y0 Y1 U  V  */
+	{ 3, 2, 1, 0 }, /* PAPC: V  U  Y1 Y0 */
 };
 
 static inline uint8_t yuv_clamp8(int32_t v)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.c
@@ -957,6 +957,111 @@ void p2c_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy, int16_t w, int16_t
 	}
 }
 
+/* Packed 4:2:2 macropixel byte positions of Y0/Y1/U/V, indexed by
+ * enum yuv422_variant. Orders are memory byte orders as documented in
+ * Picasso96.h (e.g. YUV422CGX = Y0-V-Y1-U). */
+static const struct {
+	uint8_t y0, y1, u, v;
+} yuv422_layout[YUV422_VARIANT_NUM] = {
+	{ 0, 2, 3, 1 }, /* CGX:  Y0 V  Y1 U  */
+	{ 2, 0, 1, 3 }, /* STD:  Y1 U  Y0 V  */
+	{ 1, 3, 2, 0 }, /* PC:   V  Y0 U  Y1 */
+	{ 0, 1, 3, 2 }, /* PA:   Y0 Y1 V  U  */
+	{ 3, 2, 0, 1 }, /* PAPC: U  V  Y1 Y0 */
+};
+
+static inline uint8_t yuv_clamp8(int32_t v)
+{
+	if (v < 0) return 0;
+	if (v > 255) return 255;
+	return (uint8_t)v;
+}
+
+/* Store one RGB pixel in the Amiga surface byte layout: 32-bit BGRA is
+ * byte0=B (ARM value A<<24|R<<16|G<<8|B); 16/15-bit pixels sit
+ * big-endian in memory (byte0=rrrrrggg), so the ARM uint16 store is
+ * byte-swapped relative to the natural R<<11|G<<5|B form. */
+static inline void yuv_store_pixel(uint32_t *dp, int32_t x, uint8_t color_format,
+	int32_t cy, int32_t rc, int32_t gc, int32_t bc)
+{
+	uint8_t r = yuv_clamp8((cy + rc) >> 8);
+	uint8_t g = yuv_clamp8((cy + gc) >> 8);
+	uint8_t b = yuv_clamp8((cy + bc) >> 8);
+	uint16_t v16;
+
+	switch (color_format) {
+	case MNTVA_COLOR_32BIT:
+		dp[x] = 0xFF000000u | ((uint32_t)r << 16) | ((uint32_t)g << 8) | b;
+		break;
+	case MNTVA_COLOR_16BIT565:
+		v16 = (uint16_t)(((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3));
+		((uint16_t *)dp)[x] = (uint16_t)((v16 >> 8) | (v16 << 8));
+		break;
+	case MNTVA_COLOR_15BIT:
+		v16 = (uint16_t)(((r >> 3) << 10) | ((g >> 3) << 5) | (b >> 3));
+		((uint16_t *)dp)[x] = (uint16_t)((v16 >> 8) | (v16 << 8));
+		break;
+	default:
+		break;
+	}
+}
+
+/* Convert a packed 4:2:2 YUV rect (CCIR601 studio range) to RGB at
+ * (dx,dy). `src` points at macropixel-aligned rows; `phase`=1 means the
+ * first output pixel is the second (Y1) pixel of the first macropixel
+ * (i.e. the original source x was odd). Chroma is held per macropixel
+ * (no interpolation). */
+void yuv422_to_rgb_rect(int16_t phase, int16_t dx, int16_t dy, int16_t w, int16_t h,
+	uint8_t variant, uint8_t color_format, uint16_t src_pitch, uint8_t *src)
+{
+	if (dx < 0 || dy < 0 || w <= 0 || h <= 0 || variant >= YUV422_VARIANT_NUM)
+		return;
+	if (color_format != MNTVA_COLOR_32BIT &&
+	    color_format != MNTVA_COLOR_16BIT565 &&
+	    color_format != MNTVA_COLOR_15BIT)
+		return;
+	h = (int16_t)clamp_rows_to_fb_limit((uint16_t)dy, (uint16_t)h);
+	if (!h)
+		return;
+
+	uint8_t y0_off = yuv422_layout[variant].y0;
+	uint8_t y1_off = yuv422_layout[variant].y1;
+	uint8_t u_off = yuv422_layout[variant].u;
+	uint8_t v_off = yuv422_layout[variant].v;
+
+	for (int16_t row = 0; row < h; row++) {
+		uint8_t *sp = src + (uint32_t)row * src_pitch;
+		uint32_t *dp = fb + ((uint32_t)(dy + row) * fb_pitch);
+		int32_t x = dx;
+		int32_t remaining = w;
+		int16_t skip_first = phase & 1;
+
+		while (remaining > 0) {
+			int32_t d = (int32_t)sp[u_off] - 128;
+			int32_t e = (int32_t)sp[v_off] - 128;
+			int32_t rc = 409 * e + 128;
+			int32_t gc = -100 * d - 208 * e + 128;
+			int32_t bc = 516 * d + 128;
+
+			if (!skip_first) {
+				yuv_store_pixel(dp, x, color_format,
+					298 * ((int32_t)sp[y0_off] - 16), rc, gc, bc);
+				x++;
+				remaining--;
+			}
+			skip_first = 0;
+
+			if (remaining > 0) {
+				yuv_store_pixel(dp, x, color_format,
+					298 * ((int32_t)sp[y1_off] - 16), rc, gc, bc);
+				x++;
+				remaining--;
+			}
+			sp += 4;
+		}
+	}
+}
+
 #define RL_CACHE_SIZE 256
 #define RL_CACHE_MASK (RL_CACHE_SIZE - 1)
 static uint32_t rl_cache_keys[RL_CACHE_SIZE];

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
@@ -64,6 +64,7 @@ void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t 
 
 void p2c_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy, int16_t w, int16_t h, uint8_t draw_mode, uint8_t planes, uint8_t mask, uint8_t layer_mask, uint16_t src_line_pitch, uint8_t *bmp_data_src);
 void p2d_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy, int16_t w, int16_t h, uint8_t draw_mode, uint8_t planes, uint8_t mask, uint8_t layer_mask, uint32_t color_mask, uint16_t src_line_pitch, uint8_t *bmp_data_src, uint32_t color_format);
+void yuv422_to_rgb_rect(int16_t phase, int16_t dx, int16_t dy, int16_t w, int16_t h, uint8_t variant, uint8_t color_format, uint16_t src_pitch, uint8_t *src);
 void invert_rect(uint16_t rect_x1, uint16_t rect_y1, uint16_t w, uint16_t h, uint8_t mask, uint32_t color_format);
 
 void acc_clear_buffer(uintptr_t addr, uint16_t w, uint16_t h, uint16_t pitch_, uint32_t fg_color, uint32_t color_format);
@@ -607,6 +608,7 @@ enum gfx_dma_op {
   OP_ETH_USB_OFFSETS,
   OP_SET_SPLIT_POS,
   OP_SET_PALETTE,
+  OP_WRITE_YUV,
   OP_NUM,
 };
 
@@ -648,4 +650,17 @@ enum gfxdata_u8_types {
   GFXDATA_U8_DRAWMODE,
   GFXDATA_U8_LINE_PATTERN_OFFSET,
   GFXDATA_U8_LINE_PADDING,
+  GFXDATA_U8_YUV_VARIANT,
+};
+
+/* Packed 4:2:2 macropixel byte orders (P96 RGBFTYPE names). All are one
+ * CCIR601 macropixel (two pixels, shared chroma) with the four bytes
+ * permuted; see the layout table in gfx.c. */
+enum yuv422_variant {
+  YUV422_VARIANT_CGX,   /* RGBFB_YUV422CGX: Y0 V Y1 U */
+  YUV422_VARIANT_STD,   /* RGBFB_YUV422:    Y1 U Y0 V */
+  YUV422_VARIANT_PC,    /* RGBFB_YUV422PC:  V Y0 U Y1 */
+  YUV422_VARIANT_PA,    /* RGBFB_YUV422PA:  Y0 Y1 V U */
+  YUV422_VARIANT_PAPC,  /* RGBFB_YUV422PAPC: U V Y1 Y0 */
+  YUV422_VARIANT_NUM,
 };

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
@@ -655,12 +655,13 @@ enum gfxdata_u8_types {
 
 /* Packed 4:2:2 macropixel byte orders (P96 RGBFTYPE names). All are one
  * CCIR601 macropixel (two pixels, shared chroma) with the four bytes
- * permuted; see the layout table in gfx.c. */
+ * permuted; see the layout table in gfx.c (note the old Picasso96.h
+ * comments have U and V interchanged - fixed in P96 V3.6.3). */
 enum yuv422_variant {
-  YUV422_VARIANT_CGX,   /* RGBFB_YUV422CGX: Y0 V Y1 U */
-  YUV422_VARIANT_STD,   /* RGBFB_YUV422:    Y1 U Y0 V */
-  YUV422_VARIANT_PC,    /* RGBFB_YUV422PC:  V Y0 U Y1 */
-  YUV422_VARIANT_PA,    /* RGBFB_YUV422PA:  Y0 Y1 V U */
-  YUV422_VARIANT_PAPC,  /* RGBFB_YUV422PAPC: U V Y1 Y0 */
+  YUV422_VARIANT_CGX,   /* RGBFB_YUV422CGX: Y0 U Y1 V (YUY2) */
+  YUV422_VARIANT_STD,   /* RGBFB_YUV422:    Y1 V Y0 U */
+  YUV422_VARIANT_PC,    /* RGBFB_YUV422PC:  U Y0 V Y1 (UYVY) */
+  YUV422_VARIANT_PA,    /* RGBFB_YUV422PA:  Y0 Y1 U V */
+  YUV422_VARIANT_PAPC,  /* RGBFB_YUV422PAPC: V U Y1 Y0 */
   YUV422_VARIANT_NUM,
 };

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -67,9 +67,11 @@ void Xil_AssertNonVoid() {}
 
 /* 2.4: RTG surface allocator with a real free — ZZ9000.card gates the
  * P96 off-screen bitmap hooks on this revision (older firmware would
- * leak legacy surface heap on every bitmap free). */
+ * leak legacy surface heap on every bitmap free).
+ * 2.5: OP_WRITE_YUV (packed 4:2:2 YUV→RGB rects) — ZZ9000.card gates
+ * the P96 WriteYUVRect hook on this revision. */
 #define REVISION_MAJOR 2
-#define REVISION_MINOR 4
+#define REVISION_MINOR 5
 
 #ifndef ZZ9000_SKIP_INITIAL_MEDIA_INIT
 #define ZZ9000_SKIP_INITIAL_MEDIA_INIT 0

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/zz_config.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/zz_config.c
@@ -153,6 +153,13 @@ static int apply_key(const char *key, const char *value) {
 		cfg.offscreen_bitmaps_present = 1;
 		return 0;
 	}
+	if (token_eq(key, "yuv_rect")) {
+		int v = parse_onoff(value);
+		if (v < 0) return -1;
+		cfg.yuv_rect = (uint16_t)v;
+		cfg.yuv_rect_present = 1;
+		return 0;
+	}
 	if (token_eq(key, "hdf")) {
 		if (!hdf_name_valid(value)) return -1;
 		cfg.hdf_path[0] = '0';
@@ -339,6 +346,10 @@ uint16_t zz_config_query(uint16_t key, uint16_t *present) {
 	case ZZ_CONFIG_KEY_OFFSCREEN_BITMAPS:
 		p = cfg.offscreen_bitmaps_present;
 		v = cfg.offscreen_bitmaps;
+		break;
+	case ZZ_CONFIG_KEY_YUV_RECT:
+		p = cfg.yuv_rect_present;
+		v = cfg.yuv_rect;
 		break;
 	default:
 		break;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/zz_config.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/zz_config.h
@@ -37,6 +37,7 @@ enum zz_config_key {
 	ZZ_CONFIG_KEY_MAC_MID         = 7,  /* mac[2]<<8 | mac[3] */
 	ZZ_CONFIG_KEY_MAC_LO          = 8,  /* mac[4]<<8 | mac[5] */
 	ZZ_CONFIG_KEY_OFFSCREEN_BITMAPS = 9, /* 0=off 1=on, informational (drivers query it) */
+	ZZ_CONFIG_KEY_YUV_RECT        = 10, /* 0=off 1=on, informational (drivers query it) */
 	ZZ_CONFIG_KEY_NUM
 };
 
@@ -66,6 +67,9 @@ struct zz_config {
 
 	uint8_t offscreen_bitmaps_present;
 	uint16_t offscreen_bitmaps;     /* 0-1, informational (drivers query it) */
+
+	uint8_t yuv_rect_present;
+	uint16_t yuv_rect;              /* 0-1, informational (drivers query it) */
 };
 
 /* Status codes for the REG_ZZ_CONFIG_FILE raw-read command. */

--- a/test/config/config_test.c
+++ b/test/config/config_test.c
@@ -80,9 +80,10 @@ static void test_full_valid_file(void) {
         "int2 = on\n"
         "mac = 68:82:F2:12:34:56\n"
         "hdf = games.hdf\n"
-        "offscreen_bitmaps = off\n");
+        "offscreen_bitmaps = off\n"
+        "yuv_rect = off\n");
     const struct zz_config *c = zz_config_get();
-    CHECK(n == 8);
+    CHECK(n == 9);
     CHECK(c->videocap_mode_present && c->videocap_mode == ZZVMODE_720x576);
     CHECK(c->ns_vsync_present && c->ns_vsync == 1);
     CHECK(c->scanline_mode_present && c->scanline_mode == 2);
@@ -93,6 +94,7 @@ static void test_full_valid_file(void) {
     CHECK(c->mac[3] == 0x12 && c->mac[4] == 0x34 && c->mac[5] == 0x56);
     CHECK(c->hdf_present && strcmp(c->hdf_path, "0:/games.hdf") == 0);
     CHECK(c->offscreen_bitmaps_present && c->offscreen_bitmaps == 0);
+    CHECK(c->yuv_rect_present && c->yuv_rect == 0);
 }
 
 static void test_defaults_absent(void) {
@@ -107,6 +109,7 @@ static void test_defaults_absent(void) {
     CHECK(!c->mac_present);
     CHECK(!c->hdf_present);
     CHECK(!c->offscreen_bitmaps_present);
+    CHECK(!c->yuv_rect_present);
 }
 
 static void test_case_whitespace_comments(void) {
@@ -149,6 +152,7 @@ static void test_bad_values_skipped(void) {
         "scanline_mode = -1\n"          /* negative */
         "int2 = maybe\n"
         "offscreen_bitmaps = maybe\n"
+        "yuv_rect = maybe\n"
         "mac = 68:82:F2:12:34\n"        /* five octets */
         "mac = gg:82:F2:12:34:56\n"     /* not hex */
         "hdf = ../etc/passwd\n"         /* path escape */
@@ -168,6 +172,7 @@ static void test_bad_values_skipped(void) {
     CHECK(!c->mac_present);
     CHECK(!c->hdf_present);
     CHECK(!c->offscreen_bitmaps_present);
+    CHECK(!c->yuv_rect_present);
 }
 
 static void test_last_value_wins(void) {
@@ -237,12 +242,14 @@ static void test_query_interface(void) {
         "nonstandard_vsync = ntsc\n"
         "int2 = on\n"
         "offscreen_bitmaps = off\n"
+        "yuv_rect = on\n"
         "mac = 68:82:F2:12:34:56\n";
     parse_str(text);
 
     CHECK(zz_config_query(ZZ_CONFIG_KEY_NS_VSYNC, &present) == 2 && present);
     CHECK(zz_config_query(ZZ_CONFIG_KEY_INT2, &present) == 1 && present);
     CHECK(zz_config_query(ZZ_CONFIG_KEY_OFFSCREEN_BITMAPS, &present) == 0 && present);
+    CHECK(zz_config_query(ZZ_CONFIG_KEY_YUV_RECT, &present) == 1 && present);
     CHECK(zz_config_query(ZZ_CONFIG_KEY_MAC_HI, &present) == 0x6882 && present);
     CHECK(zz_config_query(ZZ_CONFIG_KEY_MAC_MID, &present) == 0xF212 && present);
     CHECK(zz_config_query(ZZ_CONFIG_KEY_MAC_LO, &present) == 0x3456 && present);

--- a/test/rtg/rtg_regression.c
+++ b/test/rtg/rtg_regression.c
@@ -1113,6 +1113,154 @@ static void check_guard(const char *name)
 	printf("ok   %s\n", name);
 }
 
+/* Independent YUV 4:2:2 reference: the layouts are expressed as
+ * byte-position -> component (transcribed from the Picasso96.h macropixel
+ * comments), the opposite direction from the production table, and pixels
+ * are composed byte-by-byte in surface memory order. */
+enum { RC_Y0, RC_Y1, RC_U, RC_V };
+
+static const uint8_t ref_yuv_byte_comp[YUV422_VARIANT_NUM][4] = {
+	{ RC_Y0, RC_V, RC_Y1, RC_U },  /* CGX:  Y0-V-Y1-U  */
+	{ RC_Y1, RC_U, RC_Y0, RC_V },  /* STD:  Y1-U-Y0-V  */
+	{ RC_V, RC_Y0, RC_U, RC_Y1 },  /* PC:   V-Y0-U-Y1  */
+	{ RC_Y0, RC_Y1, RC_V, RC_U },  /* PA:   Y0-Y1-V-U  */
+	{ RC_U, RC_V, RC_Y1, RC_Y0 },  /* PAPC: U-V-Y1-Y0  */
+};
+
+static int32_t ref_yuv_clamp(int32_t v)
+{
+	return v < 0 ? 0 : (v > 255 ? 255 : v);
+}
+
+static void ref_yuv422_rect(int16_t phase, int16_t dx, int16_t dy, int16_t w,
+	int16_t h, uint8_t variant, uint8_t color_format, uint16_t src_pitch,
+	const uint8_t *src)
+{
+	for (int16_t yy = 0; yy < h; yy++) {
+		const uint8_t *srow = src + (size_t)yy * src_pitch;
+		uint8_t *drow = row8(expected_fb, FB_PITCH_WORDS, dy + yy);
+
+		for (int16_t xx = 0; xx < w; xx++) {
+			int16_t sx = phase + xx;
+			const uint8_t *mp = srow + (sx / 2) * 4;
+			int want_y = (sx & 1) ? RC_Y1 : RC_Y0;
+			int32_t y = 0, u = 0, v = 0;
+
+			for (int b = 0; b < 4; b++) {
+				uint8_t comp = ref_yuv_byte_comp[variant][b];
+				if (comp == want_y)
+					y = mp[b];
+				else if (comp == RC_U)
+					u = mp[b];
+				else if (comp == RC_V)
+					v = mp[b];
+			}
+
+			int32_t c = y - 16, d = u - 128, e = v - 128;
+			int32_t r = ref_yuv_clamp((298 * c + 409 * e + 128) >> 8);
+			int32_t g = ref_yuv_clamp((298 * c - 100 * d - 208 * e + 128) >> 8);
+			int32_t bl = ref_yuv_clamp((298 * c + 516 * d + 128) >> 8);
+
+			switch (color_format) {
+			case MNTVA_COLOR_32BIT: {
+				uint8_t *px = drow + (size_t)(dx + xx) * 4;
+				px[0] = (uint8_t)bl;
+				px[1] = (uint8_t)g;
+				px[2] = (uint8_t)r;
+				px[3] = 0xFF;
+				break;
+			}
+			case MNTVA_COLOR_16BIT565: {
+				uint8_t *px = drow + (size_t)(dx + xx) * 2;
+				uint16_t val = (uint16_t)(((r >> 3) << 11) | ((g >> 2) << 5) | (bl >> 3));
+				px[0] = (uint8_t)(val >> 8);   /* pixels sit big-endian in surface memory */
+				px[1] = (uint8_t)val;
+				break;
+			}
+			case MNTVA_COLOR_15BIT: {
+				uint8_t *px = drow + (size_t)(dx + xx) * 2;
+				uint16_t val = (uint16_t)(((r >> 3) << 10) | ((g >> 3) << 5) | (bl >> 3));
+				px[0] = (uint8_t)(val >> 8);
+				px[1] = (uint8_t)val;
+				break;
+			}
+			}
+		}
+	}
+}
+
+static uint8_t yuv_src[192 * 64];
+
+static void fill_yuv_src(uint32_t seed)
+{
+	uint32_t saved = rng_state;
+
+	rng_state = seed;
+	for (size_t i = 0; i < sizeof(yuv_src); i++)
+		yuv_src[i] = (uint8_t)rng32();
+	rng_state = saved;
+}
+
+static void test_yuv(void)
+{
+	static const uint8_t colormodes[3] = {
+		MNTVA_COLOR_32BIT, MNTVA_COLOR_16BIT565, MNTVA_COLOR_15BIT,
+	};
+	static const char *cm_names[3] = { "32", "565", "15" };
+	char name[64];
+
+	for (uint8_t variant = 0; variant < YUV422_VARIANT_NUM; variant++) {
+		for (int cm = 0; cm < 3; cm++) {
+			seed_frame(0xA000 + variant * 8 + cm);
+			fill_yuv_src(0xC0DE0000u + variant * 8 + cm);
+			yuv422_to_rgb_rect(0, 5, 3, 24, 16, variant, colormodes[cm], 96, yuv_src);
+			ref_yuv422_rect(0, 5, 3, 24, 16, variant, colormodes[cm], 96, yuv_src);
+			snprintf(name, sizeof(name), "yuv422 v%u -> %s", variant, cm_names[cm]);
+			check_frame(name);
+		}
+	}
+
+	/* geometry edge cases */
+	seed_frame(0xA100);
+	fill_yuv_src(0xC0DE0100);
+	yuv422_to_rgb_rect(0, 7, 2, 33, 9, YUV422_VARIANT_CGX, MNTVA_COLOR_16BIT565, 96, yuv_src);
+	ref_yuv422_rect(0, 7, 2, 33, 9, YUV422_VARIANT_CGX, MNTVA_COLOR_16BIT565, 96, yuv_src);
+	check_frame("yuv422 odd width");
+
+	seed_frame(0xA101);
+	fill_yuv_src(0xC0DE0101);
+	yuv422_to_rgb_rect(1, 4, 1, 21, 7, YUV422_VARIANT_STD, MNTVA_COLOR_32BIT, 96, yuv_src);
+	ref_yuv422_rect(1, 4, 1, 21, 7, YUV422_VARIANT_STD, MNTVA_COLOR_32BIT, 96, yuv_src);
+	check_frame("yuv422 phase 1 odd width");
+
+	seed_frame(0xA102);
+	fill_yuv_src(0xC0DE0102);
+	yuv422_to_rgb_rect(0, 13, 5, 1, 6, YUV422_VARIANT_PC, MNTVA_COLOR_16BIT565, 96, yuv_src);
+	ref_yuv422_rect(0, 13, 5, 1, 6, YUV422_VARIANT_PC, MNTVA_COLOR_16BIT565, 96, yuv_src);
+	check_frame("yuv422 w=1 odd dx");
+
+	seed_frame(0xA103);
+	fill_yuv_src(0xC0DE0103);
+	yuv422_to_rgb_rect(1, 2, 4, 1, 3, YUV422_VARIANT_PA, MNTVA_COLOR_15BIT, 96, yuv_src);
+	ref_yuv422_rect(1, 2, 4, 1, 3, YUV422_VARIANT_PA, MNTVA_COLOR_15BIT, 96, yuv_src);
+	check_frame("yuv422 w=1 phase 1");
+
+	seed_frame(0xA104);
+	fill_yuv_src(0xC0DE0104);
+	yuv422_to_rgb_rect(0, 0, 0, 40, 1, YUV422_VARIANT_PAPC, MNTVA_COLOR_32BIT, 96, yuv_src);
+	ref_yuv422_rect(0, 0, 0, 40, 1, YUV422_VARIANT_PAPC, MNTVA_COLOR_32BIT, 96, yuv_src);
+	check_frame("yuv422 h=1 origin");
+
+	/* rejected inputs must leave the frame untouched */
+	seed_frame(0xA105);
+	yuv422_to_rgb_rect(0, 5, 3, 24, 16, YUV422_VARIANT_NUM, MNTVA_COLOR_32BIT, 96, yuv_src);
+	yuv422_to_rgb_rect(0, 5, 3, 24, 16, YUV422_VARIANT_CGX, MNTVA_COLOR_8BIT, 96, yuv_src);
+	yuv422_to_rgb_rect(0, 5, 3, 0, 16, YUV422_VARIANT_CGX, MNTVA_COLOR_32BIT, 96, yuv_src);
+	yuv422_to_rgb_rect(0, 5, 3, 24, 0, YUV422_VARIANT_CGX, MNTVA_COLOR_32BIT, 96, yuv_src);
+	yuv422_to_rgb_rect(0, -1, 3, 24, 16, YUV422_VARIANT_CGX, MNTVA_COLOR_32BIT, 96, yuv_src);
+	check_frame("yuv422 rejected inputs");
+}
+
 static void test_fb_limit_clamp(void)
 {
 	seed_frame(0xb001);
@@ -1133,6 +1281,16 @@ static void test_fb_limit_clamp(void)
 	ref_invert_rect(5, FB_H - 2, 30, 2, 0xff, MNTVA_COLOR_8BIT);
 	check_frame("invert_rect clamped");
 	check_guard("invert_rect guard");
+
+	seed_frame(0xb003);
+	memset(actual_buf.guard, 0x5c, sizeof(actual_buf.guard));
+	fill_yuv_src(0xC0DE0200);
+	yuv422_to_rgb_rect(0, 4, FB_H - 3, 20, 8, YUV422_VARIANT_CGX,
+		MNTVA_COLOR_32BIT, 96, yuv_src);
+	ref_yuv422_rect(0, 4, FB_H - 3, 20, 3, YUV422_VARIANT_CGX,
+		MNTVA_COLOR_32BIT, 96, yuv_src);
+	check_frame("yuv422 clamped");
+	check_guard("yuv422 guard");
 
 	set_fb_limit(0);
 }
@@ -1232,15 +1390,30 @@ static void bench_p2d(void)
 		B_PLANES, 0xff, 0xff, 0x00ffffff, B_PITCH, data, MNTVA_COLOR_32BIT);
 }
 
+static void bench_yuv565(void)
+{
+	yuv422_to_rgb_rect(0, 3, 2, 80, 48, YUV422_VARIANT_CGX,
+		MNTVA_COLOR_16BIT565, 160, yuv_src);
+}
+
+static void bench_yuv32(void)
+{
+	yuv422_to_rgb_rect(0, 3, 2, 80, 48, YUV422_VARIANT_CGX,
+		MNTVA_COLOR_32BIT, 160, yuv_src);
+}
+
 static void run_benchmarks(void)
 {
 	seed_frame(0x7000);
+	fill_yuv_src(0x7001);
 	bench_one("fill_rect_solid 8", bench_fill8, 200000);
 	bench_one("fill_rect_solid 32", bench_fill32, 120000);
 	bench_one("acc_clear_buffer 32", bench_clear32, 120000);
 	bench_one("copy_rect_nomask 32", bench_copy32, 120000);
 	bench_one("p2c_rect src 8 planes", bench_p2c, 20000);
 	bench_one("p2d_rect src 8 planes", bench_p2d, 20000);
+	bench_one("yuv422_to_rgb 565", bench_yuv565, 20000);
+	bench_one("yuv422_to_rgb 32", bench_yuv32, 20000);
 	printf("checksum %016llx\n", (unsigned long long)checksum_words(actual_fb, FB_WORDS));
 }
 
@@ -1258,6 +1431,7 @@ static void run_tests(void)
 	test_pattern();
 	test_acc_blit();
 	test_acc_clear();
+	test_yuv();
 	test_fb_limit_clamp();
 }
 

--- a/test/rtg/rtg_regression.c
+++ b/test/rtg/rtg_regression.c
@@ -1114,17 +1114,18 @@ static void check_guard(const char *name)
 }
 
 /* Independent YUV 4:2:2 reference: the layouts are expressed as
- * byte-position -> component (transcribed from the Picasso96.h macropixel
- * comments), the opposite direction from the production table, and pixels
- * are composed byte-by-byte in surface memory order. */
+ * byte-position -> component, the opposite direction from the production
+ * table, and pixels are composed byte-by-byte in surface memory order.
+ * Orders are the P96 V3.6.3-corrected ones (the old Picasso96.h comments
+ * have U and V interchanged): CGX = YUY2, 422PC = UYVY. */
 enum { RC_Y0, RC_Y1, RC_U, RC_V };
 
 static const uint8_t ref_yuv_byte_comp[YUV422_VARIANT_NUM][4] = {
-	{ RC_Y0, RC_V, RC_Y1, RC_U },  /* CGX:  Y0-V-Y1-U  */
-	{ RC_Y1, RC_U, RC_Y0, RC_V },  /* STD:  Y1-U-Y0-V  */
-	{ RC_V, RC_Y0, RC_U, RC_Y1 },  /* PC:   V-Y0-U-Y1  */
-	{ RC_Y0, RC_Y1, RC_V, RC_U },  /* PA:   Y0-Y1-V-U  */
-	{ RC_U, RC_V, RC_Y1, RC_Y0 },  /* PAPC: U-V-Y1-Y0  */
+	{ RC_Y0, RC_U, RC_Y1, RC_V },  /* CGX:  Y0-U-Y1-V (YUY2) */
+	{ RC_Y1, RC_V, RC_Y0, RC_U },  /* STD:  Y1-V-Y0-U */
+	{ RC_U, RC_Y0, RC_V, RC_Y1 },  /* PC:   U-Y0-V-Y1 (UYVY) */
+	{ RC_Y0, RC_Y1, RC_U, RC_V },  /* PA:   Y0-Y1-U-V */
+	{ RC_V, RC_U, RC_Y1, RC_Y0 },  /* PAPC: V-U-Y1-Y0 */
 };
 
 static int32_t ref_yuv_clamp(int32_t v)


### PR DESCRIPTION
## What

Card-side YUV→RGB conversion for P96's software picture-in-picture path (`p96PIP` with a YUV source, used by video players). The 68k still pushes the YUV bytes over Zorro (no bus-mastering), but conversion and the RGB framebuffer writes move from the 68060 to the ARM — the same win profile as the P2C path. Consumed by the companion ZZ9000.card `WriteYUVRect` hook.

## Changes

- **`gfx.c` kernel** `yuv422_to_rgb_rect`: all five packed CCIR601 4:2:2 macropixel orderings from Picasso96.h (YUV422CGX/422/422PC/422PA/422PAPC) via one byte-offset table; fixed-point studio-range math with per-macropixel chroma; source-phase handling for odd source x, odd-width tails, and the `fb_limit` row clamp. 16/15-bit stores are byte-swapped: those pixels sit **big-endian** in surface memory (that's how the 68k writes them directly, and how P96 pens survive the unswapped `rgb[0]`→`memset16` path today).
- **`OP_WRITE_YUV`** appended before `OP_NUM` (shared driver/firmware op ABI stays append-only) and dispatched in `dma_rtg.c` exactly like `OP_P2C`: driver stages YUV rows in card VRAM, `offset[SRC]`/`pitch[SRC]` describe them, destination flows through `set_fb` with the longword dest pitch convention. New `GFXDATA_U8_YUV_VARIANT` byte selects the macropixel order.
- **`yuv_rect` ZZ9000.CFG key** (on/off, default on): kill-switch backend the driver queries, same pattern as `offscreen_bitmaps`.
- **Firmware revision → 2.5**: the driver gates its `WriteYUVRect` hook on this (the op doesn't exist below 2.5).

## Tests

`test/rtg`: independent oracle expressing the layouts in the opposite direction (byte-position→component, transcribed from the Picasso96.h comments) and composing pixels byte-by-byte in surface memory order; 5 variants × 3 dest formats plus odd-width/phase/w=1/h=1/rejected-input cases and an fb-limit clamp+guard test. Bench entries included. `test/config` extended for the new key. All suites green; full ARM build links clean.

## Companion PR

BlitterStudio/zz9000-drivers — ships as a **contract probe first** (log + delegate to P96's own converter): the `WriteYUVRect` TagItem contract is undocumented anywhere public, so a Sashimi capture from a real PIP session on hardware defines the stride/tag conventions before the accelerated path is enabled there. This firmware op is inert until that lands.

**No bitstream change** — ARM code only.