### PR TITLE
fix: restore ADAU prefactor control scale

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_dsp_gain.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_dsp_gain.h
@@ -1,0 +1,25 @@
+/*
+ * Pure gain-control mappings shared by the firmware and host tests.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef AUDIO_DSP_GAIN_H
+#define AUDIO_DSP_GAIN_H
+
+#include <math.h>
+
+static inline double audio_adau_prefactor_gain(int pre)
+{
+	double decibels;
+
+	if (pre > 100)
+		pre = 100;
+	if (pre < 0)
+		pre = 0;
+
+	decibels = ((double)pre - 50.0) * 12.0 / 50.0;
+	return pow(10.0, decibels / 20.0);
+}
+
+#endif /* AUDIO_DSP_GAIN_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/ax.c
@@ -16,6 +16,7 @@
 #include "stdlib.h"
 #include "ax.h"
 #include "audio_capture.h"
+#include "audio_dsp_gain.h"
 #include "memorymap.h"
 #include "xtime_l.h"
 #include "math.h"
@@ -1181,12 +1182,7 @@ int audio_adau_set_mixer_vol(int vol1, int vol2) {
 }
 
 int audio_adau_set_prefactor(int pre) {
-	double p;
-
-	if(pre > 100) pre = 100;
-	if(pre <   0) pre =   0;
-
-	p = .01f * (double)pre;
+	double p = audio_adau_prefactor_gain(pre);
 
 	uint8_t buf[4];
 	adau_to_5_23(p, buf);

--- a/test/audio/Makefile
+++ b/test/audio/Makefile
@@ -31,11 +31,12 @@ $(CAPTURE_TARGET): audio_capture_test.c $(SRC_DIR)/audio_capture.c \
 		$(SRC_DIR)/audio_capture.c
 
 $(PROFILE_TARGET): audio_profile_test.c $(SRC_DIR)/adau.h \
+	$(SRC_DIR)/audio_dsp_gain.h \
 	$(SRC_DIR)/ax.h $(SRC_DIR)/sdk_crypto.c $(SRC_DIR)/sdk_crypto.h
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -ffunction-sections \
 		-Wl,--gc-sections -o $@ audio_profile_test.c \
-		$(SRC_DIR)/sdk_crypto.c
+		$(SRC_DIR)/sdk_crypto.c -lm
 
 $(PLAYBACK_TARGET): audio_playback_frontier_test.c \
 	$(SRC_DIR)/audio_playback_frontier.h

--- a/test/audio/audio_profile_test.c
+++ b/test/audio/audio_profile_test.c
@@ -1,4 +1,5 @@
 #include <ctype.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -6,6 +7,7 @@
 
 #include "adau.h"
 #include "adau_PARAM.h"
+#include "audio_dsp_gain.h"
 #include "ax.h"
 #include "sdk_crypto.h"
 
@@ -114,6 +116,25 @@ static void test_parameter_map(void)
 	CHECK(MOD_STMIXER1_ALG0_STAGE1_VOLUME_ADDR == 60U);
 }
 
+static int gain_matches(double actual, double expected)
+{
+	return fabs(actual - expected) < 1.0e-12;
+}
+
+static void test_prefactor_gain_contract(void)
+{
+	const double minus_12_db = 0.2511886431509580;
+	const double plus_12_db = 3.9810717055349722;
+
+	CHECK(audio_adau_prefactor_gain(50) == 1.0);
+	CHECK(gain_matches(audio_adau_prefactor_gain(0), minus_12_db));
+	CHECK(gain_matches(audio_adau_prefactor_gain(100), plus_12_db));
+	CHECK(gain_matches(audio_adau_prefactor_gain(-1), minus_12_db));
+	CHECK(gain_matches(audio_adau_prefactor_gain(101), plus_12_db));
+	CHECK(MOD_PREFACTOR_ALG0_GAIN1940ALGNS3_FIXPT == 0x00800000U);
+	CHECK(MOD_PREFACTOR_ALG1_GAIN1940ALGNS4_FIXPT == 0x00800000U);
+}
+
 static void test_readback_comparison(void)
 {
 	static const uint8_t expected[] = { 0x00, 0x12, 0x34, 0x56 };
@@ -133,6 +154,7 @@ int main(void)
 	test_normal_image_identity();
 	test_production_transport_contract();
 	test_parameter_map();
+	test_prefactor_gain_contract();
 	test_readback_comparison();
 	puts("audio production profile tests passed");
 	return 0;


### PR DESCRIPTION
Writing prefactor 50 now restores unity gain instead of cutting FPGA playback by about 6 dB. The 0-100 control range now follows its documented -12 dB to +12 dB contract, with endpoint clamping preserved.

Regression coverage locks the endpoints, unity point, and generated DSP defaults. The audio host suite passes, and the Docker firmware build completes; hardware validation is still required to confirm the MMIO dispatch path and both ADAU parameter writes.

Fixes #68.
