### PR TITLE
Add ZZ9000AX capture-ready firmware interface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
         run: make -C test/video test
       - name: Video codec regression suite
         run: make -C test/video_codec test
+      - name: Audio capture regression suite
+        run: make -C test/audio test
       - name: Firmware-file restore suite
         run: make -C test/fwupdate test
       - name: SD activity LED suite

--- a/ZZ9000_proto.sdk/ZZ9000OS/Makefile
+++ b/ZZ9000_proto.sdk/ZZ9000OS/Makefile
@@ -97,6 +97,7 @@ C_SRCS = \
 	$(SRC_DIR)/platform.c \
 	$(SRC_DIR)/adc.c \
 	$(SRC_DIR)/ax.c \
+	$(SRC_DIR)/audio_capture.c \
 	$(SRC_DIR)/bootrom.c \
 	$(SRC_DIR)/codec37.c \
 	$(SRC_DIR)/codec47.c \

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_capture.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_capture.c
@@ -1,0 +1,68 @@
+/*
+ * ZZ9000AX capture-period conversion.
+ *
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "audio_capture.h"
+
+static int16_t read_s16le(const uint8_t *sample)
+{
+	uint16_t value = (uint16_t)sample[0] | ((uint16_t)sample[1] << 8);
+
+	return (int16_t)value;
+}
+
+static void write_s16be(uint8_t *sample, int16_t value)
+{
+	uint16_t encoded = (uint16_t)value;
+
+	sample[0] = (uint8_t)(encoded >> 8);
+	sample[1] = (uint8_t)encoded;
+}
+
+static int16_t interpolate(int16_t first, int16_t second, uint16_t fraction)
+{
+	int32_t delta = (int32_t)second - (int32_t)first;
+
+	return (int16_t)((int32_t)first +
+	                 (delta * (int32_t)fraction) / 32768);
+}
+
+uint16_t zz_audio_capture_convert(uint8_t *period, uint16_t output_frames)
+{
+	uint32_t output;
+
+	if (output_frames == 0U ||
+	    output_frames > ZZ_AUDIO_CAPTURE_INPUT_FRAMES)
+		output_frames = ZZ_AUDIO_CAPTURE_INPUT_FRAMES;
+
+	for (output = 0U; output < output_frames; output++) {
+		uint32_t numerator = output * ZZ_AUDIO_CAPTURE_INPUT_FRAMES;
+		uint32_t source = numerator / output_frames;
+		uint32_t remainder = numerator % output_frames;
+		uint16_t fraction =
+		    (uint16_t)((remainder * 32768U) / output_frames);
+		uint32_t next = source + 1U;
+		const uint8_t *first;
+		const uint8_t *second;
+		int16_t left;
+		int16_t right;
+
+		if (next >= ZZ_AUDIO_CAPTURE_INPUT_FRAMES)
+			next = source;
+
+		first = period + source * 4U;
+		second = period + next * 4U;
+		left = interpolate(read_s16le(first), read_s16le(second),
+		                   fraction);
+		right = interpolate(read_s16le(first + 2U),
+		                    read_s16le(second + 2U), fraction);
+
+		write_s16be(period + output * 4U, left);
+		write_s16be(period + output * 4U + 2U, right);
+	}
+
+	return output_frames;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_capture.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_capture.h
@@ -30,6 +30,14 @@
  */
 uint16_t zz_audio_capture_convert(uint8_t *period, uint16_t output_frames);
 
