### PR TITLE
fix: dead-lease revocation on unreadable lines; mono rebuild scratch

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_fabric.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_fabric.c
@@ -592,11 +592,15 @@ static uint32_t fabric_rebuild_pull(struct audio_fabric_slot *s,
 
 	pcm = g_fabric_src;
 	if (channels == 1U) {
+		/* Expand into the dedicated mono scratch, not g_fabric_stereo:
+		 * slot IS g_fabric_stereo and the resampler cannot run in
+		 * place (PR #88 review -- same aliasing the fill path
+		 * fixed). */
 		for (i = 0U; i < src_frames; i++) {
-			g_fabric_stereo[2U * i] = g_fabric_src[i];
-			g_fabric_stereo[2U * i + 1U] = g_fabric_src[i];
+			g_fabric_mono[2U * i] = g_fabric_src[i];
+			g_fabric_mono[2U * i + 1U] = g_fabric_src[i];
 		}
-		pcm = g_fabric_stereo;
+		pcm = g_fabric_mono;
 	}
 	if (rate == 48000U) {
 		memcpy(slot, pcm, AUDIO_FABRIC_PERIOD_BYTES);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_fabric_lease.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_fabric_lease.c
@@ -362,6 +362,7 @@ static void fabric_ring_heartbeat_age(struct audio_fabric_lease *l)
 		l->heartbeat_ms += FABRIC_RING_TICK_MS;
 }
 
+
 /*
  * Revocation (R13/KTD4): heartbeat expiry or a cursor fault
  * invalidates the generation. Consumption stops, the reason is
@@ -390,6 +391,20 @@ static void fabric_ring_revoke(uint32_t slot, uint32_t status)
 	fabric_ring_record(slot, s->epoch, identity, heartbeat_ms, 1U,
 		(uint8_t)status);
 	audio_fabric_producer_detach(slot);
+}
+
+/* Age and enforce the dead-client timeout on the malformed-line paths
+ * that `continue` past the normal expiry check: a producer that died
+ * mid-publication (seqlock stuck odd, or a ghost/foreign line after
+ * revoke) must still lose its lease after the two-second timeout, or
+ * the slot stays blocked until reset (PR #88 review). */
+static void fabric_ring_age_or_revoke(uint32_t slot,
+	struct audio_fabric_lease *l)
+{
+	fabric_ring_heartbeat_age(l);
+	if (l->heartbeat_ms >= FABRIC_RING_HEARTBEAT_TIMEOUT_NOW)
+		fabric_ring_revoke(slot,
+			SDK_AUDIO_RING_STATUS_REVOKED_HEARTBEAT);
 }
 
 /*
@@ -434,16 +449,16 @@ void fabric_lease_isr_tick(void)
 			if (!fabric_ring_read_producer(l, &view)) {
 				if (prev_valid)
 					l->line_valid = 1U;
-				fabric_ring_heartbeat_age(l);
+				fabric_ring_age_or_revoke(slot, l);
 				continue;
 			}
 			if (view.generation != l->generation) {
-				fabric_ring_heartbeat_age(l);
+				fabric_ring_age_or_revoke(slot, l);
 				continue;
 			}
 			if ((view.flags &
 			     ~SDK_AUDIO_RING_PRODUCER_FLAG_KNOWN) != 0U) {
-				fabric_ring_heartbeat_age(l);
+				fabric_ring_age_or_revoke(slot, l);
 				continue;
 			}
 		}

--- a/test/audio/audio_fabric_ring_test.c
+++ b/test/audio/audio_fabric_ring_test.c
@@ -622,6 +622,43 @@ static void scenario_heartbeat(void)
 		grant.generation);
 }
 
+/* ---- E2. dead producer: unreadable line still revokes (PR #88) ---- */
+
+static void scenario_dead_line(void)
+{
+	struct audio_fabric_ring_grant grant;
+	struct audio_fabric_slot_state st;
+	struct SDKAudioRingFirmwareLine fw;
+	uint32_t generation;
+	uint32_t tick;
+
+	fabric_reset_state();
+	g_dma_count = 0;
+	check(acquire_lease(AUDIO_FABRIC_SLOT_MAILBOX, 128U, &grant) ==
+	      AUDIO_FABRIC_LEASE_OK, "dead: acquire", "");
+	generation = grant.generation;
+	g_producer[AUDIO_FABRIC_SLOT_MAILBOX].generation = generation;
+	producer_fill(AUDIO_FABRIC_SLOT_MAILBOX, LEASE_PCM);
+	fabric_pass();
+	/* The producer dies mid-publication: the seqlock stays odd
+	 * forever. The grace path must still age the heartbeat and revoke
+	 * at the timeout -- a permanently unreadable line may not pin the
+	 * slot until reset. */
+	producer_publish_stuck_odd(AUDIO_FABRIC_SLOT_MAILBOX);
+	for (tick = 0U; tick < 4U; tick++)
+		fabric_pass();
+	firmware_snapshot(AUDIO_FABRIC_SLOT_MAILBOX, &fw);
+	check(be32(fw.status) ==
+		      SDK_AUDIO_RING_STATUS_REVOKED_HEARTBEAT,
+	      "dead: stuck-odd line still publishes REVOKED_HEARTBEAT", "");
+	st = lease_state(AUDIO_FABRIC_SLOT_MAILBOX);
+	check(st.state == AUDIO_FABRIC_SLOT_STATE_REVOKED,
+	      "dead: slot REVOKED on the unreadable line",
+	      fmt("state=%u", st.state));
+	(void)audio_fabric_ring_release(AUDIO_FABRIC_SLOT_MAILBOX,
+		generation);
+}
+
 /* ---- F. release and the queued-period rebuild ---- */
 
 static void run_rebuild_pass(uint8_t *pre_release, uint8_t *post_rebuild,
@@ -835,6 +872,7 @@ int main(void)
 	scenario_grace();
 	scenario_cursor_fault();
 	scenario_heartbeat();
+	scenario_dead_line();
 	scenario_rebuild();
 	scenario_warm_reset();
 	scenario_cache_fidelity();


### PR DESCRIPTION
Follow-up to #88, addressing its fourth review round:

- **P1:** a producer dying mid-publication (seqlock stuck odd / ghost line) hit malformed-line paths that age the heartbeat but skip the expiry check — the lease pinned its slot until reset despite the 2 s timeout. Those paths now age-or-revoke; new `scenario_dead_line` covers the stuck-odd case in the ring suite.
- **P2:** the queued-period rebuild expanded mono into `g_fabric_stereo` (also the conversion output), corrupting rebuilt windows for resampled mono sources; it now uses the dedicated `g_fabric_mono` scratch like the fill path.

Host `test/audio` suite green (11 targets).