### PR TITLE
docs(zorro2): document aperture service boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,31 @@ transactions hit L2 regardless of the ARM's MMU attributes.
   pixel columns in the 8/15/16 bpp modes even though 32 bpp still looks fine. The xsim
   sweep catches this; run it.
 
+### Zorro II aperture contract (read before touching shared memory)
+
+- Current Zorro II firmware, bitstreams, drivers, and SDK negotiate a
+  generation-1 aperture-relative layout. The FPGA publishes the exact 2 MB or
+  4 MB aperture, the RTG driver validates it against AutoConfig and reserves
+  every region, and only then writes the ACK token. Firmware must keep the
+  framebuffer limit, host heap, relocated `GFXData`, and PIP capability gated
+  until that ACK. Invalid or unacknowledged generation-1 descriptors fail
+  closed. Descriptor-absent legacy 4 MiB cards intentionally retain the
+  historical fixed 64 KiB `HOST_WINDOW` compatibility path, but have no
+  negotiated layout or PIP; legacy 2 MiB and unknown aperture sizes reject it.
+- Do not restore fixed `board + size - ...` service addresses for
+  generation-1 layouts or expose their historical shared heap through Zorro II.
+  CPU-visible SDK clients use the negotiated host window; card-only rings stay
+  outside the aperture. The 64 KiB template scratch is deliberately time-shared
+  with Z2 `GFXData`, relying on the synchronous Zorro register command/ACK path.
+- The shipped 2 MB profile has no PIP pool. The shipped 4 MB profile has one
+  224 KiB fixed PIP pool and does not enable arbitrary P96 offscreen
+  allocations. An 8 MB software profile exists, but there is no verified 8 MB
+  AutoConfig define/build target or release bitstream; do not advertise it as
+  a hardware variant.
+- For the production-client matrix, shared-window limits, fallbacks, and
+  hardware-qualification status, also read
+  `zz9000-sdk/docs/zz9k-zorro2-services.md` in the matching SDK checkout.
+
 ## Board / Bitstream Variants
 
 7 hardware/autoconfig variants controlled by Verilog `` `define `` blocks in `mntzorro.v`:

--- a/README.md
+++ b/README.md
@@ -58,8 +58,28 @@ into a reproducible firmware, FPGA, and SDK-service platform.
 - SDK v2 mailbox services on the ARM cores: image decode/scale, audio/MP3,
   archive/LHA decompression, crypto/TLS primitives backing the Amiga-side
   `amissl` acceleration, and a dual-core scheduler for long-running jobs.
+- A fail-closed Zorro II aperture contract shared with the current driver and
+  SDK. Matched 2 MB and 4 MB bitstreams publish their exact framebuffer,
+  staging, host-window, audio, and optional PIP regions; firmware exposes the
+  host-window services only after the RTG driver has reserved and acknowledged
+  that layout. This brings compact image/DataType, archive, AmiSSL, and audio
+  clients to Zorro II, plus one bounded MPEG-1 PIP source on 4 MB cards. An
+  invalid or unacknowledged generation-1 descriptor fails closed. For
+  descriptor-absent legacy cards, only the 4 MB compatibility case retains the
+  historical fixed 64 KiB host window, without a negotiated layout or PIP;
+  legacy 2 MB and unknown sizes reject it.
 - Audio playback through the on-board ADAU codec, including firmware-side
   MP3 and ADPCM decoding.
+
+On Zorro II, use firmware, SDK payloads, and drivers from the same release.
+Both shipped 2 MB and 4 MB profiles provide a shared 64 KiB CPU-visible host
+window; only the 4 MB profile provides a 224 KiB PIP pool. The 2 MB profile
+therefore supports compact ARM services but not ZZPlay video. Arbitrary P96
+offscreen allocation and Zorro III Fast RAM are not enabled on Zorro II. The
+software contract contains an 8 MB profile for future use, but no 8 MB
+AutoConfig bitstream variant is currently shipped. See the SDK's
+[Zorro II service matrix](https://github.com/BlitterStudio/zz9000-sdk/blob/master/docs/zz9k-zorro2-services.md)
+for client-specific limits and fallback behavior.
 
 **System**
 


### PR DESCRIPTION
## Summary

Documents the service boundaries of the merged Zorro II aperture contract for firmware users and future maintainers. The README and agent guidance now cover the shipped 2 MiB and 4 MiB profiles, ACK-gated regions, the legacy 4 MiB compatibility exception, the absence of arbitrary offscreen allocation, and the deferred 8 MiB hardware variant.

The public guidance points to the SDK's authoritative client matrix so firmware claims stay aligned with the packaged tools and fallbacks.

## Validation

- `git diff --check`
- Cross-repo stale-claim search for obsolete Z3-only image/AmiSSL guidance

## Post-Deploy Monitoring & Validation

No operational monitoring is required for this documentation-only change. After the SDK documentation PR lands, confirm the linked service matrix resolves from its `master` branch.

## Related

- Related: BlitterStudio/zz9000-sdk#23
- Related: BlitterStudio/zz9000-firmware#71
- Related: BlitterStudio/zz9000-sdk#22
- Related: BlitterStudio/zz9000-drivers#65
