### PR TITLE
fix(audio): preserve trim and staged rollback state

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_scene.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_scene.c
@@ -509,17 +509,24 @@ static void emit_gain_reduction(double requested, double applied)
 }
 
 /* Re-stage only the mixer (trim submit/release): the applied master
- * chain stays as the last apply resolved it. */
+ * chain stays as the last apply resolved it. Transactional (review
+ * 3855833169): the DSP write decides first -- last_mixer_stage (the
+ * authoritative reported mixer state) and the gain-reduction
+ * telemetry move only after the write succeeded, so a failed
+ * restage leaves software exactly at the pre-failure state, exactly
+ * like a failed commit machine leaves its last-applied record. */
 static int restage_mixer(struct mixer_stage *stage)
 {
 	struct volume_resolution vol;
 
 	resolve_output_volume(&scenes[active_scene_index], &vol);
 	compute_mixer_stage(vol.chain_linear * vol.linear, stage);
+	if (audio_adau_set_mixer_vol(stage->paula, stage->ax) != 0)
+		return -1;
 	if (stage->bounded)
 		emit_gain_reduction(stage->requested, stage->applied);
 	last_mixer_stage = *stage;
-	return audio_adau_set_mixer_vol(stage->paula, stage->ax);
+	return 0;
 }
 /* The running machine, snapshotting the volume_resolution and
  * mixer_stage types defined above. In differential mode it carries a
@@ -1989,6 +1996,8 @@ int audio_scene_trim_submit(uint8_t owner, int16_t paula, int16_t ax,
 	struct audio_scene_trim_result *result)
 {
 	struct mixer_stage stage;
+	struct trim_state prev_trim;
+	uint8_t prev_participating;
 
 	if (result != NULL)
 		memset(result, 0, sizeof(*result));
@@ -1996,11 +2005,21 @@ int audio_scene_trim_submit(uint8_t owner, int16_t paula, int16_t ax,
 			AUDIO_SCENE_OWNER_SLOTS || !module_initialized)
 		return -1;
 
+	/* Install the requested trim, then let the DSP write decide: a
+	 * failed restage rolls the owner back to its previous trim and
+	 * participation (review 3855833169), so software keeps
+	 * describing the legs the DSP still holds and a retry
+	 * re-issues the write instead of silently diverging. */
+	prev_trim = trims[owner];
+	prev_participating = owner_participating[owner];
 	trims[owner].paula = paula;
 	trims[owner].ax = ax;
 	owner_participating[owner] = 1;
-	if (restage_mixer(&stage) != 0)
+	if (restage_mixer(&stage) != 0) {
+		trims[owner] = prev_trim;
+		owner_participating[owner] = prev_participating;
 		return -1;
+	}
 	/* A machine mid-flight would overwrite these legs with its
 	 * start-time snapshot at its mixer step; coalesce a re-apply so
 	 * the trim lands for good. The submit's own write above still
@@ -2020,29 +2039,43 @@ int audio_scene_trim_submit(uint8_t owner, int16_t paula, int16_t ax,
 	return 0;
 }
 
-void audio_scene_trim_release(uint8_t owner)
+int audio_scene_trim_release(uint8_t owner)
 {
 	struct mixer_stage stage;
+	struct trim_state prev_trim;
 
 	if (owner < AUDIO_SCENE_OWNER_AHI ||
 			owner >= AUDIO_SCENE_OWNER_SLOTS ||
 			!module_initialized)
-		return;
+		return -1;
 	/* Idempotent (review 3854408614): an owner with no participating
 	 * trim is already released -- no composition, no mixer restage,
 	 * no coalesced re-apply. A neutral submit from an owner that
 	 * never trimmed therefore stays write-free. */
 	if (!owner_participating[owner])
-		return;
+		return 0;
+	/* Transactional (review 3855833169): drop the trim, then let
+	 * the DSP write decide. On failure the owner still holds its
+	 * trim in software exactly as the DSP still holds it in
+	 * hardware -- the reported mixer state stays at the legs that
+	 * were last written, no re-apply is queued, and a retry
+	 * re-enters the full release path and re-issues the neutral
+	 * write. */
+	prev_trim = trims[owner];
 	trims[owner].paula = 0;
 	trims[owner].ax = 0;
 	owner_participating[owner] = 0;
-	restage_mixer(&stage);
+	if (restage_mixer(&stage) != 0) {
+		trims[owner] = prev_trim;
+		owner_participating[owner] = 1;
+		return -1;
+	}
 	if (commit_in_progress) {
 		pending_valid = 1;
 		pending_target = active_scene_index;
 		pending_dirty = 1;
 	}
+	return 0;
 }
 
 int audio_scene_authority_active(void)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_scene.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_scene.c
