### PR TITLE
fix: restore media playback under firmware 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,11 @@ uses `280/40`; filtered profiles and Denise-adapter/Super Denise bitstreams use
 the historical `188/26`. An explicit numeric key is always a literal Custom
 override, including `188`, `26`, `0`, and `4095`.
 
-Firmware 2.10 and the matching protocol-1 bitstream also expose acknowledged
-live framing control for ZZTop 2.8. The FPGA publishes the exact applied raw
+Firmware 2.8 with the live-control capability and the matching protocol-1
+bitstream also expose acknowledged live framing control for ZZTop 2.8. The
+firmware capability bitmap is returned at register `0xE6`; older 2.8 firmware
+returns zero, keeping mixed RC1/current installations safely disabled. The
+FPGA publishes the exact applied raw
 Automatic/Custom state, resolved effective H/V values, capture-path signature,
 and detected PAL/NTSC standard. A valid live change crosses clock domains as
 one coherent word and becomes active only at a capture-frame boundary; the

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -77,19 +77,15 @@ void Xil_AssertNonVoid() {}
  * 2.7: CARD_FEATURE_DPMS + formatter sync gating — ZZ9000.card gates
  * the P96 SetDPMSLevel hook on this revision.
  * 2.8: v2.8 release identity — MPEG-1 media sessions, hardware overlay
- * scaling, per-stage pipeline profiling (MEDIA_STATUS page 5), and the
- * primary-CLUT query. ZZ9000.card gates nothing new on this revision:
- * its existing minimums (0x0204, 0x0206, 0x0207) all still pass, and the
- * overlay scaling is programmed card-side without driver involvement.
- * New SDK capability is discovered through service flags and status
- * pages, which self-gate, rather than through this number.
- * 2.9: atomic videocap_profile configuration and reliable display
- * transmitter retraining during output-mode changes.
- * 2.10: host-visible firmware half of the matched live-videocap contract.
+ * scaling, per-stage pipeline profiling (MEDIA_STATUS page 5), the
+ * primary-CLUT query, atomic videocap_profile configuration, reliable
+ * display-transmitter retraining during output-mode changes, and the
+ * host-visible firmware half of the matched live-videocap contract.
  * Startup operation 16 enters the shared acknowledged RTL control engine;
- * live calibration still requires the bitstream's exact capability. */
+ * live calibration also requires the bitstream's exact capability. Other
+ * SDK additions use service flags and status pages that self-gate. */
 #define REVISION_MAJOR 2
-#define REVISION_MINOR 10
+#define REVISION_MINOR 8
 
 #ifndef ZZ9000_SKIP_INITIAL_MEDIA_INIT
 #define ZZ9000_SKIP_INITIAL_MEDIA_INIT 0
