### PR TITLE
fix(rtg): correct P96 planar minterms

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.c
@@ -927,7 +927,10 @@ void p2c_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy, int16_t w, int16_t
 		else {
 			for (; x < rect_x2; x++) {
 				u8_fg = 0;
-				if (draw_mode & 0x01) // If bit 1 is set, the inverted planar data is always used.
+				/* Odd minterms use the inverted planar source in the
+				 * legacy handlers, except NEOR: its handler performs
+				 * the source inversion itself. */
+				if ((draw_mode & 0x01) && draw_mode != MINTERM_NEOR)
 					DECODE_INVERTED_PLANAR_PIXEL(u8_fg)
 				else
 					DECODE_PLANAR_PIXEL(u8_fg)
@@ -1289,22 +1292,24 @@ void overlay_composite_planar420_frame(uint8_t *dst, uint32_t dst_pitch,
 #define RL_CACHE_MASK (RL_CACHE_SIZE - 1)
 static uint32_t rl_cache_keys[RL_CACHE_SIZE];
 static uint8_t rl_cache_vals[RL_CACHE_SIZE];
+static uint8_t rl_cache_valid[RL_CACHE_SIZE];
 
 static inline void rl_cache_invalidate(void) {
-	memset(rl_cache_keys, 0xFF, sizeof(rl_cache_keys));
+	memset(rl_cache_valid, 0, sizeof(rl_cache_valid));
 }
 
 static inline uint8_t reverse_lookup(uint32_t *bmp_pal, uint8_t planes, uint32_t fg_color) {
 	uint8_t slot = (fg_color ^ (fg_color >> 8)) & RL_CACHE_MASK;
-	if (rl_cache_keys[slot] == fg_color)
+	if (rl_cache_valid[slot] && rl_cache_keys[slot] == fg_color)
 		return rl_cache_vals[slot];
 
-	uint8_t num_colors = (1 << planes);
-	for (uint8_t i = 0; i < num_colors; i++) {
+	uint16_t num_colors = planes >= 8 ? 256 : (uint16_t)(1u << planes);
+	for (uint16_t i = 0; i < num_colors; i++) {
 		if (bmp_pal[i] == fg_color) {
 			rl_cache_keys[slot] = fg_color;
-			rl_cache_vals[slot] = i;
-			return i;
+			rl_cache_vals[slot] = (uint8_t)i;
+			rl_cache_valid[slot] = 1;
+			return (uint8_t)i;
 		}
 	}
 	return 0;
@@ -1320,6 +1325,29 @@ void p2d_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy, int16_t w, int16_t
 		return;
 
 	uint32_t *dp = fb + (dy * fb_pitch);
+
+	/* Picasso96 defines direct-color INVERT on the native destination
+	 * value, and DST as leaving it untouched. Neither operation needs
+	 * planar decoding or an inverse color-map lookup. */
+	if (draw_mode == MINTERM_DST)
+		return;
+	if (draw_mode == MINTERM_INVERT) {
+		for (int16_t line_y = 0; line_y < h_draw; line_y++) {
+			switch (color_format) {
+				case MNTVA_COLOR_16BIT565:
+				case MNTVA_COLOR_15BIT:
+					for (int16_t x = dx; x < dx + w; x++)
+						((uint16_t *)dp)[x] ^= (uint16_t)color_mask;
+					break;
+				case MNTVA_COLOR_32BIT:
+					for (int16_t x = dx; x < dx + w; x++)
+						dp[x] ^= color_mask;
+					break;
+			}
+			dp += fb_pitch;
+		}
+		return;
+	}
 
 	uint8_t cur_bit, base_bit, base_byte;
 	uint16_t cur_byte = 0;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/gfx.h
@@ -463,7 +463,7 @@ enum gfx_minterm_modes {
 			s &= d; \
 			SET_FG_PIXEL8_MASK(0); break; \
 		case MINTERM_NEOR: \
-			d ^= ~(s & mask); break; \
+			d ^= (~s & mask); break; \
 		case MINTERM_DST: /* This one does nothing. */ \
 			return; break; \
 		case MINTERM_NOTONLYSRC: \
@@ -547,9 +547,9 @@ enum gfx_minterm_modes {
 			switch (color_format) { \
 				case MNTVA_COLOR_16BIT565: \
 				case MNTVA_COLOR_15BIT: \
-					((uint16_t *)d)[x] ^= ~(s & color_mask); break; \
+					((uint16_t *)d)[x] ^= (~s & color_mask); break; \
 				case MNTVA_COLOR_32BIT: \
-					((uint32_t *)d)[x] ^= ~(s & color_mask); break; \
+					((uint32_t *)d)[x] ^= (~s & color_mask); break; \
 			} break; \
 		case MINTERM_DST: /* This one does nothing. */ \
 			return; break; \

--- a/test/rtg/rtg_regression.c
+++ b/test/rtg/rtg_regression.c
@@ -494,13 +494,29 @@ static void ref_p2c_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy,
 	}
 }
 
+static void ref_p2c_neor_rect(int16_t sx, int16_t sy, int16_t dx, int16_t dy,
+	int16_t w, int16_t h, uint8_t planes, uint8_t mask,
+	uint8_t layer_mask, uint16_t src_line_pitch, const uint8_t *bmp_data)
+{
+	for (int16_t yy = 0; yy < h; yy++) {
+		uint8_t *drow = row8(expected_fb, FB_PITCH_WORDS, dy + yy);
+		for (int16_t xx = 0; xx < w; xx++) {
+			uint8_t src = ref_planar_pixel(bmp_data, planes, layer_mask,
+				src_line_pitch, h, sx, sy, xx, yy, 0);
+			uint8_t dst = drow[dx + xx];
+			uint8_t result = (uint8_t)~(src ^ dst);
+			drow[dx + xx] = (uint8_t)((dst & (uint8_t)~mask) | (result & mask));
+		}
+	}
+}
+
 static uint8_t ref_reverse_lookup(const uint32_t *pal, uint8_t planes, uint32_t color)
 {
-	uint8_t colors = (uint8_t)(1u << planes);
+	uint16_t colors = planes >= 8 ? 256 : (uint16_t)(1u << planes);
 
-	for (uint8_t i = 0; i < colors; i++) {
+	for (uint16_t i = 0; i < colors; i++) {
 		if (pal[i] == color)
-			return i;
+			return (uint8_t)i;
 	}
 
 	return 0;
@@ -919,6 +935,22 @@ static void test_planar(void)
 	ref_p2c_rect(5, 0, 12, 9, P2C_W, P2C_H, MINTERM_NOTSRC,
 		P2C_PLANES, 0x1f, P2C_PITCH, planar);
 	check_frame("p2c_rect notsrc");
+
+	make_planar(planar, P2C_PLANES, P2C_PITCH, P2C_H, 0x4005);
+	seed_frame(0x4006);
+	p2c_rect(1, 0, 8, 6, P2C_W, P2C_H, MINTERM_NEOR,
+		P2C_PLANES, 0xff, 0x1f, P2C_PITCH, planar);
+	ref_p2c_neor_rect(1, 0, 8, 6, P2C_W, P2C_H,
+		P2C_PLANES, 0xff, 0x1f, P2C_PITCH, planar);
+	check_frame("p2c_rect neor");
+
+	make_planar(planar, P2C_PLANES, P2C_PITCH, P2C_H, 0x4007);
+	seed_frame(0x4008);
+	p2c_rect(7, 0, 13, 4, P2C_W, P2C_H, MINTERM_NEOR,
+		P2C_PLANES, 0x5a, 0x1f, P2C_PITCH, planar);
+	ref_p2c_neor_rect(7, 0, 13, 4, P2C_W, P2C_H,
+		P2C_PLANES, 0x5a, 0x1f, P2C_PITCH, planar);
+	check_frame("p2c_rect neor masked");
 }
 
 static void test_p2d(void)
@@ -927,7 +959,7 @@ static void test_p2d(void)
 		P2D_W = 37,
 		P2D_H = 12,
 		P2D_PITCH = 8,
-		P2D_PLANES = 3,
+		P2D_PLANES = 8,
 		P2D_COLORS = 1 << P2D_PLANES,
 		P2D_BYTES = 256 * 4 + P2D_PLANES * P2D_PITCH * P2D_H,
 	};
@@ -948,19 +980,19 @@ static void test_p2d(void)
 		}
 	}
 	p2d_rect(2, 0, 11, 6, P2D_W, P2D_H, MINTERM_EOR,
-		P2D_PLANES, 0xff, 0x07, 0x00ffffff, P2D_PITCH, data, MNTVA_COLOR_32BIT);
+		P2D_PLANES, 0xff, 0xff, 0x00ffffff, P2D_PITCH, data, MNTVA_COLOR_32BIT);
 	ref_p2d_rect(2, 0, 11, 6, P2D_W, P2D_H, MINTERM_EOR,
-		P2D_PLANES, 0x07, P2D_PITCH, data, MNTVA_COLOR_32BIT);
-	check_frame("p2d_rect eor 32");
+		P2D_PLANES, 0xff, P2D_PITCH, data, MNTVA_COLOR_32BIT);
+	check_frame("p2d_rect eor 32 depth8");
 
 	for (int i = 0; i < 256; i++)
 		pal[i] = (uint32_t)(0x1000 + i);
 	make_planar(planes, P2D_PLANES, P2D_PITCH, P2D_H, 0x5003);
 	seed_frame(0x5004);
 	p2d_rect(1, 0, 9, 8, P2D_W, P2D_H, MINTERM_SRC,
-		P2D_PLANES, 0xff, 0x07, 0xffff, P2D_PITCH, data, MNTVA_COLOR_16BIT565);
+		P2D_PLANES, 0xff, 0xff, 0xffff, P2D_PITCH, data, MNTVA_COLOR_16BIT565);
 	ref_p2d_rect(1, 0, 9, 8, P2D_W, P2D_H, MINTERM_SRC,
-		P2D_PLANES, 0x07, P2D_PITCH, data, MNTVA_COLOR_16BIT565);
+		P2D_PLANES, 0xff, P2D_PITCH, data, MNTVA_COLOR_16BIT565);
 	check_frame("p2d_rect src 16");
 
 	for (int i = 0; i < 256; i++)