@@ -221,26 +221,100 @@ struct fast_step {
  * staged edits optimistically because the machine reads the live
  * tables; if the applying machine ultimately fails, these pre-commit
  * copies are restored so the staging survives and a retry re-issues
- * the whole sequence. Cleared when the machine that began after the
- * consumption completes successfully.
+ * the whole sequence. Each record is per-slot: a window may consume
+ * drafts from several slots (and drafts seed from the live tables,
+ * so a later draft composes the earlier edits).
  */
 struct staged_rollback {
 	int valid;
-	uint8_t scene_index;       /* slot whose scene/staging was consumed */
-	int scene_saved;
-	struct audio_scene_def scene;
-	struct scene_staging staging;
+	uint8_t scene_saved[AUDIO_SCENE_COUNT]; /* slots consumed here */
+	struct audio_scene_def scene[AUDIO_SCENE_COUNT];
+	struct scene_staging staging[AUDIO_SCENE_COUNT];
 	int baseline_saved;
 	uint8_t baseline_paula;
 	uint8_t baseline_ax;
-	int baseline_staged;
 	int calibration_saved;
 	uint16_t ceiling_paula;
 	uint16_t ceiling_ax;
-	int calibration_staged;
 };
 
-static struct staged_rollback rollback;
+/*
+ * Two explicit ownership slots (review 3854408627): RB_RUNNING
+ * belongs to the machine currently between commit_begin() and its
+ * terminal state; RB_QUEUED accumulates every staged commit coalesced
+ * behind it and is adopted by the follow-up machine the running one
+ * jumps into on success. A record therefore survives until its OWN
+ * machine settles, so a coalesced commit can never overwrite the
+ * running machine's snapshot nor be cleared by its success.
+ */
+#define RB_RUNNING 0
+#define RB_QUEUED  1
+static struct staged_rollback rollbacks[2];
+
+/* Fold a newer capture into an older record: a failure restores the
+ * live tables to the OLDEST capture (the state before the window
+ * opened), while the NEWEST staging carries every edit consumed in
+ * the window (drafts compose because each seeds from the live
+ * tables) -- neither the earlier nor the latest edit is lost. */
+static void rollback_merge(struct staged_rollback *old,
+	const struct staged_rollback *newer)
+{
+	int i;
+
+	for (i = 0; i < AUDIO_SCENE_COUNT; i++) {
+		if (!newer->scene_saved[i])
+			continue;
+		if (!old->scene_saved[i]) {
+			old->scene_saved[i] = 1;
+			old->scene[i] = newer->scene[i];
+		}
+		old->staging[i] = newer->staging[i];
+	}
+	/* Baseline/calibration: the oldest saved pair wins -- a class
+	 * the older record has not captured is taken from the newer
+	 * one, so a window that introduces a staged baseline (or
+	 * calibration) behind an earlier scene-only capture keeps its
+	 * rollback/staging record. The staged values live in the
+	 * module statics and are re-exposed by the restored staged
+	 * flags on rollback_restore. */
+	if (!old->baseline_saved && newer->baseline_saved) {
+		old->baseline_saved = 1;
+		old->baseline_paula = newer->baseline_paula;
+		old->baseline_ax = newer->baseline_ax;
+	}
+	if (!old->calibration_saved && newer->calibration_saved) {
+		old->calibration_saved = 1;
+		old->ceiling_paula = newer->ceiling_paula;
+		old->ceiling_ax = newer->ceiling_ax;
+	}
+}
+
+
+/* Restore a record's pre-commit state: the live tables go back and
+ * the saved staging returns as the pending draft, so a retry
+ * re-issues the whole window. Consumes the record. */
+static void rollback_restore(struct staged_rollback *rb)
+{
+	int i;
+
+	for (i = 0; i < AUDIO_SCENE_COUNT; i++) {
+		if (!rb->scene_saved[i])
+			continue;
+		scenes[i] = rb->scene[i];
+		staging[i] = rb->staging[i];
+	}
+	if (rb->baseline_saved) {
+		baseline_paula = rb->baseline_paula;
+		baseline_ax = rb->baseline_ax;
+		baseline_staged = 1; /* staged pair returns for the retry */
+	}
+	if (rb->calibration_saved) {
+		ceiling_paula = rb->ceiling_paula;
+		ceiling_ax = rb->ceiling_ax;
+		calibration_staged = 1;
+	}
+	rb->valid = 0;
+}
 
 /* Synchronously drain the machine to its terminal state (bounded by
  * the fixed per-machine step count; nothing can enqueue new work
@@ -458,7 +532,6 @@ struct commit_machine {
 	struct volume_resolution vol;  /* resolved at machine start */
 	struct mixer_stage stage;      /* composed at machine start */
 	int failed;
-	int owns_rollback; /* this machine applies a staged commit's tables */
 	int fast;          /* differential mode: todo list, no fade */
 	struct fast_step todo[224]; /* worst: full diff + 99-step ramp */
 	int todo_count;
@@ -614,7 +687,6 @@ static void commit_begin(uint8_t index, int fast)
 	if (commit.stage.bounded)
 		emit_gain_reduction(commit.stage.requested,
 			commit.stage.applied);
-	commit.owns_rollback = rollback.valid;
 	pending_valid = 0;
 	pending_target = 0;
 	pending_dirty = 0;
@@ -636,27 +708,22 @@ static void commit_finish(void)
 		/* A mid-sequence failure leaves the chain faded down and
 		 * half-written; the abort step has best-effort restored the
 		 * resolved output volume so the DAC is not left silent (a
-		 * full retry goes through the commit surface). A staged
-		 * commit that was optimistically taken from the tables goes
-		 * back: the staging survives for the retry. */
-		if (rollback.valid) {
-			if (rollback.scene_saved) {
-				scenes[rollback.scene_index] = rollback.scene;
-				staging[rollback.scene_index] = rollback.staging;
-			}
-			if (rollback.baseline_saved) {
-				baseline_paula = rollback.baseline_paula;
-				baseline_ax = rollback.baseline_ax;
-				baseline_staged = rollback.baseline_staged;
-			}
-			if (rollback.calibration_saved) {
-				ceiling_paula = rollback.ceiling_paula;
-				ceiling_ax = rollback.ceiling_ax;
-				calibration_staged =
-					rollback.calibration_staged;
-			}
-			rollback.valid = 0;
+		 * full retry goes through the commit surface). The staged
+		 * commits optimistically taken from the tables go back:
+		 * the queued window folds into the running record, so one
+		 * restore returns the live tables to the running machine's
+		 * pre-commit state while the composed draft (every edit
+		 * consumed this window) returns as staging for the retry. */
+		if (rollbacks[RB_QUEUED].valid) {
+			if (rollbacks[RB_RUNNING].valid)
+				rollback_merge(&rollbacks[RB_RUNNING],
+					&rollbacks[RB_QUEUED]);
+			else
+				rollbacks[RB_RUNNING] = rollbacks[RB_QUEUED];
+			rollbacks[RB_QUEUED].valid = 0;
 		}
+		if (rollbacks[RB_RUNNING].valid)
+			rollback_restore(&rollbacks[RB_RUNNING]);
 		/* A failed machine drops any coalesced follow-up: the
 		 * failure is the terminal outcome and the retry re-enters
 		 * through the commit surface. */
@@ -667,10 +734,11 @@ static void commit_finish(void)
 	/* Success: the DSP now holds this machine's snapshot. Record it
 	 * as the state the next differential commit diffs against -- a
 	 * failed machine records nothing, so its retry rewrites the full
-	 * diff against the state before the failure. */
+	 * diff against the state before the failure. The machine's own
+	 * rollback record settles with it; a queued record belongs to
+	 * the follow-up machine alone. */
 	fast_record_applied(&commit.scene, &commit.vol, &commit.stage);
-	if (rollback.valid && commit.owns_rollback)
-		rollback.valid = 0; /* the staged edits are now applied */
+	rollbacks[RB_RUNNING].valid = 0; /* its staged edits are applied */
 	if (pending_valid &&
 		(pending_target != commit.scene_index || pending_dirty)) {
 		uint8_t target = pending_target;
@@ -679,6 +747,10 @@ static void commit_finish(void)
 		pending_valid = 0;
 		pending_dirty = 0;
 		pending_fast = 0;
+		/* The coalesced follow-up adopts the queued window's
+		 * rollback record as its own before it starts. */
+		rollbacks[RB_RUNNING] = rollbacks[RB_QUEUED];
+		rollbacks[RB_QUEUED].valid = 0;
 		commit_begin(target, fast);
 	}
 }
@@ -1289,7 +1361,7 @@ void audio_scene_init(void)
 	pending_target = 0;
 	pending_dirty = 0;
 	pending_fast = 0;