+/* F4/F6 share one 32-bit read-decode group. Codec presence belongs in the
+ * upper word (F4) and receive status in the lower word (F6). */
+static inline uint32_t zz_audio_config_read_pack(uint16_t codec_present,
+                                                 uint16_t rx_status)
+{
+	return ((uint32_t)codec_present << 16) | rx_status;
+}
+
 static inline uint16_t zz_audio_rx_status_pack(uint8_t period,
                                                uint16_t sequence)
 {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_capture.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_capture.h
@@ -30,6 +30,13 @@
  */
 uint16_t zz_audio_capture_convert(uint8_t *period, uint16_t output_frames);
 
+static inline uint8_t zz_audio_capture_can_publish(uint16_t interrupt_mask,
+                                                   uint8_t dma_ready)
+{
+	return dma_ready &&
+	    ((interrupt_mask & ZZ_AUDIO_CONFIG_RECORD) != 0U);
+}
+
 /* F4/F6 share one 32-bit read-decode group. Codec presence belongs in the
  * upper word (F4) and receive status in the lower word (F6). */
 static inline uint32_t zz_audio_config_read_pack(uint16_t codec_present,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_capture.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_capture.h
@@ -1,0 +1,76 @@
+/*
+ * ZZ9000AX capture-period conversion and status helpers.
+ *
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef ZZ_AUDIO_CAPTURE_H
+#define ZZ_AUDIO_CAPTURE_H
+
+#include <stdint.h>
+
+#define ZZ_AUDIO_CAPTURE_INPUT_FRAMES 960U
+#define ZZ_AUDIO_CAPTURE_PERIODS      8U
+#define ZZ_AUDIO_CAPTURE_RESIDENT_PERIODS (ZZ_AUDIO_CAPTURE_PERIODS - 1U)
+
+#define ZZ_AUDIO_CONFIG_PLAY          0x0001U
+#define ZZ_AUDIO_CONFIG_RECORD        0x0002U
+#define ZZ_AUDIO_CONFIG_MASK          0x0003U
+
+#define ZZ_AUDIO_RX_STATUS_CAPABLE       0x8000U
+#define ZZ_AUDIO_RX_STATUS_PERIOD_SHIFT  12U
+#define ZZ_AUDIO_RX_STATUS_PERIOD_MASK   0x7000U
+#define ZZ_AUDIO_RX_STATUS_SEQUENCE_MASK 0x0fffU
+
+/*
+ * Convert one 48 kHz S16LE stereo DMA period in place to output_frames
+ * S16BE stereo frames. Invalid frame counts fall back to the native 960.
+ * Returns the number of output frames written.
+ */
+uint16_t zz_audio_capture_convert(uint8_t *period, uint16_t output_frames);
+
+static inline uint16_t zz_audio_rx_status_pack(uint8_t period,
+                                               uint16_t sequence)
+{
+	return (uint16_t)(ZZ_AUDIO_RX_STATUS_CAPABLE |
+	    (((uint16_t)period & (ZZ_AUDIO_CAPTURE_PERIODS - 1U)) <<
+	     ZZ_AUDIO_RX_STATUS_PERIOD_SHIFT) |
+	    (sequence & ZZ_AUDIO_RX_STATUS_SEQUENCE_MASK));
+}
+
+static inline uint8_t zz_audio_rx_status_period(uint16_t status)
+{
+	return (uint8_t)((status & ZZ_AUDIO_RX_STATUS_PERIOD_MASK) >>
+	                 ZZ_AUDIO_RX_STATUS_PERIOD_SHIFT);
+}
+
+static inline uint16_t zz_audio_rx_status_sequence(uint16_t status)
+{
+	return status & ZZ_AUDIO_RX_STATUS_SEQUENCE_MASK;
+}
+
+static inline uint16_t zz_audio_rx_sequence_distance(uint16_t newer,
+                                                      uint16_t older)
+{
+	return (newer - older) & ZZ_AUDIO_RX_STATUS_SEQUENCE_MASK;
+}
+
+static inline uint8_t zz_audio_capture_completed_period(
+    uint32_t transfer_count, uint32_t bytes_per_period)
+{
+	uint32_t writer_period =
+	    (transfer_count / bytes_per_period) % ZZ_AUDIO_CAPTURE_PERIODS;
+
+	return (uint8_t)((writer_period + ZZ_AUDIO_CAPTURE_PERIODS - 1U) %
+	                 ZZ_AUDIO_CAPTURE_PERIODS);
+}
+
+static inline uint8_t zz_audio_capture_period_distance(uint8_t newer,
+                                                        uint8_t older)
+{
+	return (uint8_t)((newer - older) &
+	                 (ZZ_AUDIO_CAPTURE_PERIODS - 1U));
+}
+
+#endif /* ZZ_AUDIO_CAPTURE_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
@@ -14,6 +14,7 @@
 #include "sleep.h"
 #include "stdlib.h"
 #include "ax.h"
+#include "audio_capture.h"
 #include "memorymap.h"
 #include "xtime_l.h"
 #include "math.h"
@@ -31,7 +32,12 @@ XAudioFormatter audio_formatter_rx;
 
 static uint8_t* audio_tx_buffer = (uint8_t*)AUDIO_TX_BUFFER_ADDRESS;
 static uint8_t* audio_inited_tx_buffer = NULL;
-static uint8_t* audio_rx_buffer = (uint8_t*)AUDIO_RX_BUFFER_ADDRESS;
+static uint8_t* volatile audio_rx_buffer = (uint8_t*)AUDIO_RX_BUFFER_ADDRESS;
+static volatile uint16_t audio_interrupt_mask = 0;
+static volatile uint16_t audio_capture_frames = ZZ_AUDIO_CAPTURE_INPUT_FRAMES;
+static volatile uint16_t audio_rx_status = ZZ_AUDIO_RX_STATUS_CAPABLE;
+static volatile uint8_t audio_rx_last_completed_period =
+    AUDIO_NUM_PERIODS - 1U;
 
 int adau_write16(u8 i2c_addr, u16 addr, u16 value) {
 	XIicPs* iic = &Iic2;
@@ -273,8 +279,6 @@ void audio_init_i2s() {
 
 	XAudioFormatter_InterruptDisable(&audio_formatter_rx, 1<<14); // timeout
 	XAudioFormatter_InterruptDisable(&audio_formatter_rx, 1<<13); // IOC
-	/*XAudioFormatter_InterruptEnable(&audio_formatter_rx, 1<<13); // IOC
-	printf("[adau] RX XAudioFormatter_InterruptEnable\n");*/
 
 	XI2srx_Config* i2srx_config = XI2s_Rx_LookupConfig(XPAR_XI2SRX_0_DEVICE_ID);
 	status = XI2s_Rx_CfgInitialize(&i2srx, i2srx_config, i2srx_config->BaseAddress);
@@ -285,6 +289,11 @@ void audio_init_i2s() {
 	//printf("[adau] I2S_RX MaxNumChannels: %d\n", i2srx.Config.MaxNumChannels);
 
 	XI2s_Rx_Enable(&i2srx, 1);
+	audio_rx_last_completed_period = AUDIO_NUM_PERIODS - 1U;
+	audio_rx_status = ZZ_AUDIO_RX_STATUS_CAPABLE;
+	XAudioFormatter_WriteReg(audio_formatter_rx.BaseAddress,
+		XAUD_FORMATTER_STS + XAUD_FORMATTER_S2MM_OFFSET, 1U<<31);
+	XAudioFormatter_InterruptEnable(&audio_formatter_rx, 1<<13); // IOC
 	XAudioFormatterDMAStart(&audio_formatter_rx);
 
 	printf("[adau] XAudioFormatter_InterruptEnable...\n");
@@ -405,8 +414,6 @@ int audio_adau_init(int program_dsp) {
 	return 1;
 }
 
-static int interrupt_enabled_audio = 0;
-
 XTime debug_time_start = 0;
 
 void audio_debug_timer(int zdata) {
@@ -443,7 +450,7 @@ void isr_audio(void *dummy) {
 	// and glitch MP3 playback. No-op when no session is bound.
 	sdk_mailbox_audio_playback_pump_isr();
 
-	if (interrupt_enabled_audio) {
+	if (audio_interrupt_mask & ZZ_AUDIO_CONFIG_PLAY) {
 		amiga_interrupt_set(AMIGA_INTERRUPT_AUDIO);
 	}
 }
@@ -452,29 +459,95 @@ int israrx_count = 0;
 
 // audio formatter interrupt, triggered whenever a period is completed
 void isr_audio_rx(void *dummy) {
+	uint32_t transfer_count;
+	uint8_t newest_period;
+	uint8_t completed_count;
+	uint8_t index;
 	uint32_t val = XAudioFormatter_ReadReg(XPAR_XAUDIOFORMATTER_1_BASEADDR, XAUD_FORMATTER_STS + XAUD_FORMATTER_S2MM_OFFSET);
 	val |= (1<<31); // clear irq
 	XAudioFormatter_WriteReg(XPAR_XAUDIOFORMATTER_1_BASEADDR,
 		XAUD_FORMATTER_STS + XAUD_FORMATTER_S2MM_OFFSET, val);
 
+	/* The transfer counter points into the period currently being written.
+	 * Derive the newest complete period from it instead of assuming that
+	 * every edge reached the CPU separately. */
+	transfer_count = XAudioFormatterGetDMATransferCount(&audio_formatter_rx);
+	newest_period = zz_audio_capture_completed_period(transfer_count,
+	                                                 AUDIO_BYTES_PER_PERIOD);
+	completed_count = zz_audio_capture_period_distance(
+	    newest_period, audio_rx_last_completed_period);
+	/* IOC means at least one period completed. Equal cursors mean the CPU
+	 * was delayed for at least one full ring. Keep only seven periods: the
+	 * eighth slot is already the formatter's active write target. */
+	if (completed_count == 0U)
+		completed_count = ZZ_AUDIO_CAPTURE_RESIDENT_PERIODS;
+
 	if (israrx_count++>1000) {
 		israrx_count = 0;
 	}
+
+	if (audio_interrupt_mask & ZZ_AUDIO_CONFIG_RECORD) {
+		uint8_t first_period =
+		    (newest_period + AUDIO_NUM_PERIODS - completed_count + 1U) %
+		    AUDIO_NUM_PERIODS;
+
+		for (index = 0U; index < completed_count; index++) {
+			uint8_t completed_period =
+			    (first_period + index) % AUDIO_NUM_PERIODS;
+			uint8_t *period = audio_rx_buffer +
+			    completed_period * AUDIO_BYTES_PER_PERIOD;
+			uint16_t sequence =
+			    (audio_rx_status + 1U) &
+			    ZZ_AUDIO_RX_STATUS_SEQUENCE_MASK;
+			uint16_t output_frames;
+
+			/* The S2MM port is non-coherent, while Amiga Zorro accesses use
+			 * the ACP. Pull the completed DMA period into the ARM coherency
+			 * domain, then publish the converted bytes back to DDR/L2. */
+			Xil_DCacheInvalidateRange((INTPTR)period,
+			                          AUDIO_BYTES_PER_PERIOD);
+			output_frames = zz_audio_capture_convert(
+			    period, audio_capture_frames);
+			Xil_DCacheFlushRange((INTPTR)period, output_frames * 4U);
+			__asm__ __volatile__("dsb" ::: "memory");
+
+			audio_rx_status = zz_audio_rx_status_pack(
+			    completed_period, sequence);
+		}
+		amiga_interrupt_set(AMIGA_INTERRUPT_AUDIO);
+	}
+
+	audio_rx_last_completed_period = newest_period;
 }
 
 uint32_t audio_get_dma_transfer_count() {
 	return XAudioFormatterGetDMATransferCount(&audio_formatter);
 }
 
-void audio_set_interrupt_enabled(int en) {
-	printf("[audio] enable irq: %d\n", en);
-	interrupt_enabled_audio = en;
+void audio_set_interrupt_mask(uint16_t mask) {
+	uint16_t old_mask = audio_interrupt_mask;
 
-	if (!en) {
+	mask &= ZZ_AUDIO_CONFIG_MASK;
+	printf("[audio] irq mask: %u\n", mask);
+	audio_interrupt_mask = mask;
+
+	if (!mask) {
 		amiga_interrupt_clear(AMIGA_INTERRUPT_AUDIO);
 	}
 
-	audio_silence();
+	if ((old_mask ^ mask) & ZZ_AUDIO_CONFIG_PLAY)
+		audio_silence();
+}
+
+void audio_set_capture_frames(uint16_t frames) {
+	if (frames == 0U || frames > ZZ_AUDIO_CAPTURE_INPUT_FRAMES)
+		frames = ZZ_AUDIO_CAPTURE_INPUT_FRAMES;
+
+	audio_capture_frames = frames;
+}
+
+uint16_t audio_get_rx_status(void) {
+	return audio_rx_status;
 }
 
 // Whether a legacy/AHI client currently drives the audio output: those
@@ -482,7 +555,7 @@ void audio_set_interrupt_enabled(int en) {
 // for the duration of playback. The SDK playback binding must not
 // steal the formatter while this is set.
 int audio_legacy_output_active() {
-	return interrupt_enabled_audio;
+	return (audio_interrupt_mask & ZZ_AUDIO_CONFIG_PLAY) != 0;
 }
 
 // offset = offset from audio tx buffer
@@ -826,4 +899,3 @@ void audio_adau_set_eq_gain(int band, int gain) {
 	usleep(25);
 
 }
-

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
@@ -37,6 +37,7 @@ static volatile uint16_t audio_interrupt_mask = 0;
 static volatile uint16_t audio_capture_frames = ZZ_AUDIO_CAPTURE_INPUT_FRAMES;
 static volatile uint16_t audio_rx_status = ZZ_AUDIO_RX_STATUS_CAPABLE;
 static volatile uint16_t audio_tx_sequence = 0;
+static volatile uint8_t audio_capture_ready = 0;
 static volatile uint8_t audio_rx_last_completed_period =
     AUDIO_NUM_PERIODS - 1U;
 
@@ -223,6 +224,11 @@ void audio_program_adau(u8* program, u32 program_len) {
 }
 
 void audio_init_i2s() {
+	/* Buffer setters run before this deferred reinitialization. Do not let
+	 * either formatter's old IOC state publish through a new CPU pointer. */
+	audio_capture_ready = 0;
+	__asm__ __volatile__("dsb" ::: "memory");
+
 	XI2stx_Config* i2s_config = XI2s_Tx_LookupConfig(XPAR_XI2STX_0_DEVICE_ID);
 	int status = XI2s_Tx_CfgInitialize(&i2s, i2s_config, i2s_config->BaseAddress);
 
@@ -291,7 +297,6 @@ void audio_init_i2s() {
 
 	XI2s_Rx_Enable(&i2srx, 1);
 	audio_rx_last_completed_period = AUDIO_NUM_PERIODS - 1U;
-	audio_rx_status = ZZ_AUDIO_RX_STATUS_CAPABLE;
 	XAudioFormatter_WriteReg(audio_formatter_rx.BaseAddress,
 		XAUD_FORMATTER_STS + XAUD_FORMATTER_S2MM_OFFSET, 1U<<31);
 	XAudioFormatter_InterruptEnable(&audio_formatter_rx, 1<<13); // IOC
@@ -309,6 +314,10 @@ void audio_init_i2s() {
 	printf("[adau] XAudioFormatterDMAStart done.\n");
 
 	audio_inited_tx_buffer = audio_tx_buffer;
+	/* Preserve audio_rx_status across retargets so a driver that sampled the
+	 * sequence before this deferred reinit observes exactly the next period. */
+	__asm__ __volatile__("dsb" ::: "memory");
+	audio_capture_ready = 1;
 }
 
 // The TX buffer address the audio formatter DMA was last INITIALIZED
@@ -470,6 +479,11 @@ void isr_audio_rx(void *dummy) {
 	XAudioFormatter_WriteReg(XPAR_XAUDIOFORMATTER_1_BASEADDR,
 		XAUD_FORMATTER_STS + XAUD_FORMATTER_S2MM_OFFSET, val);
 
+	/* The CPU-side pointer may already name a pending ring while the
+	 * formatter is still being retargeted. Only acknowledge in that state. */
+	if (!audio_capture_ready)
+		return;
+
 	/* The transfer counter points into the period currently being written.
 	 * Derive the newest complete period from it instead of assuming that
 	 * every edge reached the CPU separately. */
@@ -488,7 +502,8 @@ void isr_audio_rx(void *dummy) {
 		israrx_count = 0;
 	}
 
-	if (audio_interrupt_mask & ZZ_AUDIO_CONFIG_RECORD) {
+	if (zz_audio_capture_can_publish(audio_interrupt_mask,
+	                                 audio_capture_ready)) {
 		uint8_t first_period =
 		    (newest_period + AUDIO_NUM_PERIODS - completed_count + 1U) %
 		    AUDIO_NUM_PERIODS;
@@ -670,6 +685,10 @@ void audio_set_tx_buffer(uint8_t* addr) {
 
 void audio_set_rx_buffer(uint8_t* addr) {
 	printf("[audio] set rx buffer: %p\n", addr);
+	/* The formatter keeps writing its active ring until audio_init_i2s().
+	 * Block the ISR before exposing the pending CPU-side pointer. */
+	audio_capture_ready = 0;
+	__asm__ __volatile__("dsb" ::: "memory");
 	audio_rx_buffer = addr;
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
@@ -36,6 +36,7 @@ static uint8_t* volatile audio_rx_buffer = (uint8_t*)AUDIO_RX_BUFFER_ADDRESS;
 static volatile uint16_t audio_interrupt_mask = 0;
 static volatile uint16_t audio_capture_frames = ZZ_AUDIO_CAPTURE_INPUT_FRAMES;
 static volatile uint16_t audio_rx_status = ZZ_AUDIO_RX_STATUS_CAPABLE;
+static volatile uint16_t audio_tx_sequence = 0;
 static volatile uint8_t audio_rx_last_completed_period =
     AUDIO_NUM_PERIODS - 1U;
 
@@ -449,6 +450,7 @@ void isr_audio(void *dummy) {
 	// network load previously let the DMA overrun the fill frontier
 	// and glitch MP3 playback. No-op when no session is bound.
 	sdk_mailbox_audio_playback_pump_isr();
+	audio_tx_sequence++;
 
 	if (audio_interrupt_mask & ZZ_AUDIO_CONFIG_PLAY) {
 		amiga_interrupt_set(AMIGA_INTERRUPT_AUDIO);
@@ -522,6 +524,10 @@ void isr_audio_rx(void *dummy) {
 
 uint32_t audio_get_dma_transfer_count() {
 	return XAudioFormatterGetDMATransferCount(&audio_formatter);
+}
+
+uint16_t audio_get_tx_sequence(void) {
+	return audio_tx_sequence;
 }
 
 void audio_set_interrupt_mask(uint16_t mask) {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.h
@@ -43,6 +43,7 @@ int audio_legacy_output_active(void);
 void audio_clear_interrupt();
 uint32_t audio_get_interrupt();
 uint32_t audio_get_dma_transfer_count();
+uint16_t audio_get_tx_sequence(void);
 int audio_swab(uint16_t audio_buf_samples, uint32_t offset, int byteswap);
 void audio_set_tx_buffer(uint8_t* addr);
 void audio_set_rx_buffer(uint8_t* addr);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.h
@@ -34,7 +34,9 @@ int audio_adau_init(int program_dsp);
 void audio_init_i2s();
 void isr_audio(void *dummy);
 void isr_audio_rx(void *dummy);
-void audio_set_interrupt_enabled(int en);
+void audio_set_interrupt_mask(uint16_t mask);
+void audio_set_capture_frames(uint16_t frames);
+uint16_t audio_get_rx_status(void);
 /* Nonzero while a legacy/AHI client drives the audio output (it keeps
  * the per-period Amiga interrupt enabled during playback). */
 int audio_legacy_output_active(void);
@@ -69,4 +71,3 @@ void audio_adau_set_prefactor(int pre);
 void audio_adau_set_vol_pan(int vol, int pan);
 
 #endif
-

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -55,6 +55,7 @@ void Xil_AssertNonVoid() {}
 #include "scheduler.h"
 #include "adc.h"
 #include "ax.h"
+#include "audio_capture.h"
 #include "watchdog.h"
 #include "mp3/mp3.h"
 
@@ -1558,12 +1559,14 @@ int main() {
 						break;
 					}
 					case REG_ZZ_AUDIO_CONFIG: {
-						// is ZZ9000AX present?
-						data = (adau_enabled)<<16;
+						/* F4 and F6 share this 32-bit read group: codec
+						 * presence is the F4 word and RX status is F6. */
+						data = zz_audio_config_read_pack(
+						    (uint16_t)adau_enabled, audio_get_rx_status());
 						break;
 					}
-					case REG_ZZ_AUDIO_RX_STATUS: {
-						data = ((uint32_t)audio_get_rx_status()) << 16;
+					case REG_ZZ_AUDIO_TX_STATUS: {
+						data = ((uint32_t)audio_get_tx_sequence()) << 16;
 						break;
 					}
 					case REG_ZZ_DECODER_VAL: {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -269,7 +269,7 @@ void handle_amiga_reset(enum amiga_reset_mode mode) {
 	ethernet_send_result = 0;
 	eth_backlog_nag_counter = 0;
 	interrupt_enabled_ethernet = 0;
-	audio_set_interrupt_enabled(0);
+	audio_set_interrupt_mask(0);
 	interrupt_enabled_vblank = 0;
 
 	// drop all RTG off-screen surfaces; P96 re-allocates after reboot
@@ -1253,7 +1253,7 @@ int main() {
 				}
 				case REG_ZZ_AUDIO_CONFIG: {
 					// audio config
-					audio_set_interrupt_enabled((int)(zdata & 1));
+					audio_set_interrupt_mask((uint16_t)zdata);
 					break;
 				}
 				case REG_ZZ_SDK_DOORBELL:
@@ -1321,6 +1321,7 @@ int main() {
 					}
 				case REG_ZZ_AUDIO_SCALE:
 					audio_scale = zdata;
+					audio_set_capture_frames((uint16_t)zdata);
 					break;
 				case REG_ZZ_AUDIO_PARAM:
 					printf("[REG_ZZ_AUDIO_PARAM] %lx\n", zdata);
@@ -1559,6 +1560,10 @@ int main() {
 					case REG_ZZ_AUDIO_CONFIG: {
 						// is ZZ9000AX present?
 						data = (adau_enabled)<<16;
+						break;
+					}
+					case REG_ZZ_AUDIO_RX_STATUS: {
+						data = ((uint32_t)audio_get_rx_status()) << 16;
 						break;
 					}
 					case REG_ZZ_DECODER_VAL: {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
@@ -168,7 +168,7 @@ enum zz_reg_offsets {
   REG_ZZ_PRINT_CHR      = 0xF0,
   REG_ZZ_PRINT_HEX      = 0xF2,
   REG_ZZ_AUDIO_CONFIG   = 0xF4,
-  REG_ZZ_UNUSED_REGF6   = 0xF6,
+  REG_ZZ_AUDIO_RX_STATUS = 0xF6,
   REG_ZZ_UNUSED_REGF8   = 0xF8,
   REG_ZZ_UNUSED_REGFA   = 0xFA,
   REG_ZZ_DEBUG          = 0xFC,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
@@ -169,7 +169,7 @@ enum zz_reg_offsets {
   REG_ZZ_PRINT_HEX      = 0xF2,
   REG_ZZ_AUDIO_CONFIG   = 0xF4,
   REG_ZZ_AUDIO_RX_STATUS = 0xF6,
-  REG_ZZ_UNUSED_REGF8   = 0xF8,
+  REG_ZZ_AUDIO_TX_STATUS = 0xF8,
   REG_ZZ_UNUSED_REGFA   = 0xFA,
   REG_ZZ_DEBUG          = 0xFC,
   REG_ZZ_DEBUG_TIMER    = 0xFE,

--- a/docs/ahi-recording-protocol.md
+++ b/docs/ahi-recording-protocol.md
@@ -1,0 +1,47 @@
+# ZZ9000AX AHI recording firmware protocol
+
+The FPGA design already routes the ZZ9000AX I2S input through an S2MM audio
+formatter into an eight-period DDR ring and connects its completion interrupt
+to the ARM. AHI recording therefore needs firmware and driver changes only;
+the Verilog, Vivado project and committed bitstreams are unchanged.
+
+## Registers
+
+`REG_ZZ_AUDIO_CONFIG` (`0xF4`) retains codec presence in read bit 0. Writes are
+a control mask: bit 0 enables playback-period interrupts and bit 1 enables
+capture-ready interrupts. Older drivers write only zero or one and remain
+compatible.
+
+`REG_ZZ_AUDIO_RX_STATUS` (`0xF6`) is read-only:
+
+| Bits | Meaning |
+| --- | --- |
+| 15 | Capture protocol implemented. |
+| 14:12 | Newest completed receive-period index (0 through 7). |
+| 11:0 | Completion sequence, incremented modulo 4096. |
+
+Old firmware returns zero at `0xF6`, allowing a new driver to retain playback
+without advertising recording.
+
+## Publication order
+
+The receive formatter writes 960 48 kHz S16LE stereo frames into each
+3840-byte period. While capture interrupts are enabled, the receive ISR:
+
+1. invalidates the completed DMA period;
+2. converts it in place to the `REG_ZZ_AUDIO_SCALE` frame count using integer
+   linear resampling;
+3. stores the result as Amiga-native S16BE stereo;
+4. flushes the valid `frame_count * 4` bytes and completes a memory barrier;
+5. publishes the period index and incremented sequence;
+6. asserts the existing shared Amiga audio interrupt.
+
+The sequence update is the publication boundary: the driver must not consume a
+period before observing its new sequence. Values outside 1 through 960 in
+`REG_ZZ_AUDIO_SCALE` fall back to 960 frames.
+
+The driver selects the ring using the existing `AP_RX_BUF_OFFS_HI/LO`
+parameters. Its stride remains 3840 bytes even when the requested rate produces
+fewer frames. At most the newest seven completed periods are recoverable after
+a delayed interrupt; the eighth ring slot is already the formatter's active
+write target and is never published as backlog.

--- a/docs/ahi-recording-protocol.md
+++ b/docs/ahi-recording-protocol.md
@@ -23,6 +23,13 @@ compatible.
 Old firmware returns zero at `0xF6`, allowing a new driver to retain playback
 without advertising recording.
 
+`REG_ZZ_AUDIO_TX_STATUS` (`0xF8`) is a read-only 16-bit completion sequence.
+Firmware increments it modulo 65536 after every transmit period completes,
+before asserting the shared audio interrupt. A capture-capable driver samples
+the sequence when playback starts and services playback only after observing a
+different value. This distinguishes playback completions from capture-only
+wake-ups without changing the FPGA interrupt routing.
+
 ## Publication order
 
 The receive formatter writes 960 48 kHz S16LE stereo frames into each

--- a/docs/ahi-recording-protocol.md
+++ b/docs/ahi-recording-protocol.md
@@ -47,6 +47,21 @@ The sequence update is the publication boundary: the driver must not consume a
 period before observing its new sequence. Values outside 1 through 960 in
 `REG_ZZ_AUDIO_SCALE` fall back to 960 frames.
 
+## Receive-ring retargeting
+
+Writes to `AP_RX_BUF_OFFS_HI/LO` select a pending receive ring; the formatter
+does not use that address until the main loop performs its deferred I2S/audio
+formatter reinitialization. Firmware disables capture publication before
+changing the CPU-side ring pointer. RX interrupts during this window are
+acknowledged but do not convert data, advance the receive sequence or interrupt
+the Amiga. Publication resumes only after the formatter DMA has restarted on
+the new ring.
+
+The receive sequence remains monotonic across reinitialization. This lets a
+driver sample the status immediately after the buffer-register writes and
+still observe a distance of exactly one when the first period from the new
+ring is published.
+
 The driver selects the ring using the existing `AP_RX_BUF_OFFS_HI/LO`
 parameters. Its stride remains 3840 bytes even when the requested rate produces
 fewer frames. At most the newest seven completed periods are recoverable after

--- a/test/audio/Makefile
+++ b/test/audio/Makefile
@@ -1,0 +1,22 @@
+CC ?= cc
+CFLAGS ?= -O2 -g -Wall -Wextra -Werror
+
+SRC_DIR := ../../ZZ9000_proto.sdk/ZZ9000OS/src
+BUILD_DIR := build
+TARGET := $(BUILD_DIR)/audio_capture_test
+
+CPPFLAGS += -I$(SRC_DIR)
+
+.PHONY: test clean
+
+test: $(TARGET)
+	$(TARGET)
+
+$(TARGET): audio_capture_test.c $(SRC_DIR)/audio_capture.c \
+	$(SRC_DIR)/audio_capture.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ audio_capture_test.c \
+		$(SRC_DIR)/audio_capture.c
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/test/audio/audio_capture_test.c
+++ b/test/audio/audio_capture_test.c
@@ -1,0 +1,144 @@
+/*
+ * Host tests for the ZZ9000AX capture conversion and publication helpers.
+ *
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "audio_capture.h"
+
+#define PERIOD_BYTES (ZZ_AUDIO_CAPTURE_INPUT_FRAMES * 4U)
+
+static uint8_t period[PERIOD_BYTES];
+
+static void write_s16le(uint8_t *sample, int16_t value)
+{
+	uint16_t encoded = (uint16_t)value;
+
+	sample[0] = (uint8_t)encoded;
+	sample[1] = (uint8_t)(encoded >> 8);
+}
+
+static int16_t read_s16be(const uint8_t *sample)
+{
+	return (int16_t)(((uint16_t)sample[0] << 8) | sample[1]);
+}
+
+static void fill_ramp(void)
+{
+	uint32_t frame;
+
+	for (frame = 0; frame < ZZ_AUDIO_CAPTURE_INPUT_FRAMES; frame++) {
+		write_s16le(period + frame * 4U, (int16_t)(frame - 480));
+		write_s16le(period + frame * 4U + 2U,
+		            (int16_t)(1000 - (int32_t)frame));
+	}
+}
+
+static int expect_frame(uint32_t frame, int16_t left, int16_t right)
+{
+	int16_t actual_left = read_s16be(period + frame * 4U);
+	int16_t actual_right = read_s16be(period + frame * 4U + 2U);
+
+	if (actual_left != left || actual_right != right) {
+		printf("frame %u: got %d/%d, expected %d/%d\n",
+		       frame, actual_left, actual_right, left, right);
+		return 1;
+	}
+
+	return 0;
+}
+
+static int test_native_conversion(void)
+{
+	fill_ramp();
+	if (zz_audio_capture_convert(period, 960U) != 960U)
+		return 1;
+
+	return expect_frame(0U, -480, 1000) |
+	       expect_frame(480U, 0, 520) |
+	       expect_frame(959U, 479, 41);
+}
+
+static int test_44100_conversion(void)
+{
+	fill_ramp();
+	if (zz_audio_capture_convert(period, 882U) != 882U)
+		return 1;
+
+	/* Output frame 441 maps exactly to source frame 480. */
+	return expect_frame(0U, -480, 1000) |
+	       expect_frame(441U, 0, 520);
+}
+
+static int test_8000_conversion(void)
+{
+	fill_ramp();
+	if (zz_audio_capture_convert(period, 160U) != 160U)
+		return 1;
+
+	/* 48 kHz to 8 kHz is an exact six-to-one downsample. */
+	return expect_frame(1U, -474, 994) |
+	       expect_frame(159U, 474, 46);
+}
+
+static int test_invalid_frame_count_falls_back(void)
+{
+	fill_ramp();
+	return zz_audio_capture_convert(period, 0U) != 960U;
+}
+
+static int test_status_helpers(void)
+{
+	uint16_t status = zz_audio_rx_status_pack(6U, 0x1234U);
+
+	if (!(status & ZZ_AUDIO_RX_STATUS_CAPABLE) ||
+	    zz_audio_rx_status_period(status) != 6U ||
+	    zz_audio_rx_status_sequence(status) != 0x234U)
+		return 1;
+	if (zz_audio_rx_sequence_distance(2U, 0xffeU) != 4U)
+		return 1;
+
+	return 0;
+}
+
+static int test_transfer_cursor_helpers(void)
+{
+	if (zz_audio_capture_completed_period(0U, PERIOD_BYTES) != 7U)
+		return 1;
+	if (zz_audio_capture_completed_period(PERIOD_BYTES, PERIOD_BYTES) != 0U)
+		return 1;
+	if (zz_audio_capture_completed_period(PERIOD_BYTES * 9U + 12U,
+	                                      PERIOD_BYTES) != 0U)
+		return 1;
+	if (zz_audio_capture_period_distance(1U, 7U) != 2U)
+		return 1;
+	if (ZZ_AUDIO_CAPTURE_RESIDENT_PERIODS != 7U)
+		return 1;
+
+	return 0;
+}
+
+int main(void)
+{
+	int failed = 0;
+
+	failed |= test_native_conversion();
+	failed |= test_44100_conversion();
+	failed |= test_8000_conversion();
+	failed |= test_invalid_frame_count_falls_back();
+	failed |= test_status_helpers();
+	failed |= test_transfer_cursor_helpers();
+
+	if (failed) {
+		puts("audio capture tests FAILED");
+		return 1;
+	}
+
+	puts("audio capture tests passed");
+	return 0;
+}

--- a/test/audio/audio_capture_test.c
+++ b/test/audio/audio_capture_test.c
@@ -110,6 +110,21 @@ static int test_status_helpers(void)
 	return 0;
 }
 
+static int test_publication_gate(void)
+{
+	if (!zz_audio_capture_can_publish(ZZ_AUDIO_CONFIG_RECORD, 1U))
+		return 1;
+	if (!zz_audio_capture_can_publish(ZZ_AUDIO_CONFIG_PLAY |
+	                                  ZZ_AUDIO_CONFIG_RECORD, 1U))
+		return 1;
+	if (zz_audio_capture_can_publish(ZZ_AUDIO_CONFIG_RECORD, 0U))
+		return 1;
+	if (zz_audio_capture_can_publish(ZZ_AUDIO_CONFIG_PLAY, 1U))
+		return 1;
+
+	return 0;
+}
+
 static int test_transfer_cursor_helpers(void)
 {
 	if (zz_audio_capture_completed_period(0U, PERIOD_BYTES) != 7U)
@@ -136,6 +151,7 @@ int main(void)
 	failed |= test_8000_conversion();
 	failed |= test_invalid_frame_count_falls_back();
 	failed |= test_status_helpers();
+	failed |= test_publication_gate();
 	failed |= test_transfer_cursor_helpers();
 
 	if (failed) {

--- a/test/audio/audio_capture_test.c
+++ b/test/audio/audio_capture_test.c
@@ -95,10 +95,14 @@ static int test_invalid_frame_count_falls_back(void)
 static int test_status_helpers(void)
 {
 	uint16_t status = zz_audio_rx_status_pack(6U, 0x1234U);
+	uint32_t read_group = zz_audio_config_read_pack(1U, status);
 
 	if (!(status & ZZ_AUDIO_RX_STATUS_CAPABLE) ||
 	    zz_audio_rx_status_period(status) != 6U ||
 	    zz_audio_rx_status_sequence(status) != 0x234U)
+		return 1;
+	if ((uint16_t)(read_group >> 16) != 1U ||
+	    (uint16_t)read_group != status)
 		return 1;
 	if (zz_audio_rx_sequence_distance(2U, 0xffeU) != 4U)
 		return 1;


### PR DESCRIPTION
## Summary

- extend the existing AX audio control register with an independent recording-enable bit
- publish capture capability, completed period, and sequence through the previously unused `0xF6` register
- enable the existing I2S/S2MM receive interrupt and make completed DMA periods coherent for Amiga access
- convert native 48 kHz S16LE input to the requested 20 ms AHI period as S16BE, including integer downsampling
- recover delayed receive interrupts from the hardware transfer cursor while excluding the active DMA write period
- add host tests for conversion, byte order, status packing, sequence wrap, and cursor math

## Compatibility

This uses the receive formatter, DMA ring, and interrupt already present in the FPGA design. No Verilog, Vivado project, or bitstream changes are included or required.

Existing drivers continue to write only playback bit 0. New drivers can detect old firmware because the previously unused receive-status register reads as zero.

Companion driver: BlitterStudio/zz9000-drivers#48.

## Validation

- `make -C test/audio test`
- RTG, video, video-codec, scheduler, config, and other host regression suites
- full `ZZ9000OS.elf` and legacy-bitstream fallback build with Arm GNU Toolchain 13.2.rel1
- `./build_bootimage.sh` using the committed bitstream

Physical RCA capture validation is still required before this draft is marked ready.

Supports BlitterStudio/zz9000-drivers#47.