@@ -1598,6 +1594,7 @@ int main() {
 					}
 					case REG_ZZ_VOLTAGE_INT: {
 						data = ((int16_t)(xadc_get_int_voltage()*100.0)) << 16;
+						data |= ZZ_FW_CAPABILITIES;
 						break;
 					}
 					case REG_ZZ_CONFIG_KEY: {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/mp3/mp3_backend_config.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/mp3/mp3_backend_config.h
@@ -8,11 +8,10 @@
 
 #define ZZ9K_MP3_BACKEND_MINIMP3 1
 
-/*
- * The SDK audio service only promises MP3 decode. Keep the firmware build small
- * and avoid pulling in stdio-based helpers; streaming uses explicit callbacks.
- */
-#define MINIMP3_ONLY_MP3 1
+/* The audio stream service backs both the MHI MP3 path and mpega.library.
+ * mpega.library clients such as RiVA pass MPEG Layer II elementary audio, so
+ * keep minimp3's Layer I/II decoder enabled as part of the compatibility
+ * contract.  Streaming still uses explicit callbacks and needs no stdio. */
 #define MINIMP3_NO_STDIO 1
 
 #endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
@@ -150,7 +150,9 @@ enum zz_reg_offsets {
   REG_ZZ_TEMPERATURE    = 0xE0,
   REG_ZZ_VOLTAGE_AUX    = 0xE2,
   REG_ZZ_VOLTAGE_INT    = 0xE4,
-  REG_ZZ_UNUSED_REGE6   = 0xE6,
+  /* The lower half of the voltage-int read group is a firmware-owned
+   * capability bitmap. Old firmware returned zero here. */
+  REG_ZZ_FW_CAPABILITIES = 0xE6,
   /* ZZ9000.CFG query: write a zz_config_key id, then read back the
    * 32-bit group at 0xE8 — value in the upper half (0xE8 on Z2),
    * present flag in the lower half (0xEA on Z2). */
@@ -185,6 +187,11 @@ enum zz_reg_offsets {
   REG_ZZ_SDK_DIAG_DATA  = 0x114,
   REG_ZZ_SDK_DIAG_ZADDR = 0x118,
 };
+
+#define ZZ_FW_CAP_VIDEOCAP_PROFILE (1U << 0)
+#define ZZ_FW_CAP_VIDEOCAP_LIVE    (1U << 1)
+#define ZZ_FW_CAPABILITIES \
+  (ZZ_FW_CAP_VIDEOCAP_PROFILE | ZZ_FW_CAP_VIDEOCAP_LIVE)
 
 enum zz9k_card_features {
   CARD_FEATURE_NONE,

--- a/test/audio/Makefile
+++ b/test/audio/Makefile
@@ -8,8 +8,9 @@ PROFILE_TARGET := $(BUILD_DIR)/audio_profile_test
 PLAYBACK_TARGET := $(BUILD_DIR)/audio_playback_frontier_test
 DRAIN_TARGET := $(BUILD_DIR)/audio_stream_drain_test
 MP3_PROBE_TARGET := $(BUILD_DIR)/mp3_frame_probe_test
+MPEG_LAYER2_TARGET := $(BUILD_DIR)/mpeg_layer2_decode_test
 TARGETS := $(CAPTURE_TARGET) $(PROFILE_TARGET) $(PLAYBACK_TARGET) \
-	$(DRAIN_TARGET) $(MP3_PROBE_TARGET)
+	$(DRAIN_TARGET) $(MP3_PROBE_TARGET) $(MPEG_LAYER2_TARGET)
 
 CPPFLAGS += -I$(SRC_DIR)
 
@@ -21,6 +22,7 @@ test: $(TARGETS)
 	$(PLAYBACK_TARGET)
 	$(DRAIN_TARGET)
 	$(MP3_PROBE_TARGET)
+	$(MPEG_LAYER2_TARGET)
 
 $(CAPTURE_TARGET): audio_capture_test.c $(SRC_DIR)/audio_capture.c \
 	$(SRC_DIR)/audio_capture.h
@@ -51,6 +53,11 @@ $(MP3_PROBE_TARGET): mp3_frame_probe_test.c \
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ mp3_frame_probe_test.c \
 		$(SRC_DIR)/mp3/decode_mp3.c
+
+$(MPEG_LAYER2_TARGET): mpeg_layer2_decode_test.c \
+	$(SRC_DIR)/mp3/mp3_backend_config.h $(SRC_DIR)/mp3/minimp3.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ mpeg_layer2_decode_test.c
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/test/audio/mpeg_layer2_decode_test.c
+++ b/test/audio/mpeg_layer2_decode_test.c
@@ -1,0 +1,41 @@
+/*
+ * MPEG Layer II coverage for the streaming decoder used by mpega.library.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "mp3/mp3_backend_config.h"
+
+#define MINIMP3_IMPLEMENTATION 1
+#include "mp3/minimp3.h"
+
+#define MPEG1_L2_128K_44100_FRAME_BYTES 417
+
+int main(void)
+{
+	mp3dec_t decoder;
+	mp3dec_frame_info_t info;
+	mp3d_sample_t pcm[MINIMP3_MAX_SAMPLES_PER_FRAME];
+	uint8_t frame[MPEG1_L2_128K_44100_FRAME_BYTES];
+	int samples;
+
+	memset(frame, 0, sizeof(frame));
+	/* MPEG-1 Layer II, 128 kbit/s, 44.1 kHz, stereo. */
+	frame[0] = 0xffU;
+	frame[1] = 0xfdU;
+	frame[2] = 0x80U;
+	frame[3] = 0x00U;
+	mp3dec_init(&decoder);
+	memset(&info, 0, sizeof(info));
+	samples = mp3dec_decode_frame(
+		&decoder, frame, sizeof(frame), pcm, &info);
+	if (samples != 1152)
+		return 1;
+	if (info.frame_bytes != MPEG1_L2_128K_44100_FRAME_BYTES ||
+	    info.layer != 2 || info.hz != 44100 || info.channels != 2)
+		return 2;
+	return 0;
+}

--- a/test/video/videocap_control_test.c
+++ b/test/video/videocap_control_test.c
@@ -105,6 +105,7 @@ static int main_source_contract(void)
 	unsigned int revision_minor = 0;
 	unsigned int revision_major_defines = 0;
 	unsigned int revision_minor_defines = 0;
+	unsigned int firmware_capability_reads = 0;
 	unsigned int videocap_pack_writes = 0;
 	unsigned int videocap_ops = 0;
 
@@ -118,6 +119,8 @@ static int main_source_contract(void)
 			revision_major_defines++;
 		if (sscanf(line, "#define REVISION_MINOR %u", &revision_minor) == 1)
 			revision_minor_defines++;
+		if (strstr(line, "data |= ZZ_FW_CAPABILITIES;") != NULL)
+			firmware_capability_reads++;
 		if (strstr(line, "video_formatter_write(videocap_control_pack(") != NULL)
 			videocap_pack_writes++;
 		if (strstr(line, "MNTVF_OP_VIDEOCAP);") != NULL)
@@ -126,10 +129,15 @@ static int main_source_contract(void)
 	fclose(source);
 
 	if (revision_major_defines != 1U || revision_minor_defines != 1U ||
-	    ((revision_major << 8) | revision_minor) != 0x020aU) {
+	    ((revision_major << 8) | revision_minor) != 0x0208U) {
 		printf("firmware revision contract mismatch: defines=%u/%u revision=0x%04x\n",
 		       revision_major_defines, revision_minor_defines,
 		       (revision_major << 8) | revision_minor);
+		return 0;
+	}
+	if (firmware_capability_reads != 1U) {
+		printf("firmware capability contract mismatch: reads=%u\n",
+		       firmware_capability_reads);
 		return 0;
 	}
 	if (videocap_pack_writes != 1U || videocap_ops != 1U) {

--- a/util/test_sdk_mp3_backend.c
+++ b/util/test_sdk_mp3_backend.c
@@ -16,8 +16,8 @@ int main(void) {
 	printf("missing ZZ9K_MP3_BACKEND_MINIMP3\n");
 	return 1;
 #endif
-#ifndef MINIMP3_ONLY_MP3
-	printf("missing MINIMP3_ONLY_MP3\n");
+#ifdef MINIMP3_ONLY_MP3
+	printf("unexpected MINIMP3_ONLY_MP3\n");
 	return 2;
 #endif
 #ifndef MINIMP3_NO_STDIO


### PR DESCRIPTION
## Summary

Settlers II intro playback through `mpega.library` now completes with audio in both RiVA and ZZPlay. The firmware decoder keeps MPEG Layer I/II support enabled for clients that send Layer II elementary audio.

The release also continues to identify as firmware 2.8. New video-profile and live-control support is advertised through explicit capability bits, so older 2.8 RC1 and mixed installations fail closed without requiring a 2.10 version bump.

## Validation

- The affected A4000 user confirmed playback with RiVA and ZZPlay without crashes, MuForce hits, or missing audio.
- Audio regression tests cover MPEG Layer II decoding.
- Firmware video and configuration tests pass.
- The standard and legacy firmware ELFs build successfully.
- GitHub Actions builds and packages the release variants successfully.