-	memset(&rollback, 0, sizeof(rollback));
+	memset(rollbacks, 0, sizeof(rollbacks));
 	memset(&last_mixer_stage, 0, sizeof(last_mixer_stage));
 	/* audio_adau_init leaves the DSP holding the power-on state the
 	 * module defaults describe (scene 0 at the default baseline
@@ -1325,7 +1397,8 @@ int audio_scene_apply_after_dsp_init(void)
 	pending_valid = 0;
 	pending_dirty = 0;
 	pending_fast = 0;
-	rollback.valid = 0;
+	rollbacks[RB_RUNNING].valid = 0;
+	rollbacks[RB_QUEUED].valid = 0;
 	/* An in-flight CFG save describes an SD transaction the reset
 	 * hook abandons (zz_config_save_reset drops its junk temp); drop
 	 * the machine the same way so a post-reset save is not refused
@@ -1626,6 +1699,7 @@ int audio_scene_stage_param(uint8_t index, uint32_t param,
 
 int audio_scene_commit_staged(uint8_t index)
 {
+	struct staged_rollback capture;
 	int apply = 0;
 
 	if (!module_initialized || index >= AUDIO_SCENE_COUNT)
@@ -1633,29 +1707,26 @@ int audio_scene_commit_staged(uint8_t index)
 
 	/* The applying machine reads the live tables, so the staged
 	 * edits are taken optimistically first; if that machine
-	 * ultimately fails, the pre-commit state saved in rollback is
-	 * restored and the failed machine does NOT record its state as
-	 * applied, so a retry re-writes the diff instead of returning OK
-	 * with zero writes (the edit set would be lost). */
-	memset(&rollback, 0, sizeof(rollback));
-	rollback.scene_index = index;
+	 * ultimately fails, this pre-commit capture is restored and the
+	 * failed machine does NOT record its state as applied, so a
+	 * retry re-writes the diff instead of returning OK with zero
+	 * writes (the edit set would be lost). */
+	memset(&capture, 0, sizeof(capture));
 
 	/* A staged operator baseline joins the same commit (R17). */
 	if (baseline_staged) {
-		rollback.baseline_saved = 1;
-		rollback.baseline_paula = baseline_paula;
-		rollback.baseline_ax = baseline_ax;
-		rollback.baseline_staged = baseline_staged;
+		capture.baseline_saved = 1;
+		capture.baseline_paula = baseline_paula;
+		capture.baseline_ax = baseline_ax;
 		baseline_paula = staged_baseline_paula;
 		baseline_ax = staged_baseline_ax;
 		baseline_staged = 0;
 		apply = 1;
 	}
 	if (calibration_staged) {
-		rollback.calibration_saved = 1;
-		rollback.ceiling_paula = ceiling_paula;
-		rollback.ceiling_ax = ceiling_ax;
-		rollback.calibration_staged = calibration_staged;
+		capture.calibration_saved = 1;
+		capture.ceiling_paula = ceiling_paula;
+		capture.ceiling_ax = ceiling_ax;
 		ceiling_paula = staged_ceiling_paula;
 		ceiling_ax = staged_ceiling_ax;
 		calibration_staged = 0;
@@ -1663,9 +1734,9 @@ int audio_scene_commit_staged(uint8_t index)
 	}
 	if (staging[index].has_draft) {
 		/* Stage-time validation keeps every draft a valid scene. */
-		rollback.scene_saved = 1;
-		rollback.scene = scenes[index];
-		rollback.staging = staging[index];
+		capture.scene_saved[index] = 1;
+		capture.scene[index] = scenes[index];
+		capture.staging[index] = staging[index];
 		scenes[index] = staging[index].draft;
 		staging[index].has_draft = 0;
 		if (index == active_scene_index)
@@ -1673,10 +1744,18 @@ int audio_scene_commit_staged(uint8_t index)
 	}
 	if (!apply)
 		return 0; /* inactive slot, nothing can fail: consumed */
-	rollback.valid = 1;
+	capture.valid = 1;
 	if (commit_in_progress) {
 		/* A machine is mid-flight on its own snapshot; the staged
-		 * state is applied by the coalesced follow-up machine. */
+		 * state is applied by the coalesced follow-up machine,
+		 * which adopts this capture -- composed with any earlier
+		 * queued one -- as its own rollback record, so it can
+		 * survive neither overwritten by the running machine's
+		 * failure nor cleared by its success. */
+		if (rollbacks[RB_QUEUED].valid)
+			rollback_merge(&rollbacks[RB_QUEUED], &capture);
+		else
+			rollbacks[RB_QUEUED] = capture;
 		pending_valid = 1;
 		pending_target = active_scene_index;
 		pending_dirty = 1;
@@ -1685,6 +1764,7 @@ int audio_scene_commit_staged(uint8_t index)
 	}
 	/* A live edit commit runs differentially: only the parameters
 	 * the staging changed, no fade envelope. */
+	rollbacks[RB_RUNNING] = capture;
 	commit_begin(active_scene_index, 1);
 	return 0;
 }
@@ -1947,6 +2027,12 @@ void audio_scene_trim_release(uint8_t owner)
 	if (owner < AUDIO_SCENE_OWNER_AHI ||
 			owner >= AUDIO_SCENE_OWNER_SLOTS ||
 			!module_initialized)
+		return;
+	/* Idempotent (review 3854408614): an owner with no participating
+	 * trim is already released -- no composition, no mixer restage,
+	 * no coalesced re-apply. A neutral submit from an owner that
+	 * never trimmed therefore stays write-free. */
+	if (!owner_participating[owner])
 		return;
 	trims[owner].paula = 0;
 	trims[owner].ax = 0;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_scene.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_scene.h
@@ -152,11 +152,14 @@ double audio_scene_enforced_boundary(void);
  * under the enforced boundary; release resets that owner's trim to
  * neutral -- idempotently: an owner with no participating trim is
  * already released, so release performs no composition and no mixer
- * restage. submit returns 0 and fills *result (when non-NULL); owner
- * must be one of AUDIO_SCENE_OWNER_AHI/MHI/SDK. */
+ * restage. Both are transactional (review 3855833169): a failed
+ * mixer restage restores the previous trim, participation and
+ * reported mixer state, queues no re-apply, and a retry re-issues
+ * the DSP write. submit returns 0 and fills *result (when non-NULL);
+ * owner must be one of AUDIO_SCENE_OWNER_AHI/MHI/SDK. */
 int audio_scene_trim_submit(uint8_t owner, int16_t paula, int16_t ax,
 	struct audio_scene_trim_result *result);
