### PR TITLE
fix(rtg): honor line mode in fast path

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/dma_rtg.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/dma_rtg.c
@@ -23,7 +23,8 @@ void handle_blitter_dma_op(struct ZZ_VIDEO_STATE* vs, uint16_t zdata)
             set_fb((uint32_t*) ((u32)vs->framebuffer + data->offset[0]),
                     data->pitch[0]);
 
-            if (data->user[1] == 0xFFFF && data->mask == 0xFF)
+            if (line_uses_solid_path(data->user[1], data->mask,
+                    data->u8_user[GFXDATA_U8_DRAWMODE]))
                 draw_line_solid(data->x[0], data->y[0], data->x[1], data->y[1],
                         data->user[0], (int16_t)data->user[3], data->rgb[0],
                         data->u8_user[GFXDATA_U8_COLORMODE]);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
@@ -62,6 +62,12 @@ void pattern_fill_rect(uint32_t color_format, uint16_t rect_x1, uint16_t rect_y1
 	uint16_t x_offset, uint16_t y_offset,
 	uint8_t *tmpl_data, uint16_t tmpl_pitch, uint16_t loop_rows);
 
+static inline int line_uses_solid_path(uint16_t pattern, uint8_t mask,
+	uint8_t draw_mode)
+{
+	return pattern == 0xFFFF && mask == 0xFF && draw_mode == 0; /* JAM1 */
+}
+
 void draw_line(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint16_t len, int16_t err_seed, uint16_t pattern, uint16_t pattern_offset, uint32_t fg_color, uint32_t bg_color, uint32_t color_format, uint8_t mask, uint8_t draw_mode);
 void draw_line_solid(int16_t rect_x1, int16_t rect_y1, int16_t rect_x2, int16_t rect_y2, uint16_t len, int16_t err_seed, uint32_t fg_color, uint32_t color_format);
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -1016,7 +1016,7 @@ int main() {
 					// rect_x3 contains the pattern. if all bits are set for both the mask and the pattern,
 					// there's no point in passing non-essential data to the pattern/mask aware function.
 
-					if (rect_x3 == 0xFFFF && zdata == 0xFF)
+					if (line_uses_solid_path(rect_x3, zdata, draw_mode))
 						draw_line_solid(rect_x1, rect_y1, rect_x2, rect_y2,
 								blitter_user1, blitter_user3, rect_rgb,
 								blitter_colormode);

--- a/test/rtg/rtg_regression.c
+++ b/test/rtg/rtg_regression.c
@@ -747,6 +747,21 @@ static void test_lines(void)
 	check_frame("draw_line_solid steep 2:1 major-Y up");
 }
 
+static void test_line_dispatch(void)
+{
+	if (!line_uses_solid_path(0xFFFF, 0xFF, JAM1) ||
+	    line_uses_solid_path(0xFFFF, 0xFF, JAM2) ||
+	    line_uses_solid_path(0xFFFF, 0xFF, COMPLEMENT) ||
+	    line_uses_solid_path(0xFFFF, 0xFF, INVERSVID) ||
+	    line_uses_solid_path(0xAAAA, 0xFF, JAM1) ||
+	    line_uses_solid_path(0xFFFF, 0x7F, JAM1)) {
+		printf("FAIL line solid-path dispatch\n");
+		failures++;
+	} else {
+		printf("ok   line solid-path dispatch\n");
+	}
+}
+
 static void test_lines_clipped(void)
 {
 	/* Full odd-major line must match the independent round-half-up oracle. An
@@ -1737,6 +1752,7 @@ static void run_tests(void)
 	test_fill_and_invert();
 	test_copy();
 	test_lines();
+	test_line_dispatch();
 	test_lines_clipped();
 	test_lines_negative_origin();
 	test_lines_pattern();


### PR DESCRIPTION
## Summary

- select the solid-line renderer only for full-pattern, full-mask JAM1 commands
- route JAM2, COMPLEMENT, and INVERSVID commands through the draw-mode-aware renderer
- share the selection predicate across Z2 and Z3 dispatch and cover it with a host regression

## Impact

The solid shortcut ignores pattern background and XOR semantics, so pattern and mask alone are insufficient to select it. This change fixes the dispatch contract without changing the line wire protocol.

The companion driver PR uses Picasso96 DrawLineDefault for COMPLEMENT because the Line callback lacks FRST_DOT. That driver fix does not require a firmware reflash; this PR is independent firmware hardening for non-JAM1 commands.

## Testing

- make -C test/rtg test

## Companion PR

- BlitterStudio/zz9000-drivers#53

Refs BlitterStudio/zz9000-drivers#51