@@ -968,10 +1000,19 @@ static void test_p2d(void)
 	make_planar(planes, P2D_PLANES, P2D_PITCH, P2D_H, 0x5005);
 	seed_frame(0x5006);
 	p2d_rect(4, 0, 7, 5, P2D_W, P2D_H, MINTERM_NOTSRC,
-		P2D_PLANES, 0xff, 0x07, 0x00ffffff, P2D_PITCH, data, MNTVA_COLOR_32BIT);
+		P2D_PLANES, 0xff, 0xff, 0x00ffffff, P2D_PITCH, data, MNTVA_COLOR_32BIT);
 	ref_p2d_rect(4, 0, 7, 5, P2D_W, P2D_H, MINTERM_NOTSRC,
-		P2D_PLANES, 0x07, P2D_PITCH, data, MNTVA_COLOR_32BIT);
+		P2D_PLANES, 0xff, P2D_PITCH, data, MNTVA_COLOR_32BIT);
 	check_frame("p2d_rect notsrc 32");
+
+	seed_frame(0x5007);
+	p2d_rect(0, 0, 6, 4, P2D_W, P2D_H, MINTERM_INVERT,
+		P2D_PLANES, 0xff, 0xff, 0x00ffffff, P2D_PITCH, data, MNTVA_COLOR_32BIT);
+	for (int y = 4; y < 4 + P2D_H; y++) {
+		for (int x = 6; x < 6 + P2D_W; x++)
+			row32(expected_fb, FB_PITCH_WORDS, y)[x] ^= 0x00ffffff;
+	}
+	check_frame("p2d_rect invert native");
 }
 
 static void test_template(void)


### PR DESCRIPTION
## Summary

P96CTS `BltBitMap-minterms` now produces correct results on ZZ9000 hardware at both 8-bit and direct-color depths. The chunky path no longer turns NEOR into EOR, while direct-color INVERT operates on the native destination color and depth-8 color-map lookups cover all 256 entries. Cache validity also no longer relies on a sentinel value that can be a real pixel color.

## Validation

- RTG regression suite passes, including new full-mask and masked NEOR, depth-8 P2D lookup, and native direct-color inversion coverage.
- RTG regression suite passes under AddressSanitizer and UndefinedBehaviorSanitizer.
- Docker ARM firmware build and link complete successfully.
- Real-hardware P96CTS validation is still pending.

Fixes BlitterStudio/zz9000-drivers#57.