-void audio_scene_trim_release(uint8_t owner);
+int audio_scene_trim_release(uint8_t owner);
 
 /* ---- staged scene edits and the single commit path (U4, KTD7) ---- */
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_scene.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_scene.h
@@ -150,7 +150,9 @@ double audio_scene_enforced_boundary(void);
 
 /* Source-trim lifecycle (R3, R4): submit composes with the baseline
  * under the enforced boundary; release resets that owner's trim to
- * neutral. submit returns 0 and fills *result (when non-NULL); owner
+ * neutral -- idempotently: an owner with no participating trim is
+ * already released, so release performs no composition and no mixer
+ * restage. submit returns 0 and fills *result (when non-NULL); owner
  * must be one of AUDIO_SCENE_OWNER_AHI/MHI/SDK. */
 int audio_scene_trim_submit(uint8_t owner, int16_t paula, int16_t ax,
 	struct audio_scene_trim_result *result);
@@ -184,10 +186,14 @@ int audio_scene_stage_param(uint8_t index, uint32_t param,
  * changes. A commit of an inactive scene stores the staged
  * definition without touching the DSP. Returns 0 once the staged
  * edits are taken into the live tables and the machine is started
- * (or, for a mid-flight machine, the re-apply is coalesced); the
- * staging is consumed only when the applying machine ultimately
+ * (or, for a mid-flight machine, the re-apply is coalesced);
+ * the staging is consumed only when the applying machine ultimately
  * succeeds -- a failing machine restores the pre-commit tables so a
- * retry re-issues the whole sequence.
+ * retry re-issues the whole sequence. A commit coalesced behind a
+ * running machine owns its rollback record until its own follow-up
+ * machine settles: the running machine's failure also folds the
+ * queued record in (its edits return as staging for the retry),
+ * while its success hands the record to the follow-up alone.
  */
 int audio_scene_commit_staged(uint8_t index);
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_audio_control.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_audio_control.c
@@ -96,11 +96,12 @@ static uint16_t ctrl_scene_write(const uint8_t *params,
 /* Owner source trim (R3). The ABI balance word is the requested
  * absolute mixer pair (two 0..255 volumes, 127 = 0 dB each,
  * AP_DSP_SET_VOLUMES packing) -- except the reserved neutral word
- * 0x7f7f, which means "no trim from this owner": the reply reports
- * the operator baseline pair as applied, unbounded, and the mixer is
- * not restaged (an absolute 127/127 request is therefore not
- * expressible). Any other word is converted to legs-relative deltas
- * against the baseline. The payload carries no owner identity -- the
+ * 0x7f7f, which means "no trim from this owner": it releases the SDK
+ * trim slot, then the reply reports the operator baseline pair as
+ * applied, unbounded (an absolute 127/127 request is therefore not
+ * expressible); with no trim held the release is a write-free no-op.
+ * Any other word is converted to legs-relative deltas against the
+ * baseline. The payload carries no owner identity -- the
  * single-owner model holds until I1 -- so every mailbox trim targets
  * the SDK slot and a driver releases by submitting the neutral
  * balance. */
@@ -125,10 +126,15 @@ static uint16_t ctrl_trim_submit(const uint8_t *params,
 
 	balance = sdk_get_be32(p->balance);
 	if (balance == SDK_AUDIO_BALANCE_NEUTRAL) {
-		/* Keep-baseline: no trim from this owner, so no
-		 * composition and no mixer restage -- the operator
-		 * baseline pair stands and is reported verbatim,
-		 * unbounded. */
+		/* Keep-baseline release: the reserved word is this
+		 * owner's documented release path, so a trim it
+		 * previously submitted is dropped before the operator
+		 * baseline is reported -- the reply then tells the
+		 * truth about the applied legs. Release is idempotent
+		 * at the scene layer: an owner that never trimmed (or
+		 * already released) stays write-free and the baseline
+		 * pair stands verbatim, unbounded. */
+		audio_scene_trim_release(AUDIO_SCENE_OWNER_SDK);
 		sdk_put_be32(out->balance_applied,
 			SDK_AUDIO_BALANCE_PACK(audio_scene_baseline_paula(),
 				audio_scene_baseline_ax()));

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_audio_control.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_audio_control.c
@@ -133,8 +133,13 @@ static uint16_t ctrl_trim_submit(const uint8_t *params,
 		 * truth about the applied legs. Release is idempotent
 		 * at the scene layer: an owner that never trimmed (or
 		 * already released) stays write-free and the baseline
-		 * pair stands verbatim, unbounded. */
-		audio_scene_trim_release(AUDIO_SCENE_OWNER_SDK);
+		 * pair stands verbatim, unbounded. A failed release
+		 * write (review 3855833169) reports IO error with no
+		 * result payload: the scene layer kept the held trim,
+		 * the DSP still applies it, and claiming the baseline
+		 * here would lie about both. */
+		if (audio_scene_trim_release(AUDIO_SCENE_OWNER_SDK) != 0)
+			return SDK_STATUS_IO_ERROR;
 		sdk_put_be32(out->balance_applied,
 			SDK_AUDIO_BALANCE_PACK(audio_scene_baseline_paula(),
 				audio_scene_baseline_ax()));

--- a/test/audio/audio_control_test.c
+++ b/test/audio/audio_control_test.c
@@ -640,6 +640,82 @@ static void test_trim_neutral_keep_baseline(void)
 			(unsigned long)flags));
 }
 
+
+/* ---- trim submit: the neutral word releases a held SDK trim ---- */
+
+/*
+ * Review 3854408614: after a non-neutral submission took the SDK
+ * trim slot, the reserved neutral word is the documented release
+ * path. It must drop that trim before reporting the operator
+ * baseline, so the applied state and the DSP both return to the
+ * baseline pair -- and, with the slot already released, a repeat
+ * neutral submit stays write-free (release is idempotent).
+ */
+static void test_trim_neutral_releases_held_trim(void)
+{
+	struct SDKAudioTrimSubmitPayload tr;
+	struct SDKAudioControlStateGetPayload get;
+	uint32_t flags, applied, bound;
+	uint16_t status;
+	int a = -1, b = -1;
+
+	audio_scene_init();
+	memset(&tr, 0, sizeof(tr));
+	memset(&get, 0, sizeof(get));
+
+	/* A non-neutral balance takes the SDK trim slot and moves the
+	 * applied mixer legs off the baseline. */
+	put32(tr.balance, SDK_AUDIO_BALANCE_PACK(108, 44));
+	check(run_op(SDK_OP_AUDIO_TRIM_SUBMIT, &tr, sizeof(tr)) ==
+		SDK_STATUS_OK, "non-neutral trim accepted", NULL);
+	applied = w32(&result_buf[0]);
+	check(applied == SDK_AUDIO_BALANCE_PACK(108, 44),
+		"held trim reports its applied pair",
+		fmt("applied=0x%lx", (unsigned long)applied));
+
+	/* The neutral word releases: the baseline pair is reported and
+	 * actually applied. */
+	clear_writes();
+	put32(tr.balance, SDK_AUDIO_BALANCE_NEUTRAL);
+	status = run_op(SDK_OP_AUDIO_TRIM_SUBMIT, &tr, sizeof(tr));
+	check(status == SDK_STATUS_OK, "neutral release accepted",
+		fmt("status=%u", status));
+	applied = w32(&result_buf[0]);
+	bound = w32(&result_buf[4]);
+	flags = w32(&result_buf[8]);
+	check(applied == SDK_AUDIO_BALANCE_PACK(128, 64) &&
+		flags == 0 && bound == 0,
+		"neutral release reports the baseline pair, unbounded",
+		fmt("applied=0x%lx bound=0x%lx flags=0x%lx",
+			(unsigned long)applied, (unsigned long)bound,
+			(unsigned long)flags));
+	check(last_write(WRITE_MIXER, &a, &b) && a == 128 && b == 64,
+		"neutral release restages the mixer to the baseline legs",
+		fmt("v1=%d v2=%d", a, b));
+
+	status = run_op(SDK_OP_AUDIO_CONTROL_STATE_GET, &get, sizeof(get));
+	check(status == SDK_STATUS_OK, "state get after release", NULL);
+	check(w32(&result_buf[12]) == SDK_AUDIO_BALANCE_PACK(128, 64) &&
+		w32(&result_buf[20]) == 0,
+		"control state reports the baseline applied, unbounded",
+		fmt("trim=0x%lx flags=0x%lx",
+			(unsigned long)w32(&result_buf[12]),
+			(unsigned long)w32(&result_buf[20])));
+
+	/* Idempotent: the slot is already released, so a second neutral
+	 * submit performs no mixer write and still reports baseline. */
+	clear_writes();
+	put32(tr.balance, SDK_AUDIO_BALANCE_NEUTRAL);
+	check(run_op(SDK_OP_AUDIO_TRIM_SUBMIT, &tr, sizeof(tr)) ==
+		SDK_STATUS_OK, "repeat neutral submit accepted", NULL);
+	check(w32(&result_buf[0]) == SDK_AUDIO_BALANCE_PACK(128, 64),
+		"repeat neutral still reports the baseline pair",
+		fmt("applied=0x%lx", (unsigned long)w32(&result_buf[0])));
+	check(write_count == 0,
+		"repeat neutral release is write-free",
+		fmt("writes=%d", write_count));
+}
+
 /* ---- meter read: framed snapshot through the dispatch ---- */
 
 #define TEST_FRAMES 8
@@ -1176,6 +1252,7 @@ int main(void)
 	test_nested_commit_coalesces();
 	test_trim_submit_result();
 	test_trim_neutral_keep_baseline();
+	test_trim_neutral_releases_held_trim();
 	test_meter_read();
 	test_scene_save();
 	test_baseline_write_persists_through_queued_save();

--- a/test/audio/audio_control_test.c
+++ b/test/audio/audio_control_test.c
@@ -101,7 +101,7 @@ int audio_adau_set_lpf_params(int f0)
 int audio_adau_set_mixer_vol(int vol1, int vol2)
 {
 	record_write(WRITE_MIXER, vol1, vol2);
-	return 0;
+	return fail_next_write ? -1 : 0;
 }
 
 int audio_adau_set_prefactor(int pre)
@@ -716,6 +716,105 @@ static void test_trim_neutral_releases_held_trim(void)
 		fmt("writes=%d", write_count));
 }
 
+/* ---- trim submit: a failed neutral release reports IO error ---- */
+
+/*
+ * Review 3855833169: the neutral word releases a held SDK trim
+ * through a DSP write, and that write can fail. The failure must
+ * surface as SDK_STATUS_IO_ERROR with no result payload claiming the
+ * baseline (the scene layer kept the held trim and the DSP still
+ * applies it), the control state must still report the held trim,
+ * and a retry re-issues the write and then reports the baseline.
+ */
+static void test_trim_neutral_release_write_failure(void)
+{
+	struct SDKAudioTrimSubmitPayload tr;
+	struct SDKAudioControlStateGetPayload get;
+	uint32_t flags, applied, bound, trim, baseline;
+	uint16_t status;
+	int a = -1, b = -1;
+
+	audio_scene_init();
+	memset(&tr, 0, sizeof(tr));
+	memset(&get, 0, sizeof(get));
+
+	/* Hold a non-neutral SDK trim. */
+	put32(tr.balance, SDK_AUDIO_BALANCE_PACK(108, 44));
+	check(run_op(SDK_OP_AUDIO_TRIM_SUBMIT, &tr, sizeof(tr)) ==
+		SDK_STATUS_OK, "non-neutral trim accepted", NULL);
+	check(w32(&result_buf[0]) == SDK_AUDIO_BALANCE_PACK(108, 44),
+		"held trim reports its applied pair",
+		fmt("applied=0x%lx",
+			(unsigned long)w32(&result_buf[0])));
+
+	/* Force the neutral-release mixer write to fail: an error
+	 * response, no claimed result payload, and the write was
+	 * still attempted. */
+	clear_writes();
+	fail_next_write = 1;
+	put32(tr.balance, SDK_AUDIO_BALANCE_NEUTRAL);
+	status = run_op(SDK_OP_AUDIO_TRIM_SUBMIT, &tr, sizeof(tr));
+	fail_next_write = 0;
+	check(status == SDK_STATUS_IO_ERROR,
+		"neutral release reports IO error on write failure",
+		fmt("status=%u", status));
+	check(result_len == 0,
+		"failed neutral release claims no result payload",
+		fmt("len=%u", result_len));
+	check(count_writes(WRITE_MIXER) == 1,
+		"the failed neutral release attempted its DSP write",
+		fmt("writes=%d", count_writes(WRITE_MIXER)));
+
+	/* The control state still reports the held trim against the
+	 * unchanged baseline: software and DSP agree, and the failure
+	 * is retryable. */
+	status = run_op(SDK_OP_AUDIO_CONTROL_STATE_GET, &get,
+		sizeof(get));
+	check(status == SDK_STATUS_OK,
+		"state get after failed release", NULL);
+	flags = w32(&result_buf[20]);
+	trim = w32(&result_buf[12]);
+	baseline = w32(&result_buf[8]);
+	check(trim == SDK_AUDIO_BALANCE_PACK(108, 44) && flags == 0,
+		"control state keeps the held trim, unbounded",
+		fmt("trim=0x%lx flags=0x%lx", (unsigned long)trim,
+			(unsigned long)flags));
+	check(baseline == SDK_AUDIO_BALANCE_PACK(128, 64),
+		"baseline unchanged by the failed release",
+		fmt("baseline=0x%lx", (unsigned long)baseline));
+
+	/* Retry: the write lands, the baseline pair is finally
+	 * reported as applied, and the control state follows. */
+	clear_writes();
+	put32(tr.balance, SDK_AUDIO_BALANCE_NEUTRAL);
+	status = run_op(SDK_OP_AUDIO_TRIM_SUBMIT, &tr, sizeof(tr));
+	check(status == SDK_STATUS_OK,
+		"neutral release retry succeeds",
+		fmt("status=%u", status));
+	applied = w32(&result_buf[0]);
+	bound = w32(&result_buf[4]);
+	flags = w32(&result_buf[8]);
+	check(result_len == sizeof(struct SDKAudioTrimResultPayload) &&
+		applied == SDK_AUDIO_BALANCE_PACK(128, 64) &&
+		flags == 0 && bound == 0,
+		"retry reports the baseline pair, unbounded",
+		fmt("applied=0x%lx bound=0x%lx flags=0x%lx",
+			(unsigned long)applied, (unsigned long)bound,
+			(unsigned long)flags));
+	check(last_write(WRITE_MIXER, &a, &b) && a == 128 && b == 64,
+		"retry re-issues the neutral mixer write",
+		fmt("v1=%d v2=%d", a, b));
+	status = run_op(SDK_OP_AUDIO_CONTROL_STATE_GET, &get,
+		sizeof(get));
+	check(status == SDK_STATUS_OK, "state get after retry", NULL);
+	check(w32(&result_buf[12]) == SDK_AUDIO_BALANCE_PACK(128, 64) &&
+		w32(&result_buf[20]) == 0,
+		"control state reports the baseline after the retry",
+		fmt("trim=0x%lx flags=0x%lx",
+			(unsigned long)w32(&result_buf[12]),
+			(unsigned long)w32(&result_buf[20])));
+}
+
 /* ---- meter read: framed snapshot through the dispatch ---- */
 
 #define TEST_FRAMES 8
@@ -1253,6 +1352,7 @@ int main(void)
 	test_trim_submit_result();
 	test_trim_neutral_keep_baseline();
 	test_trim_neutral_releases_held_trim();
+	test_trim_neutral_release_write_failure();
 	test_meter_read();
 	test_scene_save();
 	test_baseline_write_persists_through_queued_save();

--- a/test/audio/audio_scene_test.c
+++ b/test/audio/audio_scene_test.c
@@ -933,6 +933,192 @@ static void test_restore_failure_keeps_staging(void)
 }
 
 /*
+ * Review 3854408627, overwrite mode 1: a staged commit queued behind
+ * a running machine must not overwrite the running machine's
+ * rollback snapshot. The running machine's failure restores ITS OWN
+ * pre-commit tables while every queued edit -- the newest draft
+ * composes them all -- returns as staging for the retry.
+ */
+static void test_running_failure_keeps_queued_window(void)
+{
+	int i;
+
+	audio_scene_init();
+	clear_writes();
+
+	/* The running machine: a volume edit on the active scene. */
+	check(audio_scene_stage_param(0, SDK_AUDIO_SCENE_PARAM_VOLUME, 70)
+		== 0, "stage the running volume edit", NULL);
+	check(audio_scene_commit_staged(0) == 0,
+		"running staged commit dispatches", NULL);
+
+	/* Land mid-machine (one setter call per poll). */
+	for (i = 0; i < 10; i++)
+		(void)audio_scene_poll();
+
+	/* The queued window: two more staged commits coalesce behind
+	 * the running machine. */
+	check(audio_scene_stage_param(0, SDK_AUDIO_SCENE_PARAM_EQ_BAND_3,
+		40) == 0, "stage the first queued edit", NULL);
+	check(audio_scene_commit_staged(0) == 0,
+		"first queued commit coalesces", NULL);
+	check(audio_scene_stage_param(0, SDK_AUDIO_SCENE_PARAM_EQ_BAND_9,
+		60) == 0, "stage the second queued edit", NULL);
+	check(audio_scene_commit_staged(0) == 0,
+		"second queued commit coalesces", NULL);
+
+	/* The running machine now fails mid-sequence. */
+	fail_next_write = 1;
+	pump_scene();
+	check(audio_scene_get(0)->volume == 100,
+		"failed running machine restores its own pre-commit state",
+		fmt("volume=%u", audio_scene_get(0)->volume));
+	check(audio_scene_get(0)->eq[2] == 50 &&
+		audio_scene_get(0)->eq[8] == 50,
+		"queued edits are rolled out of the live tables",
+		fmt("eq3=%u eq9=%u", audio_scene_get(0)->eq[2],
+			audio_scene_get(0)->eq[8]));
+
+	/* The whole window survives as staging: the retry re-issues
+	 * every edit, the earlier and the latest alike. */
+	fail_next_write = 0;
+	clear_writes();
+	check(audio_scene_commit_staged(0) == 0,
+		"retry after the failed window accepted", NULL);
+	pump_scene();
+	check(write_count == 202,
+		"retry re-writes volume ramp (180) + two EQ diffs (2x11)",
+		fmt("writes=%d", write_count));
+	check(audio_scene_get(0)->volume == 70 &&
+		audio_scene_get(0)->eq[2] == 40 &&
+		audio_scene_get(0)->eq[8] == 60,
+		"retried window lands every edit",
+		fmt("volume=%u eq3=%u eq9=%u", audio_scene_get(0)->volume,
+			audio_scene_get(0)->eq[2],
+			audio_scene_get(0)->eq[8]));
+}
+
+/*
+ * Review 3854408627, overwrite mode 2: the running machine succeeds
+ * and must not clear the queued commit's rollback record when it
+ * jumps into the coalesced follow-up. The follow-up's failure
+ * restores its own pre-commit live state (the running machine's
+ * success stays applied) and its staging survives for the retry.
+ */
+static void test_queued_failure_restores_own_window(void)
+{
+	int i;
+
+	audio_scene_init();
+
+	check(audio_scene_stage_param(0, SDK_AUDIO_SCENE_PARAM_VOLUME, 70)
+		== 0, "stage the running volume edit", NULL);
+	check(audio_scene_commit_staged(0) == 0,
+		"running staged commit dispatches", NULL);
+	for (i = 0; i < 10; i++)
+		(void)audio_scene_poll();
+	clear_writes();
+
+	check(audio_scene_stage_param(0, SDK_AUDIO_SCENE_PARAM_EQ_BAND_3,
+		40) == 0, "stage the queued edit", NULL);
+	check(audio_scene_commit_staged(0) == 0,
+		"queued commit coalesces", NULL);
+
+	/* The running machine completes and hands the queued record to
+	 * the follow-up machine, whose EQ write for band index 2 (the
+	 * staged EQ_BAND_3 edit) then fails. */
+	fail_eq_band = 2;
+	pump_scene();
+	check(audio_scene_get(0)->volume == 70,
+		"running machine's success stays applied",
+		fmt("volume=%u", audio_scene_get(0)->volume));
+	check(audio_scene_get(0)->eq[2] == 50,
+		"failed follow-up restores its own pre-commit state",
+		fmt("eq3=%u", audio_scene_get(0)->eq[2]));
+
+	fail_eq_band = -1;
+	clear_writes();
+	check(audio_scene_commit_staged(0) == 0,
+		"retry after the failed follow-up accepted", NULL);
+	pump_scene();
+	check(write_count == 11,
+		"retry re-writes the EQ diff (11 substeps)",
+		fmt("writes=%d", write_count));
+	check(audio_scene_get(0)->eq[2] == 40,
+		"retried queued edit lands",
+		fmt("eq3=%u", audio_scene_get(0)->eq[2]));
+}
+
+/*
+ * Coalesced rollback classes: a queued window may introduce a staged
+ * baseline (or calibration) behind an earlier scene-only capture.
+ * Merging the captures must carry the baseline class along, so a
+ * failure of the running machine restores the live baseline and the
+ * staged baseline returns for the retry -- both merge sites: into
+ * the queued record, and the queued record folded into the running
+ * one.
+ */
+static void test_running_failure_keeps_queued_baseline(void)
+{
+	int i;
+
+	audio_scene_init();
+	clear_writes();
+
+	/* The running machine: a volume edit on the active scene. */
+	check(audio_scene_stage_param(0, SDK_AUDIO_SCENE_PARAM_VOLUME, 70)
+		== 0, "stage the running volume edit", NULL);
+	check(audio_scene_commit_staged(0) == 0,
+		"running staged commit dispatches", NULL);
+	for (i = 0; i < 10; i++)
+		(void)audio_scene_poll();
+
+	/* The queued window: a scene-only edit first, then a staged
+	 * baseline joining behind it. */
+	check(audio_scene_stage_param(0, SDK_AUDIO_SCENE_PARAM_EQ_BAND_9,
+		60) == 0, "stage the scene-only queued edit", NULL);
+	check(audio_scene_commit_staged(0) == 0,
+		"scene-only queued commit coalesces", NULL);
+	check(audio_scene_stage_param(0, SDK_AUDIO_SCENE_PARAM_BASELINE,
+		SDK_AUDIO_BALANCE_PACK(150, 40)) == 0,
+		"stage the queued baseline edit", NULL);
+	check(audio_scene_commit_staged(0) == 0,
+		"baseline queued commit coalesces", NULL);
+
+	/* The running machine fails mid-sequence. */
+	fail_next_write = 1;
+	pump_scene();
+	check(audio_scene_baseline_paula() == 128 &&
+		audio_scene_baseline_ax() == 64,
+		"failed running machine restores the live baseline",
+		fmt("paula=%u ax=%u", audio_scene_baseline_paula(),
+			audio_scene_baseline_ax()));
+	check(audio_scene_get(0)->volume == 100 &&
+		audio_scene_get(0)->eq[8] == 50,
+		"failed running machine restores the live scene tables",
+		fmt("volume=%u eq9=%u", audio_scene_get(0)->volume,
+			audio_scene_get(0)->eq[8]));
+
+	/* The staged baseline returns with the rest of the window: the
+	 * retry re-issues every edit. */
+	fail_next_write = 0;
+	clear_writes();
+	check(audio_scene_commit_staged(0) == 0,
+		"retry after the failed window accepted", NULL);
+	pump_scene();
+	check(audio_scene_get(0)->volume == 70 &&
+		audio_scene_get(0)->eq[8] == 60,
+		"retried window lands the scene edits",
+		fmt("volume=%u eq9=%u", audio_scene_get(0)->volume,
+			audio_scene_get(0)->eq[8]));
+	check(audio_scene_baseline_paula() == 150 &&
+		audio_scene_baseline_ax() == 40,
+		"retried window lands the staged baseline",
+		fmt("paula=%u ax=%u", audio_scene_baseline_paula(),
+			audio_scene_baseline_ax()));
+}
+
+/*
  * Differential commits: a staged live edit writes only the changed
  * parameters -- no fade, no full sequence, no restore -- in the
  * commit order (LPF, EQ bands ascending, prefactor, mixer, vol/pan),
@@ -1227,6 +1413,9 @@ int main(void)
 	test_apply_failure_restores_volume();
 	test_dispatch_does_not_block();
 	test_restore_failure_keeps_staging();
+	test_running_failure_keeps_queued_window();
+	test_queued_failure_restores_own_window();
+	test_running_failure_keeps_queued_baseline();
 
 	test_fast_commit_diff();
 	test_fast_commit_failure_keeps_diff();

--- a/test/audio/audio_scene_test.c
+++ b/test/audio/audio_scene_test.c
@@ -750,6 +750,142 @@ static void test_trim_lifecycle(void)
 }
 
 /*
+ * Review 3855833169: trim submit/release are transactional. A failed
+ * mixer restage cannot leave software describing legs the DSP never
+ * accepted -- the previous trim, participation and the authoritative
+ * reported mixer state survive, no telemetry is emitted, no re-apply
+ * is queued, and a retry re-issues the DSP write.
+ */
+static void test_trim_write_failure_is_transactional(void)
+{
+	struct audio_scene_trim_result result;
+	struct audio_scene_control_state state;
+	int a = -1, b = -1;
+
+	audio_scene_init();
+	audio_scene_select(0);
+	pump_scene();
+	clear_writes();
+
+	/* Held trim: both legs off the baseline, unbounded. */
+	memset(&result, 0, sizeof(result));
+	check(audio_scene_trim_submit(AUDIO_SCENE_OWNER_AHI, -20, -10,
+			&result) == 0 && !result.bounded &&
+		result.mixer_paula == 108 && result.mixer_ax == 54,
+		"held trim accepted",
+		fmt("bounded=%u v1=%u v2=%u", result.bounded,
+			result.mixer_paula, result.mixer_ax));
+
+	/* A failed re-submit over a held trim rolls back to the held
+	 * values: the next composition (another owner's submit) proves
+	 * the held trim is still in the sum, not the refused one. */
+	fail_next_write = 1;
+	check(audio_scene_trim_submit(AUDIO_SCENE_OWNER_AHI, -30, 0,
+			NULL) == -1,
+		"failed re-submit over a held trim reports failure", NULL);
+	fail_next_write = 0;
+	memset(&result, 0, sizeof(result));
+	check(audio_scene_trim_submit(AUDIO_SCENE_OWNER_MHI, -5, 0,
+			&result) == 0 && !result.bounded &&
+		result.mixer_paula == 103 && result.mixer_ax == 54,
+		"held trim survives a failed re-submit in composition",
+		fmt("v1=%u v2=%u", result.mixer_paula, result.mixer_ax));
+	audio_scene_trim_release(AUDIO_SCENE_OWNER_MHI);
+
+	/* Forced neutral-release write failure: the release is
+	 * refused, its DSP write was attempted exactly once, and the
+	 * reported state keeps describing the held trim. */
+	clear_writes();
+	fail_next_write = 1;
+	check(audio_scene_trim_release(AUDIO_SCENE_OWNER_AHI) == -1,
+		"failed neutral release reports failure", NULL);
+	fail_next_write = 0;
+	check(count_writes(WRITE_MIXER) == 1,
+		"failed release attempted exactly one mixer write",
+		fmt("writes=%d", count_writes(WRITE_MIXER)));
+	audio_scene_control_state(&state);
+	check(state.trim_paula == 108 && state.trim_ax == 54 &&
+		state.trim_bounded == 0,
+		"failed release keeps the reported held trim",
+		fmt("p=%u ax=%u bounded=%u", state.trim_paula,
+			state.trim_ax, state.trim_bounded));
+
+	/* Retry: participation survived, so the full release path
+	 * re-runs and the neutral write lands. */
+	clear_writes();
+	check(audio_scene_trim_release(AUDIO_SCENE_OWNER_AHI) == 0,
+		"release retry succeeds", NULL);
+	check(last_write(WRITE_MIXER, &a, &b) && a == 128 && b == 64,
+		"release retry re-issues the neutral mixer write",
+		fmt("v1=%d v2=%d", a, b));
+	audio_scene_control_state(&state);
+	check(state.trim_paula == 128 && state.trim_ax == 64 &&
+		state.trim_bounded == 0,
+		"retry reports the baseline legs",
+		fmt("p=%u ax=%u", state.trim_paula, state.trim_ax));
+
+	/* Direct submit failure: a fresh owner's trim is not
+	 * installed -- no applied legs are claimed and the reported
+	 * state stays at the last written pair. */
+	fail_next_write = 1;
+	memset(&result, 0, sizeof(result));
+	check(audio_scene_trim_submit(AUDIO_SCENE_OWNER_MHI, -20, 0,
+			&result) == -1,
+		"failed trim submit reports failure", NULL);
+	fail_next_write = 0;
+	check(result.bounded == 0 && result.mixer_paula == 0 &&
+		result.mixer_ax == 0,
+		"failed submit claims no applied legs",
+		fmt("bounded=%u v1=%u v2=%u", result.bounded,
+			result.mixer_paula, result.mixer_ax));
+	audio_scene_control_state(&state);
+	check(state.trim_paula == 128 && state.trim_ax == 64 &&
+		state.trim_bounded == 0,
+		"failed submit leaves the reported state unchanged",
+		fmt("p=%u ax=%u", state.trim_paula, state.trim_ax));
+
+	/* A bounded submit that fails writes nothing: no telemetry, no
+	 * bounded flag, previous (non-participating) state retained. */
+	fail_next_write = 1;
+	memset(&result, 0, sizeof(result));
+	check(audio_scene_trim_submit(AUDIO_SCENE_OWNER_MHI, 100, 0,
+			&result) == -1,
+		"failed bounded submit reports failure", NULL);
+	fail_next_write = 0;
+	check(audio_scene_gain_reduction_events() == 0,
+		"failed bounded submit emits no gain-reduction event",
+		fmt("events=%lu",
+			(unsigned long)audio_scene_gain_reduction_events()));
+	audio_scene_control_state(&state);
+	check(state.trim_paula == 128 && state.trim_ax == 64 &&
+		state.trim_bounded == 0,
+		"failed bounded submit keeps the reported state neutral",
+		fmt("p=%u ax=%u bounded=%u", state.trim_paula,
+			state.trim_ax, state.trim_bounded));
+
+	/* The failed submits installed no participation: releasing
+	 * that owner is a write-free no-op, and the retried submit
+	 * then lands. */
+	clear_writes();
+	check(audio_scene_trim_release(AUDIO_SCENE_OWNER_MHI) == 0,
+		"never-installed owner releases as a no-op", NULL);
+	check(write_count == 0,
+		"failed submit installed no participation",
+		fmt("writes=%d", write_count));
+	memset(&result, 0, sizeof(result));
+	check(audio_scene_trim_submit(AUDIO_SCENE_OWNER_MHI, -20, 0,
+			&result) == 0 && !result.bounded &&
+		result.mixer_paula == 108 && result.mixer_ax == 64,
+		"submit retry succeeds",
+		fmt("bounded=%u v1=%u v2=%u", result.bounded,
+			result.mixer_paula, result.mixer_ax));
+	audio_scene_trim_release(AUDIO_SCENE_OWNER_MHI);
+
+	check(audio_scene_gain_reduction_events() == 0,
+		"no telemetry across every failed write", NULL);
+}
+
+/*
  * Staged-edit commit failure: the staging is consumed only on
  * success, so a failed write sequence leaves the draft pending (and
  * the live tables untouched) and a retry re-writes the diff instead
@@ -1409,6 +1545,7 @@ int main(void)
 	test_baseline_trim_composition();
 	test_boot_apply_order();
 	test_trim_lifecycle();
+	test_trim_write_failure_is_transactional();
 	test_commit_failure_keeps_staging();
 	test_apply_failure_restores_volume();
 	test_dispatch_does_not_block();


### PR DESCRIPTION
## Summary

Neutral SDK trim submissions now release a previously held trim before reporting the operator baseline. Trim submit and release are transactional: a failed mixer write preserves prior ownership, trim values and authoritative control-state readback, returns an I/O error, and remains retryable.

Coalesced staged commits own separate running and queued rollback records, so a failure in either machine restores its own live state and preserves every queued edit for retry. This follows up findings from merged PR #84 without changing the public ABI or staged-commit coalescing contract.

## Design

- Trim release is idempotent when an owner is already absent.
- DSP write success is the commit point for mixer state and gain-reduction telemetry.
- Failed submit/release restores the prior trim transaction and queues no misleading reapply.
- Rollback storage is bounded and static. Running and queued machines cannot overwrite or clear each other's records.
- Repeated queued edits preserve the oldest live snapshot and newest composed staging across scene, baseline and calibration state.

## Validation

The complete `test/audio` suite passes with `-Werror`, including reproductions for:

- non-neutral SDK trim followed by neutral release;
- failed neutral release, unchanged state, and successful retry;
- failed trim submit without ownership or telemetry leakage;
- running-machine failure with queued scene and baseline edits;
- queued follow-up failure and retry;
- repeated coalesced scene edits.

## Related

- https://github.com/BlitterStudio/zz9000-firmware/pull/86#discussion_r3855833169
- https://github.com/BlitterStudio/zz9000-firmware/pull/84#discussion_r3854408614
- https://github.com/BlitterStudio/zz9000-firmware/pull/84#discussion_r3854408627
