### PR TITLE
fix(usb): harden host lifecycle and add ISO transport

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: USB proxy and EHCI regression suite
+        run: make -C test/usb test
       - name: RTG regression suite
         run: make -C test/rtg test
       - name: Video pipeline regression suite

--- a/BUILD.md
+++ b/BUILD.md
@@ -45,6 +45,24 @@ or from a POSIX shell:
 The Docker wrappers cache the official Arm GNU Toolchain and bootgen in Docker
 volumes named `zz9000-arm-toolchain` and `zz9000-bootgen`.
 
+**USB proxy change** — run the bounded host models before building the ARM
+artifact:
+
+```bash
+make -C test/usb test
+```
+
+Then verify the mirrored driver contract from a sibling
+`zz9000-drivers` checkout:
+
+```bash
+python3 ../zz9000-drivers/tools/check-usb-proxy-contract.py "$PWD"
+```
+
+ISO protocol changes must update firmware and driver constants together.
+Physical Poseidon qualification is separate from these host checks; record it
+in `zz9000-drivers/docs/usb-qualification-matrix.md`.
+
 **HDL change (bitstream rebuild)** — requires a Linux box with Vivado:
 ```bash
 ./build_bitstream.sh       # regenerates project from zz9000_project.tcl
@@ -175,9 +193,10 @@ LED should turn green after the firmware loads.
 
 The GitHub Actions workflow
 [`.github/workflows/build.yml`](.github/workflows/build.yml) runs on
-every push and pull request: installs the Arm GNU Toolchain (cached),
-builds bootgen from source (cached), then runs `./build_firmware.sh`
-+ `./build_bootimage.sh` against the committed bitstream. It does **not**
+every push and pull request: runs the host regression suites, including
+`test/usb`; installs the Arm GNU Toolchain (cached); builds bootgen from
+source (cached); then runs `./build_firmware.sh` +
+`./build_bootimage.sh` against the committed bitstream. It does **not**
 run Vivado — any HDL change must include an updated
 `bootimage_work/zz9000_ps_wrapper.bit` for CI to pick up the new logic.
 Release-style ZIP artifacts are uploaded per run.

--- a/README.md
+++ b/README.md
@@ -312,6 +312,28 @@ Keep these rules in mind:
 See the commented [ZZ9000.CFG sample](ZZ9000.CFG) for every accepted value and
 additional notes.
 
+## USB host stack
+
+Firmware 2.9 and `zzusbhw.device` 2.2 form one USB proxy release. The
+matched pair negotiates protocol v2 before advertising persistent interrupt,
+simple ISO, or realtime ISO support. A driver that does not receive the
+required capability set leaves those public capabilities disabled rather than
+using an incompatible mailbox path.
+
+Implemented transport paths are control, bulk, persistent interrupt, and
+high-speed or split full-speed ISO IN/OUT. Full-speed ISO requires a
+high-speed hub transaction translator. Direct low-speed devices remain
+unadvertised. MIDIStreaming stays on its descriptor-defined bulk endpoints;
+enabling USB audio ISO does not reroute MIDI through ISO.
+
+Host-side models cover mailbox ownership, EHCI retirement, error mapping,
+periodic cadence, ISO descriptors/batches, and stop/reset races. These are not
+physical-device qualification. The current hardware evidence and every
+unavailable topology are listed in the drivers repository's
+[`docs/usb-qualification-matrix.md`](https://github.com/BlitterStudio/zz9000-drivers/blob/master/docs/usb-qualification-matrix.md).
+Run the matched `ZZDiag` binary on AmigaOS to capture driver/firmware
+capabilities, epochs, counters, queue state, schedule bits, and recent events.
+
 ## Amiga MMU and Cache Notes
 
 On 68040/68060 systems, configure any pure ZZ9000 RAM window in the

--- a/ZZ9000_proto.sdk/ZZ9000OS/Makefile
+++ b/ZZ9000_proto.sdk/ZZ9000OS/Makefile
@@ -130,6 +130,7 @@ C_SRCS = \
 	$(SRC_DIR)/mp3/decode_mp3.c \
 	$(SRC_DIR)/compression/audio/adpcm.c \
 	$(SRC_DIR)/usb/ehci-hcd.c \
+	$(SRC_DIR)/usb/ehci-iso.c \
 	$(SRC_DIR)/usb/ehci-zynq.c \
 	$(SRC_DIR)/usb/ulpi-viewport.c \
 	$(SRC_DIR)/usb/ulpi.c \
@@ -142,6 +143,8 @@ C_SRCS = \
 	$(SRC_DIR)/zz_config.c \
 	$(SRC_DIR)/fw_update.c \
 	$(SRC_DIR)/usb_proxy.c \
+	$(SRC_DIR)/usb_proxy_diag.c \
+	$(SRC_DIR)/usb_proxy_iso.c \
 	$(SRC_DIR)/sdk_compression.c \
 	$(SRC_DIR)/lzh/extract.c \
 	$(SRC_DIR)/lzh/huf.c \

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/interrupt.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/interrupt.h
@@ -4,6 +4,7 @@
  */
 
 #include <xscugic.h>
+#include "usb_event_irq.h"
 
 #ifndef ZZ_INTERRUPT_H
 #define ZZ_INTERRUPT_H
@@ -13,6 +14,7 @@
 #define AMIGA_INTERRUPT_AUDIO  2
 #define AMIGA_INTERRUPT_VBLANK 4
 #define AMIGA_INTERRUPT_SDK    8
+#define AMIGA_INTERRUPT_USB    ZZUSB_EVENT_INTERRUPT_BIT
 
 XScuGic* interrupt_get_intc();
 int interrupt_configure();

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/lscript.ld
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/lscript.ld
@@ -44,8 +44,8 @@ SECTIONS
 .text : {
    KEEP (*(.vectors))
    KEEP (*(.boot))
-   *(EXCLUDE_FILE (*LzmaDec.o *Lzma2Dec.o *sdk_compression.o *sdk_image_stream.o *sdk_video_stream.o *sdk_video_plmpeg.o *sdk_video_yuy2.o *audio_convert_tables.o) .text)
-   *(EXCLUDE_FILE (*LzmaDec.o *Lzma2Dec.o *sdk_compression.o *sdk_image_stream.o *sdk_video_stream.o *sdk_video_plmpeg.o *sdk_video_yuy2.o *audio_convert_tables.o) .text.*)
+   *(EXCLUDE_FILE (*LzmaDec.o *Lzma2Dec.o *sdk_compression.o *sdk_image_stream.o *sdk_video_stream.o *sdk_video_plmpeg.o *sdk_video_yuy2.o *audio_convert_tables.o *usb_proxy.o *ehci-iso.o *usb_proxy_iso.o) .text)
+   *(EXCLUDE_FILE (*LzmaDec.o *Lzma2Dec.o *sdk_compression.o *sdk_image_stream.o *sdk_video_stream.o *sdk_video_plmpeg.o *sdk_video_yuy2.o *audio_convert_tables.o *usb_proxy.o *ehci-iso.o *usb_proxy_iso.o) .text.*)
    *(.gnu.linkonce.t.*)
    *(.plt)
    *(.gnu_warning)
@@ -67,8 +67,8 @@ SECTIONS
 
 .rodata : {
    __rodata_start = .;
-   *(EXCLUDE_FILE (*LzmaDec.o *Lzma2Dec.o *sdk_compression.o *sdk_image_stream.o *sdk_video_stream.o *sdk_video_plmpeg.o *sdk_video_yuy2.o *audio_convert_tables.o *audio_scene.o) .rodata)
-   *(EXCLUDE_FILE (*LzmaDec.o *Lzma2Dec.o *sdk_compression.o *sdk_image_stream.o *sdk_video_stream.o *sdk_video_plmpeg.o *sdk_video_yuy2.o *audio_convert_tables.o *audio_scene.o) .rodata.*)
+   *(EXCLUDE_FILE (*LzmaDec.o *Lzma2Dec.o *sdk_compression.o *sdk_image_stream.o *sdk_video_stream.o *sdk_video_plmpeg.o *sdk_video_yuy2.o *audio_convert_tables.o *audio_scene.o *usb_proxy.o *ehci-iso.o *usb_proxy_iso.o) .rodata)
+   *(EXCLUDE_FILE (*LzmaDec.o *Lzma2Dec.o *sdk_compression.o *sdk_image_stream.o *sdk_video_stream.o *sdk_video_plmpeg.o *sdk_video_yuy2.o *audio_convert_tables.o *audio_scene.o *usb_proxy.o *ehci-iso.o *usb_proxy_iso.o) .rodata.*)
    *(.gnu.linkonce.r.*)
    __rodata_end = .;
 } > ps7_ddr_0
@@ -319,6 +319,28 @@ ASSERT(__z2_direct_ring_end <= (ORIGIN(ps7_ddr_0) + LENGTH(ps7_ddr_0)),
    *audio_scene.o(.rodata.*)
    . = ALIGN(16);
    __audio_tables_end = .;
+} > ps7_ddr_hi
+
+/* USB proxy dispatch and the isochronous scheduler are not boot-path code.
+ * Keep them in high DDR so feature growth cannot consume the fixed low-DDR
+ * framebuffer boundary. */
+.usb_iso_text : {
+   . = ALIGN(16);
+   __usb_iso_text_start = .;
+   *ehci-iso.o(.text)
+   *ehci-iso.o(.text.*)
+   *ehci-iso.o(.rodata)
+   *ehci-iso.o(.rodata.*)
+   *usb_proxy_iso.o(.text)
+   *usb_proxy_iso.o(.text.*)
+   *usb_proxy_iso.o(.rodata)
+   *usb_proxy.o(.text)
+   *usb_proxy.o(.text.*)
+   *usb_proxy.o(.rodata)
+   *usb_proxy.o(.rodata.*)
+   *usb_proxy_iso.o(.rodata.*)
+   . = ALIGN(16);
+   __usb_iso_text_end = .;
 } > ps7_ddr_hi
 
 .bss (NOLOAD) : {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -332,6 +332,12 @@ void handle_amiga_reset(enum amiga_reset_mode mode) {
 	audio_set_rx_buffer((uint8_t*)AUDIO_RX_BUFFER_ADDRESS);
 
 	reset_storage_request_state();
+	/*
+	 * A warm Amiga reset abandons every host-owned USB request. Retire
+	 * persistent EHCI work before a rebooted driver can negotiate, and
+	 * move the epoch fence so no pre-reset completion can match it.
+	 */
+	usb_proxy_advance_controller_epoch();
 	if (mode == AMIGA_RESET_INIT_MEDIA) {
 		init_storage_services();
 	}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -167,11 +167,15 @@ static int usb_proxy_request_matches(
         be32(&shared_cmd->data_length) != be32(&snapshot->data_length))
         return 0;
 
-    if (is_v2 &&
-        (be32(&shared_ext->request_id) != be32(&ext_snapshot->request_id) ||
-         be32(&shared_ext->controller_epoch) !=
-             be32(&ext_snapshot->controller_epoch)))
-        return 0;
+    if (is_v2) {
+        if (be32(&shared_ext->request_id) !=
+            be32(&ext_snapshot->request_id))
+            return 0;
+        if (be16(&snapshot->cmd) != ZZUSB_CMD_QUERY_CAPS &&
+            be32(&shared_ext->controller_epoch) !=
+                be32(&ext_snapshot->controller_epoch))
+            return 0;
+    }
     return 1;
 }
 static uint32_t sd_storage_read_block = 0;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -1298,8 +1298,9 @@ int main() {
 					usb_proxy_pending_v2 =
 						(zdata & ZZUSB_DOORBELL_V2) ? 1 : 0;
 					usb_proxy_pending = 1;
-					usb_proxy_publish_diagnostics(
-						(volatile void *)USB_BLOCK_STORAGE_ADDRESS, 1U);
+					if (usb_proxy_pending_v2)
+						usb_proxy_publish_diagnostics(
+							(volatile void *)USB_BLOCK_STORAGE_ADDRESS, 1U);
 					break;
 				}
 				case REG_ZZ_SDBLK_TX_HI: {
@@ -1893,8 +1894,9 @@ int main() {
 				}
 
 				usb_proxy_status = 0;
-				usb_proxy_publish_diagnostics(
-					(volatile void *)USB_BLOCK_STORAGE_ADDRESS, 0U);
+				if (is_v2)
+					usb_proxy_publish_diagnostics(
+						(volatile void *)USB_BLOCK_STORAGE_ADDRESS, 0U);
 			}
 
 			{

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -157,8 +157,7 @@ static int usb_proxy_request_matches(
     volatile struct ZZUSBCommand *shared_cmd,
     volatile struct ZZUSBProtocolExtension *shared_ext,
     const struct ZZUSBCommand *snapshot,
-    const struct ZZUSBProtocolExtension *ext_snapshot,
-    int is_v2)
+    uint32_t request_id, uint32_t request_epoch, int is_v2)
 {
     if (be16(&shared_cmd->cmd) != be16(&snapshot->cmd) ||
         be32(&shared_cmd->dev_addr) != be32(&snapshot->dev_addr) ||
@@ -167,15 +166,10 @@ static int usb_proxy_request_matches(
         be32(&shared_cmd->data_length) != be32(&snapshot->data_length))
         return 0;
 
-    if (is_v2) {
-        if (be32(&shared_ext->request_id) !=
-            be32(&ext_snapshot->request_id))
-            return 0;
-        if (be16(&snapshot->cmd) != ZZUSB_CMD_QUERY_CAPS &&
-            be32(&shared_ext->controller_epoch) !=
-                be32(&ext_snapshot->controller_epoch))
-            return 0;
-    }
+    if (is_v2 &&
+        (be32(&shared_ext->request_id) != request_id ||
+         be32(&shared_ext->controller_epoch) != request_epoch))
+        return 0;
     return 1;
 }
 static uint32_t sd_storage_read_block = 0;
@@ -1817,6 +1811,8 @@ int main() {
 				u32 proxy_buf_size = ZZUSB_APERTURE_SIZE;
 				uint32_t data_length;
 				uint32_t actual_length;
+				uint32_t request_id;
+				uint32_t request_epoch;
 				uint16_t command;
 				uint16_t direction;
 				uint16_t result;
@@ -1833,9 +1829,15 @@ int main() {
 				if (is_v2) {
 					memcpy(&usb_proxy_ext_snapshot, (const void *)proxy_ext,
 					       sizeof(usb_proxy_ext_snapshot));
+					request_id =
+						be32(&usb_proxy_ext_snapshot.request_id);
+					request_epoch =
+						be32(&usb_proxy_ext_snapshot.controller_epoch);
 				} else {
 					memset(&usb_proxy_ext_snapshot, 0,
 					       sizeof(usb_proxy_ext_snapshot));
+					request_id = 0;
+					request_epoch = 0;
 				}
 
 				result = zzusb_validate_command(
@@ -1868,7 +1870,7 @@ int main() {
 				__asm__ __volatile__("dsb" ::: "memory");
 				request_matches = usb_proxy_request_matches(
 					proxy_cmd, proxy_ext, &usb_proxy_cmd_snapshot,
-					&usb_proxy_ext_snapshot, is_v2);
+					request_id, request_epoch, is_v2);
 
 				if (request_matches) {
 					if (result == ZZUSB_STATUS_OK && actual_length != 0 &&

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -152,6 +152,12 @@ static volatile int usb_proxy_pending_v2 = 0;
 static struct ZZUSBCommand usb_proxy_cmd_snapshot __attribute__((aligned(64)));
 static struct ZZUSBProtocolExtension usb_proxy_ext_snapshot __attribute__((aligned(16)));
 static uint8_t usb_proxy_data_snapshot[ZZUSB_MAX_XFER] __attribute__((aligned(64)));
+static struct ZZUSBCommand usb_proxy_maint_cmd_snapshot
+	__attribute__((aligned(64)));
+static struct ZZUSBProtocolExtension usb_proxy_maint_ext_snapshot
+	__attribute__((aligned(16)));
+static uint8_t usb_proxy_maint_data_snapshot[ZZUSB_MAINT_DATA_MAX]
+	__attribute__((aligned(64)));
 
 static int usb_proxy_request_matches(
     volatile struct ZZUSBCommand *shared_cmd,
@@ -171,6 +177,94 @@ static int usb_proxy_request_matches(
          be32(&shared_ext->controller_epoch) != request_epoch))
         return 0;
     return 1;
+}
+
+void usb_proxy_poll_maintenance(void)
+{
+	volatile struct ZZUSBCommand *shared_cmd =
+		(volatile struct ZZUSBCommand *)(USB_BLOCK_STORAGE_ADDRESS +
+		                                ZZUSB_MAINT_HEADER_OFFSET);
+	volatile struct ZZUSBProtocolExtension *shared_ext =
+		(volatile struct ZZUSBProtocolExtension *)
+			(USB_BLOCK_STORAGE_ADDRESS + ZZUSB_MAINT_HEADER_OFFSET +
+			 ZZUSB_CMD_SIZE);
+	uint8_t *shared_data =
+		(uint8_t *)USB_BLOCK_STORAGE_ADDRESS + ZZUSB_MAINT_DATA_OFFSET;
+	uint32_t data_length;
+	uint32_t actual_length;
+	uint32_t request_id;
+	uint32_t request_epoch;
+	uint16_t command;
+	uint16_t result;
+	int request_matches;
+
+	Xil_DCacheInvalidateRange((u32)shared_cmd, ZZUSB_V2_HEADER_SIZE);
+	__asm__ __volatile__("dsb" ::: "memory");
+	if (be16(&shared_cmd->status) != ZZUSB_STATUS_PENDING)
+		return;
+
+	memcpy(&usb_proxy_maint_cmd_snapshot, (const void *)shared_cmd,
+	       sizeof(usb_proxy_maint_cmd_snapshot));
+	memcpy(&usb_proxy_maint_ext_snapshot, (const void *)shared_ext,
+	       sizeof(usb_proxy_maint_ext_snapshot));
+	request_id = be32(&usb_proxy_maint_ext_snapshot.request_id);
+	request_epoch = be32(&usb_proxy_maint_ext_snapshot.controller_epoch);
+	command = be16(&usb_proxy_maint_cmd_snapshot.cmd);
+	data_length = be32(&usb_proxy_maint_cmd_snapshot.data_length);
+
+	result = zzusb_validate_command(
+		&usb_proxy_maint_cmd_snapshot, &usb_proxy_maint_ext_snapshot, 1,
+		usb_proxy_get_controller_epoch());
+	if (result == ZZUSB_STATUS_OK &&
+	    command != ZZUSB_CMD_ISO_QUEUE &&
+	    command != ZZUSB_CMD_ISO_REAP &&
+	    command != ZZUSB_CMD_ISO_STOP)
+		result = ZZUSB_STATUS_UNSUPPORTED;
+	if (result == ZZUSB_STATUS_OK && data_length > ZZUSB_MAINT_DATA_MAX)
+		result = ZZUSB_STATUS_BADPARAM;
+	if (result == ZZUSB_STATUS_OK && data_length != 0 &&
+	    command == ZZUSB_CMD_ISO_QUEUE) {
+		Xil_DCacheInvalidateRange((u32)shared_data, data_length);
+		__asm__ __volatile__("dsb" ::: "memory");
+		memcpy(usb_proxy_maint_data_snapshot, shared_data, data_length);
+	}
+	if (result == ZZUSB_STATUS_OK)
+		result = usb_proxy_handle_command(
+			&usb_proxy_maint_cmd_snapshot, &usb_proxy_maint_ext_snapshot,
+			usb_proxy_maint_data_snapshot, 1);
+
+	actual_length = be32(&usb_proxy_maint_cmd_snapshot.actual_length);
+	if (actual_length > ZZUSB_MAINT_DATA_MAX) {
+		actual_length = 0;
+		put_be32(&usb_proxy_maint_cmd_snapshot.actual_length, 0);
+		result = ZZUSB_STATUS_OVERRUN;
+	}
+
+	Xil_DCacheInvalidateRange((u32)shared_cmd, ZZUSB_V2_HEADER_SIZE);
+	__asm__ __volatile__("dsb" ::: "memory");
+	request_matches = usb_proxy_request_matches(
+		shared_cmd, shared_ext, &usb_proxy_maint_cmd_snapshot,
+		request_id, request_epoch, 1);
+	if (!request_matches) {
+		usb_proxy_note_late_completion(
+			&usb_proxy_maint_cmd_snapshot, &usb_proxy_maint_ext_snapshot,
+			1);
+		usb_proxy_advance_controller_epoch();
+		return;
+	}
+
+	if (result == ZZUSB_STATUS_OK && actual_length != 0 &&
+	    command == ZZUSB_CMD_ISO_REAP) {
+		memcpy(shared_data, usb_proxy_maint_data_snapshot, actual_length);
+		Xil_DCacheFlushRange((u32)shared_data, actual_length);
+	}
+	put_be16(&usb_proxy_maint_cmd_snapshot.status, result);
+	memcpy((void *)shared_cmd, &usb_proxy_maint_cmd_snapshot,
+	       sizeof(usb_proxy_maint_cmd_snapshot));
+	memcpy((void *)shared_ext, &usb_proxy_maint_ext_snapshot,
+	       sizeof(usb_proxy_maint_ext_snapshot));
+	Xil_DCacheFlushRange((u32)shared_cmd, ZZUSB_V2_HEADER_SIZE);
+	__asm__ __volatile__("dsb" ::: "memory");
 }
 static uint32_t sd_storage_read_block = 0;
 static uint32_t sd_storage_write_block = 0;
@@ -1806,6 +1900,7 @@ int main() {
 		} else {
 			// there are no read/write requests, we can do other housekeeping
 
+			usb_proxy_poll_maintenance();
 			if (usb_proxy_pending) {
 				volatile struct ZZUSBCommand *proxy_cmd =
 					(volatile struct ZZUSBCommand *)USB_BLOCK_STORAGE_ADDRESS;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -1846,7 +1846,8 @@ int main() {
 				data_length = be32(&usb_proxy_cmd_snapshot.data_length);
 				direction = be16(&usb_proxy_cmd_snapshot.direction);
 				command = be16(&usb_proxy_cmd_snapshot.cmd);
-				if (result == ZZUSB_STATUS_OK && data_length != 0 &&
+				if (result == ZZUSB_STATUS_OK &&
+				    usb_proxy_can_stage_payload() && data_length != 0 &&
 				    (direction == 0 ||
 				     command == ZZUSB_CMD_ISO_QUEUE)) {
 					memcpy(usb_proxy_data_snapshot, proxy_data, data_length);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -1873,6 +1873,10 @@ int main() {
 					request_id, request_epoch, is_v2);
 
 				if (request_matches) {
+					if (command == ZZUSB_CMD_DIAG_SNAPSHOT &&
+					    result == ZZUSB_STATUS_OK)
+						usb_proxy_publish_diagnostics(
+							(volatile void *)USB_BLOCK_STORAGE_ADDRESS, 0U);
 					if (result == ZZUSB_STATUS_OK && actual_length != 0 &&
 					    (direction == 0x80 ||
 					     command == ZZUSB_CMD_ENUMERATE ||
@@ -1900,7 +1904,7 @@ int main() {
 				}
 
 				usb_proxy_status = 0;
-				if (is_v2)
+				if (is_v2 && command != ZZUSB_CMD_DIAG_SNAPSHOT)
 					usb_proxy_publish_diagnostics(
 						(volatile void *)USB_BLOCK_STORAGE_ADDRESS, 0U);
 			}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -1900,7 +1900,8 @@ int main() {
 		} else {
 			// there are no read/write requests, we can do other housekeeping
 
-			usb_proxy_poll_maintenance();
+			if (!usb_proxy_pending)
+				usb_proxy_poll_maintenance();
 			if (usb_proxy_pending) {
 				volatile struct ZZUSBCommand *proxy_cmd =
 					(volatile struct ZZUSBCommand *)USB_BLOCK_STORAGE_ADDRESS;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/main.c
@@ -88,7 +88,7 @@ void Xil_AssertNonVoid() {}
  * live calibration also requires the bitstream's exact capability. Other
  * SDK additions use service flags and status pages that self-gate. */
 #define REVISION_MAJOR 2
-#define REVISION_MINOR 8
+#define REVISION_MINOR 9
 
 #ifndef ZZ9000_SKIP_INITIAL_MEDIA_INIT
 #define ZZ9000_SKIP_INITIAL_MEDIA_INIT 0
@@ -148,6 +148,32 @@ static uint32_t usb_storage_write_block = 0;
 static char sd_storage_available_flag = 0;
 
 static volatile int usb_proxy_pending = 0;
+static volatile int usb_proxy_pending_v2 = 0;
+static struct ZZUSBCommand usb_proxy_cmd_snapshot __attribute__((aligned(64)));
+static struct ZZUSBProtocolExtension usb_proxy_ext_snapshot __attribute__((aligned(16)));
+static uint8_t usb_proxy_data_snapshot[ZZUSB_MAX_XFER] __attribute__((aligned(64)));
+
+static int usb_proxy_request_matches(
+    volatile struct ZZUSBCommand *shared_cmd,
+    volatile struct ZZUSBProtocolExtension *shared_ext,
+    const struct ZZUSBCommand *snapshot,
+    const struct ZZUSBProtocolExtension *ext_snapshot,
+    int is_v2)
+{
+    if (be16(&shared_cmd->cmd) != be16(&snapshot->cmd) ||
+        be32(&shared_cmd->dev_addr) != be32(&snapshot->dev_addr) ||
+        be16(&shared_cmd->endpoint) != be16(&snapshot->endpoint) ||
+        be16(&shared_cmd->direction) != be16(&snapshot->direction) ||
+        be32(&shared_cmd->data_length) != be32(&snapshot->data_length))
+        return 0;
+
+    if (is_v2 &&
+        (be32(&shared_ext->request_id) != be32(&ext_snapshot->request_id) ||
+         be32(&shared_ext->controller_epoch) !=
+             be32(&ext_snapshot->controller_epoch)))
+        return 0;
+    return 1;
+}
 static uint32_t sd_storage_read_block = 0;
 static uint32_t sd_storage_write_block = 0;
 
@@ -219,6 +245,7 @@ static void reset_storage_request_state() {
 	usb_write_pending = 0;
 #endif
 	usb_proxy_pending = 0;
+	usb_proxy_pending_v2 = 0;
 	usb_proxy_status = 0;
 
 	sd_status = 0;
@@ -559,6 +586,8 @@ int main() {
 	while (1) {
 		watchdog_kick();
 		sd_activity_led_poll();
+		usb_proxy_periodic_pump();
+		usb_proxy_iso_pump();
 #ifdef AUDIO_FABRIC_BENCH
 		/* Instrument build (U5): one aggregate cost report per
 		 * second on the console; compiles away entirely in
@@ -766,6 +795,9 @@ int main() {
 					}
 					if (zdata & 128) {
 						amiga_interrupt_clear(AMIGA_INTERRUPT_SDK);
+					}
+					if (zzusb_event_ack_mask(zdata)) {
+						amiga_interrupt_clear(AMIGA_INTERRUPT_USB);
 					}
 				} else {
 					if (zdata & 128) {
@@ -1263,7 +1295,11 @@ int main() {
 				}
 				case REG_ZZ_USB_PROXY_CMD: {
 					usb_proxy_status = 1;
+					usb_proxy_pending_v2 =
+						(zdata & ZZUSB_DOORBELL_V2) ? 1 : 0;
 					usb_proxy_pending = 1;
+					usb_proxy_publish_diagnostics(
+						(volatile void *)USB_BLOCK_STORAGE_ADDRESS, 1U);
 					break;
 				}
 				case REG_ZZ_SDBLK_TX_HI: {
@@ -1768,24 +1804,97 @@ int main() {
 			if (usb_proxy_pending) {
 				volatile struct ZZUSBCommand *proxy_cmd =
 					(volatile struct ZZUSBCommand *)USB_BLOCK_STORAGE_ADDRESS;
-				uint8_t *proxy_data = (uint8_t *)USB_BLOCK_STORAGE_ADDRESS + ZZUSB_DATA_OFFSET;
-				u32 proxy_buf_size = 24576;
+				volatile struct ZZUSBProtocolExtension *proxy_ext =
+					(volatile struct ZZUSBProtocolExtension *)
+						(USB_BLOCK_STORAGE_ADDRESS + ZZUSB_CMD_SIZE);
+				uint8_t *proxy_data =
+					(uint8_t *)USB_BLOCK_STORAGE_ADDRESS + ZZUSB_DATA_OFFSET;
+				u32 proxy_buf_size = ZZUSB_APERTURE_SIZE;
+				uint32_t data_length;
+				uint32_t actual_length;
+				uint16_t command;
+				uint16_t direction;
+				uint16_t result;
+				int is_v2 = usb_proxy_pending_v2;
+				int request_matches;
+
 				usb_proxy_pending = 0;
+				usb_proxy_pending_v2 = 0;
 				Xil_DCacheInvalidateRange((u32)proxy_cmd, proxy_buf_size);
 				__asm__ __volatile__("dsb" ::: "memory");
 
-				uint16_t result = usb_proxy_handle_command(proxy_cmd, proxy_data);
+				memcpy(&usb_proxy_cmd_snapshot, (const void *)proxy_cmd,
+				       sizeof(usb_proxy_cmd_snapshot));
+				if (is_v2) {
+					memcpy(&usb_proxy_ext_snapshot, (const void *)proxy_ext,
+					       sizeof(usb_proxy_ext_snapshot));
+				} else {
+					memset(&usb_proxy_ext_snapshot, 0,
+					       sizeof(usb_proxy_ext_snapshot));
+				}
 
-				Xil_DCacheFlushRange((u32)proxy_data, proxy_buf_size - ZZUSB_DATA_OFFSET);
-				__asm__ __volatile__("dsb" ::: "memory");
-				Xil_DCacheFlushRange((u32)proxy_cmd + 16, 8);
-				__asm__ __volatile__("dsb" ::: "memory");
+				result = zzusb_validate_command(
+					&usb_proxy_cmd_snapshot, &usb_proxy_ext_snapshot,
+					is_v2, usb_proxy_get_controller_epoch());
+				data_length = be32(&usb_proxy_cmd_snapshot.data_length);
+				direction = be16(&usb_proxy_cmd_snapshot.direction);
+				command = be16(&usb_proxy_cmd_snapshot.cmd);
+				if (result == ZZUSB_STATUS_OK && data_length != 0 &&
+				    (direction == 0 ||
+				     command == ZZUSB_CMD_ISO_QUEUE)) {
+					memcpy(usb_proxy_data_snapshot, proxy_data, data_length);
+				}
 
-				put_be16(&proxy_cmd->status, result);
-				Xil_DCacheFlushRange((u32)proxy_cmd, 32);
+				if (result == ZZUSB_STATUS_OK) {
+					result = usb_proxy_handle_command(
+						&usb_proxy_cmd_snapshot, &usb_proxy_ext_snapshot,
+						usb_proxy_data_snapshot, is_v2);
+				}
+				actual_length = be32(&usb_proxy_cmd_snapshot.actual_length);
+				if (actual_length > (is_v2 ? ZZUSB_V2_DATA_MAX :
+				                     ZZUSB_MAX_XFER)) {
+					actual_length = 0;
+					put_be32(&usb_proxy_cmd_snapshot.actual_length, 0);
+					result = ZZUSB_STATUS_OVERRUN;
+				}
+
+				Xil_DCacheInvalidateRange((u32)proxy_cmd,
+				                         ZZUSB_V2_HEADER_SIZE);
 				__asm__ __volatile__("dsb" ::: "memory");
+				request_matches = usb_proxy_request_matches(
+					proxy_cmd, proxy_ext, &usb_proxy_cmd_snapshot,
+					&usb_proxy_ext_snapshot, is_v2);
+
+				if (request_matches) {
+					if (result == ZZUSB_STATUS_OK && actual_length != 0 &&
+					    (direction == 0x80 ||
+					     command == ZZUSB_CMD_ENUMERATE ||
+					     command == ZZUSB_CMD_ISO_REAP)) {
+						memcpy(proxy_data, usb_proxy_data_snapshot,
+						       actual_length);
+						Xil_DCacheFlushRange((u32)proxy_data,
+						                     actual_length);
+					}
+					put_be16(&usb_proxy_cmd_snapshot.status, result);
+					memcpy((void *)proxy_cmd, &usb_proxy_cmd_snapshot,
+					       sizeof(usb_proxy_cmd_snapshot));
+					if (is_v2) {
+						memcpy((void *)proxy_ext, &usb_proxy_ext_snapshot,
+						       sizeof(usb_proxy_ext_snapshot));
+					}
+					Xil_DCacheFlushRange((u32)proxy_cmd,
+					                     ZZUSB_V2_HEADER_SIZE);
+					__asm__ __volatile__("dsb" ::: "memory");
+				} else {
+					usb_proxy_note_late_completion(
+						&usb_proxy_cmd_snapshot, &usb_proxy_ext_snapshot,
+						is_v2);
+					usb_proxy_advance_controller_epoch();
+				}
 
 				usb_proxy_status = 0;
+				usb_proxy_publish_diagnostics(
+					(volatile void *)USB_BLOCK_STORAGE_ADDRESS, 0U);
 			}
 
 			{

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -19,9 +19,12 @@
 #include <xil_cache.h>
 #include <string.h>
 #include <sleep.h>
+#include <xtime_l.h>
 
 #include "ehci.h"
 #include "memalign.h"
+#include "ehci_lifecycle.h"
+#include "ehci_periodic.h"
 
 
 void flush_dcache_range(unsigned long start, unsigned long stop) {
@@ -36,18 +39,39 @@ uint32_t virt_to_phys(void* addr) {
 	return (uint32_t)addr;
 }
 
-// FIXME
-unsigned long tmr=0;
-void udelay(int us) {
+static uint64_t ehci_now_ticks(void)
+{
+	XTime now;
+
+	XTime_GetTime(&now);
+	return (uint64_t)now;
+}
+
+static uint64_t ehci_ticks_for_us(uint32_t usec)
+{
+	return ((uint64_t)usec * (uint64_t)COUNTS_PER_SECOND + 999999ULL) /
+	       1000000ULL;
+}
+
+void udelay(int us)
+{
 	usleep(us);
 }
-void mdelay(int ms) {
-	usleep(1000*ms);
+
+void mdelay(int ms)
+{
+	usleep(1000 * ms);
 }
-unsigned long get_timer(unsigned long i) {
-	mdelay(1);
-	tmr++;
-	return (tmr-i);
+
+unsigned long get_timer(unsigned long base)
+{
+	uint64_t ticks = ehci_now_ticks();
+	uint64_t seconds = ticks / (uint64_t)COUNTS_PER_SECOND;
+	uint64_t remainder = ticks % (uint64_t)COUNTS_PER_SECOND;
+	uint32_t now_ms = (uint32_t)(seconds * 1000ULL +
+		(remainder * 1000ULL) / (uint64_t)COUNTS_PER_SECOND);
+
+	return (uint32_t)(now_ms - (uint32_t)base);
 }
 
 #ifndef CONFIG_USB_MAX_CONTROLLER_COUNT
@@ -61,6 +85,41 @@ unsigned long get_timer(unsigned long i) {
 #define HCHALT_TIMEOUT (8 * 1000)
 
 static struct ehci_ctrl ehcic[CONFIG_USB_MAX_CONTROLLER_COUNT];
+
+struct ehci_async_allocation {
+	struct QH *qh;
+	struct qTD *qtd;
+	struct ehci_async_allocation *next;
+};
+
+static struct ehci_async_allocation *quarantined_async;
+static int ehci_recovery_required;
+
+static void ehci_release_async(struct ehci_async_allocation *allocation)
+{
+	if (!allocation)
+		return;
+	free(allocation->qtd);
+	free(allocation->qh);
+	free(allocation);
+}
+
+static void ehci_quarantine_async(struct ehci_async_allocation *allocation)
+{
+	allocation->next = quarantined_async;
+	quarantined_async = allocation;
+	ehci_recovery_required = 1;
+}
+
+static void ehci_reclaim_async_after_reset(void)
+{
+	while (quarantined_async) {
+		struct ehci_async_allocation *allocation = quarantined_async;
+
+		quarantined_async = allocation->next;
+		ehci_release_async(allocation);
+	}
+}
 
 static struct descriptor {
 	struct usb_hub_descriptor hub;
@@ -151,7 +210,6 @@ static void ehci_set_usbmode(struct ehci_ctrl *ctrl)
 
 	reg_ptr = (uint32_t *)((u8 *)&ctrl->hcor->or_usbcmd + USBMODE);
 	tmp = ehci_readl(reg_ptr);
-	printf("[usbmode] before: %08lx\n", (unsigned long)tmp);
 	tmp |= USBMODE_CM_HC;
 #if defined(CONFIG_EHCI_MMIO_BIG_ENDIAN)
 	tmp |= USBMODE_BE;
@@ -159,8 +217,6 @@ static void ehci_set_usbmode(struct ehci_ctrl *ctrl)
 	tmp &= ~USBMODE_BE;
 #endif
 	ehci_writel(reg_ptr, tmp);
-	tmp = ehci_readl(reg_ptr);
-	printf("[usbmode] after: %08lx\n", (unsigned long)tmp);
 }
 
 static void ehci_powerup_fixup(struct ehci_ctrl *ctrl, uint32_t *status_reg,
@@ -174,8 +230,6 @@ static uint32_t *ehci_get_portsc_register(struct ehci_ctrl *ctrl, int port)
 	int max_ports = HCS_N_PORTS(ehci_readl(&ctrl->hccr->cr_hcsparams));
 
 	if (port < 0 || port >= max_ports) {
-		/* Printing the message would cause a scan failure! */
-		printf("The request port(%u) exceeds maximum port number\n", port);
 		return NULL;
 	}
 
@@ -184,18 +238,23 @@ static uint32_t *ehci_get_portsc_register(struct ehci_ctrl *ctrl, int port)
 
 static int handshake(uint32_t *ptr, uint32_t mask, uint32_t done, int usec)
 {
+	uint64_t start = ehci_now_ticks();
+	uint64_t budget;
 	uint32_t result;
-	do {
+
+	if (usec <= 0)
+		return -1;
+	budget = ehci_ticks_for_us((uint32_t)usec);
+	for (;;) {
 		result = ehci_readl(ptr);
-		udelay(5);
 		if (result == ~(uint32_t)0)
 			return -1;
-		result &= mask;
-		if (result == done)
+		if ((result & mask) == done)
 			return 0;
-		usec--;
-	} while (usec > 0);
-	return -1;
+		if ((uint64_t)(ehci_now_ticks() - start) >= budget)
+			return -1;
+		udelay(5);
+	}
 }
 
 static int ehci_reset(struct ehci_ctrl *ctrl)
@@ -209,7 +268,6 @@ static int ehci_reset(struct ehci_ctrl *ctrl)
 	ret = handshake((uint32_t *)&ctrl->hcor->or_usbcmd,
 			CMD_RESET, 0, 250 * 1000);
 	if (ret < 0) {
-		printf("EHCI fail to reset\n");
 		goto out;
 	}
 
@@ -254,8 +312,6 @@ static int ehci_shutdown(struct ehci_ctrl *ctrl)
 			HCHALT_TIMEOUT);
 	}
 
-	if (ret)
-		puts("EHCI failed to shut down host controller.\n");
 
 	return ret;
 }
@@ -266,8 +322,6 @@ static int ehci_td_buffer(struct qTD *td, void *buf, size_t sz)
 	unsigned long addr = (unsigned long)buf;
 	int idx;
 
-	if (addr != ALIGN(addr, ARCH_DMA_MINALIGN))
-		printf("EHCI-HCD: Misaligned buffer address (%p vs %lx)\n", buf, ALIGN(addr, ARCH_DMA_MINALIGN));
 
 	flush_dcache_range(addr, ALIGN(addr + sz, ARCH_DMA_MINALIGN));
 
@@ -285,7 +339,6 @@ static int ehci_td_buffer(struct qTD *td, void *buf, size_t sz)
 	}
 
 	if (idx == QT_BUFFER_CNT) {
-		printf("out of buffer pointers (%zu bytes left)\n", sz);
 		return -1;
 	}
 
@@ -338,12 +391,42 @@ static void ehci_update_endpt2_dev_n_port(struct usb_device *udev,
 				     QH_ENDPT2_HUBADDR(hubaddr));
 }
 
+static int ehci_stop_async_schedule(struct ehci_ctrl *ctrl)
+{
+	uint32_t cmd = ehci_readl(&ctrl->hcor->or_usbcmd);
+
+	cmd &= ~CMD_ASE;
+	ehci_writel(&ctrl->hcor->or_usbcmd, cmd);
+	return handshake((uint32_t *)&ctrl->hcor->or_usbsts,
+			 STS_ASS, 0, 100 * 1000);
+}
+
+static int ehci_unlink_async_qh(struct ehci_ctrl *ctrl)
+{
+	uint32_t cmd;
+
+	ctrl->qh_list.qh_link = cpu_to_hc32(
+		virt_to_phys(&ctrl->qh_list) | QH_LINK_TYPE_QH);
+	flush_dcache_range((unsigned long)&ctrl->qh_list,
+		ALIGN_END_ADDR(struct QH, &ctrl->qh_list, 1));
+
+	ehci_writel(&ctrl->hcor->or_usbsts, STS_IAA);
+	cmd = ehci_readl(&ctrl->hcor->or_usbcmd);
+	ehci_writel(&ctrl->hcor->or_usbcmd, cmd | CMD_IAAD);
+	if (handshake((uint32_t *)&ctrl->hcor->or_usbsts,
+		      STS_IAA, STS_IAA, 10 * 1000) < 0)
+		return -ETIMEDOUT;
+	ehci_writel(&ctrl->hcor->or_usbsts, STS_IAA);
+	return 0;
+}
+
 static int
 ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 		   void *buffer, int length, struct devrequest *req,
 		   unsigned long timeout_ms)
 {
-	ALLOC_ALIGN_BUFFER(struct QH, qh, 1, USB_DMA_MINALIGN);
+	struct ehci_async_allocation *allocation;
+	struct QH *qh;
 	struct qTD *qtd;
 	int qtd_count = 0;
 	int qtd_counter = 0;
@@ -353,9 +436,16 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 	uint32_t endpt, maxpacket, token, usbsts;
 	uint32_t c, toggle;
 	uint32_t cmd;
+	int async_linked = 0;
+	int descriptors_reclaimable = 0;
 	unsigned long timeout;
 	int ret = 0;
 	struct ehci_ctrl *ctrl = ehci_get_ctrl(dev);
+	if (ehci_recovery_required) {
+		dev->status = USB_ST_CRC_ERR;
+		dev->act_len = 0;
+		return -EAGAIN;
+	}
 
 	//printf("dev=%p, pipe=%lx, buffer=%p, length=%d, req=%p\n", dev, pipe,
 	//      buffer, length, req);
@@ -428,11 +518,18 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 
 	// FIXME needs 128kB ram?
 
-	qtd = memalign(USB_DMA_MINALIGN, qtd_count * sizeof(struct qTD)); // FIXME dynamic allocation
-	if (qtd == NULL) {
-		printf("unable to allocate TDs\n");
-		return -1;
+	allocation = malloc(sizeof(*allocation));
+	qh = memalign(USB_DMA_MINALIGN, sizeof(*qh));
+	qtd = memalign(USB_DMA_MINALIGN, qtd_count * sizeof(*qtd));
+	if (!allocation || !qh || !qtd) {
+		free(qtd);
+		free(qh);
+		free(allocation);
+		return -ENOMEM;
 	}
+	allocation->qh = qh;
+	allocation->qtd = qtd;
+	allocation->next = NULL;
 
 	memset(qh, 0, sizeof(struct QH));
 	memset(qtd, 0, qtd_count * sizeof(*qtd));
@@ -492,7 +589,6 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 			QT_TOKEN_STATUS(QT_TOKEN_STATUS_ACTIVE);
 		qtd[qtd_counter].qt_token = cpu_to_hc32(token);
 		if (ehci_td_buffer(&qtd[qtd_counter], req, sizeof(*req))) {
-			printf("unable to construct SETUP TD\n");
 			goto fail;
 		}
 		/* Update previous qTD! */
@@ -551,8 +647,6 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 			qtd[qtd_counter].qt_token = cpu_to_hc32(token);
 			if (ehci_td_buffer(&qtd[qtd_counter], buf_ptr,
 						xfr_bytes)) {
-				printf("unable to construct DATA TD\n");
-
 				goto fail;
 			}
 			/* Update previous qTD! */
@@ -592,6 +686,7 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 	}
 
 	ctrl->qh_list.qh_link = cpu_to_hc32(virt_to_phys(qh) | QH_LINK_TYPE_QH);
+	async_linked = 1;
 
 	/* Flush dcache */
 	uint32_t end = ALIGN_END_ADDR(struct QH, &ctrl->qh_list, 1);
@@ -614,7 +709,6 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 	ret = handshake((uint32_t *)&ctrl->hcor->or_usbsts, STS_ASS, STS_ASS,
 			100 * 1000);
 	if (ret < 0) {
-		printf("EHCI fail timeout STS_ASS set\n");
 		goto fail;
 	}
 
@@ -650,48 +744,17 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 		invalidate_dcache_range((unsigned long)buffer,
 			ALIGN((unsigned long)buffer + length, ARCH_DMA_MINALIGN));
 
-	/* Check that the TD processing happened */
-	if (QT_TOKEN_GET_STATUS(token) & QT_TOKEN_STATUS_ACTIVE) {
-		printf("EHCI timeout\n");
-		printf("[ehci-dbg] === AFTER TIMEOUT ===\n");
-		printf("[ehci-dbg] cmd=%08lx sts=%08lx asynclist=%08lx configflag=%08lx portsc=%08lx\n",
-		       (unsigned long)ehci_readl(&ctrl->hcor->or_usbcmd),
-		       (unsigned long)ehci_readl(&ctrl->hcor->or_usbsts),
-		       (unsigned long)ehci_readl(&ctrl->hcor->or_asynclistaddr),
-		       (unsigned long)ehci_readl(&ctrl->hcor->or_configflag),
-		       (unsigned long)ehci_readl(&ctrl->hcor->or_portsc[0]));
-		printf("[ehci-dbg] qh_endpt1=%08lx qh_endpt2=%08lx\n",
-		       (unsigned long)hc32_to_cpu(qh->qh_endpt1),
-		       (unsigned long)hc32_to_cpu(qh->qh_endpt2));
-		printf("[ehci-dbg] qh_overlay after: next=%08lx altnext=%08lx token=%08lx\n",
-		       (unsigned long)hc32_to_cpu(qh->qh_overlay.qt_next),
-		       (unsigned long)hc32_to_cpu(qh->qh_overlay.qt_altnext),
-		       (unsigned long)hc32_to_cpu(qh->qh_overlay.qt_token));
-		for (int i = 0; i < qtd_count; i++) {
-			printf("[ehci-dbg] qtd[%d] after: next=%08lx altnext=%08lx token=%08lx buf0=%08lx\n",
-			       i,
-			       (unsigned long)hc32_to_cpu(qtd[i].qt_next),
-			       (unsigned long)hc32_to_cpu(qtd[i].qt_altnext),
-			       (unsigned long)hc32_to_cpu(qtd[i].qt_token),
-			       (unsigned long)hc32_to_cpu(qtd[i].qt_buffer[0]));
-		}
-		printf("[ehci-dbg] dev: addr=%d speed=%d maxpkt=%d ep=%lu dir=%s\n",
-		       dev->devnum, dev->speed, dev->maxpacketsize,
-		       usb_pipeendpoint(pipe),
-		       usb_pipein(pipe) ? "IN" : "OUT");
-		printf("[ehci-dbg] pipe=%08lx req=%p buffer=%p length=%d\n",
-		       pipe, req, buffer, length);
-	}
 
-	/* Disable async schedule. */
-	cmd = ehci_readl(&ctrl->hcor->or_usbcmd);
-	cmd &= ~CMD_ASE;
-	ehci_writel(&ctrl->hcor->or_usbcmd, cmd);
+	if (ehci_unlink_async_qh(ctrl) == 0)
+		descriptors_reclaimable = 1;
 
-	ret = handshake((uint32_t *)&ctrl->hcor->or_usbsts, STS_ASS, 0,
-			100 * 1000);
-	if (ret < 0) {
-		printf("EHCI fail timeout STS_ASS reset\n");
+	ret = ehci_stop_async_schedule(ctrl);
+	if (ret == 0)
+		descriptors_reclaimable = 1;
+
+	if (!ehci_dma_reclaimable(ret == 0, descriptors_reclaimable, 0)) {
+		dev->status = USB_ST_CRC_ERR;
+		dev->act_len = 0;
 		goto fail;
 	}
 
@@ -702,8 +765,8 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 	 * scrub the async-ring state so the next ehci_submit_async call
 	 * starts fresh:
 	 *
-	 *   1. Point qh_list.qh_link back at qh_list itself (no dangling
-	 *      pointer to the stack-allocated qh we're about to unwind).
+	 *   1. Point qh_list.qh_link back at qh_list itself so no later
+	 *      schedule traversal reaches the retired heap QH.
 	 *   2. Zero qh_list.qh_overlay and set its qt_next / qt_altnext
 	 *      to TERMINATE — otherwise the HC, on the next async-enable,
 	 *      may resume from the cached overlay state (which may still
@@ -787,11 +850,19 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 		//      ehci_readl(&ctrl->hcor->or_portsc[1]));
 	}
 
-	free(qtd);
+	ehci_release_async(allocation);
 	return (dev->status != USB_ST_NOT_PROC) ? 0 : -1;
 
 fail:
-	free(qtd);
+	if (async_linked && !descriptors_reclaimable &&
+	    ehci_unlink_async_qh(ctrl) == 0)
+		descriptors_reclaimable = 1;
+	if (async_linked && ehci_stop_async_schedule(ctrl) == 0)
+		descriptors_reclaimable = 1;
+	if (!async_linked || descriptors_reclaimable)
+		ehci_release_async(allocation);
+	else
+		ehci_quarantine_async(allocation);
 	return -1;
 }
 
@@ -876,13 +947,10 @@ static int ehci_submit_root(struct usb_device *dev, unsigned long pipe,
 				srclen = 42;
 				break;
 			default:
-				printf("unknown value DT_STRING %x\n",
-					le16_to_cpu(req->value));
 				goto unknown;
 			}
 			break;
 		default:
-			printf("unknown value %x\n", le16_to_cpu(req->value));
 			goto unknown;
 		}
 		break;
@@ -894,7 +962,6 @@ static int ehci_submit_root(struct usb_device *dev, unsigned long pipe,
 			srclen = descriptor.hub.bLength;
 			break;
 		default:
-			printf("unknown value %x\n", le16_to_cpu(req->value));
 			goto unknown;
 		}
 		break;
@@ -975,8 +1042,6 @@ static int ehci_submit_root(struct usb_device *dev, unsigned long pipe,
 			    !ehci_is_TDI() &&
 			    EHCI_PS_IS_LOWSPEED(reg)) {
 				/* Low speed device, give up ownership. */
-				printf("port %d low speed --> companion\n",
-				      port - 1);
 				reg |= EHCI_PS_PO;
 				ehci_writel(status_reg, reg);
 				return -ENXIO;
@@ -1009,7 +1074,6 @@ static int ehci_submit_root(struct usb_device *dev, unsigned long pipe,
 					reg = ehci_readl(status_reg);
 					if ((reg & (EHCI_PS_PE | EHCI_PS_CS))
 					    == EHCI_PS_CS && !ehci_is_TDI()) {
-						printf("port %d full speed --> companion\n", port - 1);
 						reg &= ~EHCI_PS_CLEAR;
 						reg |= EHCI_PS_PO;
 						ehci_writel(status_reg, reg);
@@ -1018,8 +1082,6 @@ static int ehci_submit_root(struct usb_device *dev, unsigned long pipe,
 						ctrl->portreset |= 1 << port;
 					}
 				} else {
-					printf("port(%d) reset error\n",
-					       port - 1);
 				}
 			}
 			break;
@@ -1030,7 +1092,6 @@ static int ehci_submit_root(struct usb_device *dev, unsigned long pipe,
 			ehci_writel(status_reg, reg);
 			break;
 		default:
-			printf("unknown feature %x\n", le16_to_cpu(req->value));
 			goto unknown;
 		}
 		/* unblock posted writes */
@@ -1060,7 +1121,6 @@ static int ehci_submit_root(struct usb_device *dev, unsigned long pipe,
 			ctrl->portreset &= ~(1 << port);
 			break;
 		default:
-			printf("unknown feature %x\n", le16_to_cpu(req->value));
 			goto unknown;
 		}
 		ehci_writel(status_reg, reg);
@@ -1068,7 +1128,6 @@ static int ehci_submit_root(struct usb_device *dev, unsigned long pipe,
 		(void) ehci_readl(&ctrl->hcor->or_usbcmd);
 		break;
 	default:
-		printf("Unknown request\n");
 		goto unknown;
 	}
 
@@ -1084,9 +1143,6 @@ static int ehci_submit_root(struct usb_device *dev, unsigned long pipe,
 	return 0;
 
 unknown:
-	printf("[ehci unknown] requesttype=%x, request=%x, value=%x, index=%x, length=%x\n",
-	      req->requesttype, req->request, le16_to_cpu(req->value),
-	      le16_to_cpu(req->index), le16_to_cpu(req->length));
 
 	dev->act_len = 0;
 	dev->status = USB_ST_STALLED;
@@ -1129,6 +1185,34 @@ void ehci_set_controller_priv(int index, void *priv, const struct ehci_ops *ops)
 void *ehci_get_controller_priv(int index)
 {
 	return ehcic[index].priv;
+}
+
+/*
+ * Zynq AR47540: after reset, do not assert USBCMD.RS until ULPI post-reset
+ * processing has completed, observed as PORTSC.PR clear on every root port.
+ */
+static int ehci_wait_ulpi_post_reset(struct ehci_ctrl *ctrl)
+{
+	int ports = HCS_N_PORTS(ehci_readl(&ctrl->hccr->cr_hcsparams));
+	int port;
+
+	for (port = 0; port < ports; port++) {
+		unsigned long start = get_timer(0);
+		uint32_t reg;
+
+		do {
+			reg = ehci_readl(&ctrl->hcor->or_portsc[port]);
+			if (reg == ~(uint32_t)0)
+				return -ENODEV;
+			if (!(reg & EHCI_PS_PR))
+				break;
+			if (ehci_deadline_expired_u32((uint32_t)get_timer(0),
+						      (uint32_t)start, 10U))
+				return -ETIMEDOUT;
+			udelay(5);
+		} while (1);
+	}
+	return 0;
 }
 
 static int ehci_common_init(struct ehci_ctrl *ctrl, unsigned int tweaks)
@@ -1215,6 +1299,11 @@ static int ehci_common_init(struct ehci_ctrl *ctrl, unsigned int tweaks)
 	if (HCS_PPC(reg))
 		put_unaligned(get_unaligned(&descriptor.hub.wHubCharacteristics)
 				| 0x01, &descriptor.hub.wHubCharacteristics);
+
+	if (ehci_wait_ulpi_post_reset(ctrl) < 0) {
+		printf("EHCI ULPI post-reset processing timed out\n");
+		return -ETIMEDOUT;
+	}
 
 	/* Start the host controller. */
 	cmd = ehci_readl(&ctrl->hcor->or_usbcmd);
@@ -1339,7 +1428,38 @@ struct int_queue {
 	struct QH *current;
 	struct QH *last;
 	struct qTD *tds;
+	struct int_queue *next_quarantined;
+	int linked;
+	struct ehci_periodic_plan plan;
 };
+
+static struct int_queue *quarantined_interrupt;
+
+static void ehci_release_int_queue(struct int_queue *queue)
+{
+	if (!queue)
+		return;
+	free(queue->tds);
+	free(queue->first);
+	free(queue);
+}
+
+static void ehci_quarantine_int_queue(struct int_queue *queue)
+{
+	queue->next_quarantined = quarantined_interrupt;
+	quarantined_interrupt = queue;
+	ehci_recovery_required = 1;
+}
+
+static void ehci_reclaim_interrupt_after_reset(void)
+{
+	while (quarantined_interrupt) {
+		struct int_queue *queue = quarantined_interrupt;
+
+		quarantined_interrupt = queue->next_quarantined;
+		ehci_release_int_queue(queue);
+	}
+}
 
 #define NEXT_QH(qh) (struct QH *)((unsigned long)hc32_to_cpu((qh)->qh_link) & ~0x1f)
 
@@ -1357,7 +1477,6 @@ enable_periodic(struct ehci_ctrl *ctrl)
 	ret = handshake((uint32_t *)&hcor->or_usbsts,
 			STS_PSS, STS_PSS, 1000);
 	if (ret < 0) {
-		printf("EHCI failed: timeout when enabling periodic list\n");
 		return -ETIMEDOUT;
 	}
 	udelay(100);
@@ -1378,7 +1497,32 @@ disable_periodic(struct ehci_ctrl *ctrl)
 	ret = handshake((uint32_t *)&hcor->or_usbsts,
 			STS_PSS, 0, 1000);
 	if (ret < 0) {
-		printf("EHCI failed: timeout when disabling periodic list\n");
+		return -ETIMEDOUT;
+	}
+	return 0;
+}
+
+int ehci_periodic_schedule_pause(struct ehci_ctrl *ctrl)
+{
+	int result;
+
+	if (!ctrl)
+		return -EINVAL;
+	if (ctrl->periodic_schedules <= 0)
+		return 0;
+	result = disable_periodic(ctrl);
+	if (result < 0)
+		ehci_recovery_required = 1;
+	return result;
+}
+
+int ehci_periodic_schedule_resume(struct ehci_ctrl *ctrl, int delta)
+{
+	if (!ctrl || ctrl->periodic_schedules + delta < 0)
+		return -EINVAL;
+	ctrl->periodic_schedules += delta;
+	if (ctrl->periodic_schedules > 0 && enable_periodic(ctrl) < 0) {
+		ehci_recovery_required = 1;
 		return -ETIMEDOUT;
 	}
 	return 0;
@@ -1390,27 +1534,29 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 {
 	struct ehci_ctrl *ctrl = ehci_get_ctrl(dev);
 	struct int_queue *result = NULL;
+	struct ehci_periodic_plan plan;
 	uint32_t i, toggle;
+	int split = dev->parent && dev->parent->parent;
+	unsigned slot_seed = (unsigned)usb_pipeendpoint(pipe) +
+			     (unsigned)dev->portnr;
+
+	if (!ehci_periodic_build_plan(
+		    dev->speed, (unsigned)interval, split,
+		    dev->tt_think_time, dev->tt_multi, slot_seed, &plan))
+		return NULL;
+	if (ehci_recovery_required)
+		return NULL;
 
 	/*
-	 * Interrupt transfers requiring several transactions are not supported
-	 * because bInterval is ignored.
-	 *
-	 * Also, ehci_submit_async() relies on wMaxPacketSize being a power of 2
-	 * <= PKT_ALIGN if several qTDs are required, while the USB
-	 * specification does not constrain this for interrupt transfers. That
-	 * means that ehci_submit_async() would support interrupt transfers
-	 * requiring several transactions only as long as the transfer size does
-	 * not require more than a single qTD.
+	 * Each queue element must fit in one transaction and one qTD. Persistent
+	 * queues are rearmed after completion instead of chaining transactions
+	 * that could execute within the same service interval.
 	 */
 	if (elementsize > usb_maxpacket(dev, pipe)) {
-		printf("%s: xfers requiring several transactions are not supported.\n",
-		       __func__);
 		return NULL;
 	}
 
 	if (usb_pipetype(pipe) != PIPE_INTERRUPT) {
-		printf("non-interrupt pipe (type=%lu)", usb_pipetype(pipe));
 		return NULL;
 	}
 
@@ -1419,21 +1565,20 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 	 * no matter the alignment
 	 */
 	if (elementsize >= 16384) {
-		printf("too large elements for interrupt transfers\n");
 		return NULL;
 	}
 
 	result = malloc(sizeof(*result));  // FIXME dynamic allocation
 	if (!result) {
-		printf("ehci intr queue: out of memory\n");
 		goto fail1;
 	}
+	memset(result, 0, sizeof(*result));
 	result->elementsize = elementsize;
 	result->pipe = pipe;
+	result->plan = plan;
 	result->first = memalign(USB_DMA_MINALIGN,
 				 sizeof(struct QH) * queuesize); // FIXME dynamic allocation
 	if (!result->first) {
-		printf("ehci intr queue: out of memory\n");
 		goto fail2;
 	}
 	result->current = result->first;
@@ -1441,7 +1586,6 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 	result->tds = memalign(USB_DMA_MINALIGN,
 			       sizeof(struct qTD) * queuesize); // FIXME dynamic allocation
 	if (!result->tds) {
-		printf("ehci intr queue: out of memory\n");
 		goto fail3;
 	}
 	memset(result->first, 0, sizeof(struct QH) * queuesize);
@@ -1467,13 +1611,9 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 			QH_ENDPT1_EPS(ehci_encode_speed(dev->speed)) |
 			(usb_pipeendpoint(pipe) << 8) | /* Endpoint Number */
 			(usb_pipedevice(pipe) << 0));
-		qh->qh_endpt2 = cpu_to_hc32((1 << 30) | /* 1 Tx per mframe */
-			(1 << 0)); /* S-mask: microframe 0 */
-		if (dev->speed == USB_SPEED_LOW ||
-				dev->speed == USB_SPEED_FULL) {
-			/* C-mask: microframes 2-4 */
-			qh->qh_endpt2 |= cpu_to_hc32((0x1c << 8));
-		}
+		qh->qh_endpt2 = cpu_to_hc32((1 << 30) |
+			(uint32_t)plan.start_mask |
+			((uint32_t)plan.complete_mask << 8));
 		ehci_update_endpt2_dev_n_port(dev, qh);
 
 		td->qt_next = cpu_to_hc32(QT_NEXT_TERMINATE);
@@ -1511,7 +1651,7 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 
 	if (ctrl->periodic_schedules > 0) {
 		if (disable_periodic(ctrl) < 0) {
-			printf("FATAL: periodic should never fail, but did");
+			ehci_recovery_required = 1;
 			goto fail3;
 		}
 	}
@@ -1520,6 +1660,7 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 	struct QH *list = &ctrl->periodic_queue;
 	result->last->qh_link = list->qh_link;
 	list->qh_link = cpu_to_hc32((unsigned long)result->first | QH_LINK_TYPE_QH);
+	result->linked = 1;
 
 	flush_dcache_range((unsigned long)result->last,
 			   ALIGN_END_ADDR(struct QH, result->last, 1));
@@ -1527,8 +1668,8 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 			   ALIGN_END_ADDR(struct QH, list, 1));
 
 	if (enable_periodic(ctrl) < 0) {
-		printf("FATAL: periodic should never fail, but did");
-		goto fail3;
+		ehci_quarantine_int_queue(result);
+		return NULL;
 	}
 	ctrl->periodic_schedules++;
 
@@ -1558,7 +1699,6 @@ static void *_ehci_poll_int_queue(struct usb_device *dev,
 
 	/* depleted queue */
 	if (cur == NULL) {
-		printf("Exit poll_int_queue with completed queue\n");
 		return NULL;
 	}
 	/* still active */
@@ -1619,51 +1759,137 @@ static void *_ehci_poll_int_queue(struct usb_device *dev,
 	return cur->buffer;
 }
 
+static int _ehci_rearm_int_queue(struct usb_device *dev,
+				 struct int_queue *queue)
+{
+	struct QH *qh;
+	struct qTD *td;
+	unsigned long pipe;
+	uint32_t toggle;
+	uint32_t address;
+
+	if (!queue || !queue->linked || queue->first != queue->last)
+		return -EINVAL;
+
+	qh = queue->first;
+	td = queue->tds;
+	pipe = queue->pipe;
+	toggle = usb_gettoggle(dev, usb_pipeendpoint(pipe), usb_pipeout(pipe));
+	address = (uint32_t)(unsigned long)qh->buffer;
+
+	memset(td, 0, sizeof(*td));
+	td->qt_next = cpu_to_hc32(QT_NEXT_TERMINATE);
+	td->qt_altnext = cpu_to_hc32(QT_NEXT_TERMINATE);
+	td->qt_token = cpu_to_hc32(
+		QT_TOKEN_DT(toggle) |
+		(queue->elementsize << 16) |
+		(3 << 10) |
+		((usb_pipein(pipe) ? 1 : 0) << 8) |
+		QT_TOKEN_STATUS_ACTIVE);
+	td->qt_buffer[0] = cpu_to_hc32(address);
+	td->qt_buffer[1] = cpu_to_hc32((address + 0x1000) & ~0xfff);
+	td->qt_buffer[2] = cpu_to_hc32((address + 0x2000) & ~0xfff);
+	td->qt_buffer[3] = cpu_to_hc32((address + 0x3000) & ~0xfff);
+	td->qt_buffer[4] = cpu_to_hc32((address + 0x4000) & ~0xfff);
+	flush_dcache_range((unsigned long)qh->buffer,
+			   ALIGN_END_ADDR(char, qh->buffer, queue->elementsize));
+	flush_dcache_range((unsigned long)td,
+			   ALIGN_END_ADDR(struct qTD, td, 1));
+
+	qh->qh_curtd = 0;
+	memset(&qh->qh_overlay, 0, sizeof(qh->qh_overlay));
+	qh->qh_overlay.qt_next = cpu_to_hc32((unsigned long)td);
+	qh->qh_overlay.qt_altnext = cpu_to_hc32(QT_NEXT_TERMINATE);
+	queue->current = qh;
+	flush_dcache_range((unsigned long)qh,
+			   ALIGN_END_ADDR(struct QH, qh, 1));
+	return 0;
+}
+
 /* Do not free buffers associated with QHs, they're owned by someone else */
 static int _ehci_destroy_int_queue(struct usb_device *dev,
 				   struct int_queue *queue)
 {
 	struct ehci_ctrl *ctrl = ehci_get_ctrl(dev);
-	int result = -1;
-	unsigned long timeout;
+	struct QH *cur;
+	unsigned long start;
+	int result = 0;
+
+	if (!queue)
+		return 0;
+	if (!queue->linked) {
+		ehci_release_int_queue(queue);
+		return 0;
+	}
 
 	if (disable_periodic(ctrl) < 0) {
-		printf("FATAL: periodic should never fail, but did");
-		goto out;
+		ehci_quarantine_int_queue(queue);
+		return -ETIMEDOUT;
 	}
-	ctrl->periodic_schedules--;
+	if (ctrl->periodic_schedules > 0)
+		ctrl->periodic_schedules--;
 
-	struct QH *cur = &ctrl->periodic_queue;
-	timeout = get_timer(0) + 20; /* abort after 20ms */
+	cur = &ctrl->periodic_queue;
+	start = get_timer(0);
 	while (!(cur->qh_link & cpu_to_hc32(QH_LINK_TERMINATE))) {
 		if (NEXT_QH(cur) == queue->first) {
 			cur->qh_link = queue->last->qh_link;
 			flush_dcache_range((unsigned long)cur,
 					   ALIGN_END_ADDR(struct QH, cur, 1));
-			result = 0;
+			queue->linked = 0;
 			break;
 		}
 		cur = NEXT_QH(cur);
-		if (get_timer(0) > timeout) {
-			printf("Timeout destroying interrupt endpoint queue\n");
-			result = -1;
-			goto out;
+		if (ehci_deadline_expired_u32((uint32_t)get_timer(0),
+					      (uint32_t)start, 20U)) {
+			ehci_quarantine_int_queue(queue);
+			return -ETIMEDOUT;
 		}
 	}
 
-	if (ctrl->periodic_schedules > 0) {
-		result = enable_periodic(ctrl);
-		if (result < 0)
-			printf("FATAL: periodic should never fail, but did");
+	/*
+	 * PSS=0 is the retirement acknowledgement for periodic memory. If the
+	 * queue was not found, the stopped schedule cannot reference it.
+	 */
+	queue->linked = 0;
+	if (ctrl->periodic_schedules > 0 && enable_periodic(ctrl) < 0) {
+		ehci_recovery_required = 1;
+		result = -ETIMEDOUT;
 	}
 
-out:
-	free(queue->tds);
-	free(queue->first);
-	free(queue);
-
+	ehci_release_int_queue(queue);
 	return result;
 }
+
+int ehci_controller_needs_recovery(void)
+{
+	return ehci_recovery_required;
+}
+
+int ehci_controller_recover(void)
+{
+	struct ehci_ctrl *ctrl = &ehcic[0];
+	int result;
+
+	if (!ehci_recovery_required)
+		return 0;
+	if (!ctrl->hccr || !ctrl->hcor)
+		return -ENODEV;
+
+	result = ehci_reset(ctrl);
+	if (result < 0)
+		return result;
+
+	/* CMD_RESET acknowledgement is the only safe bulk reclaim fence. */
+	ehci_reclaim_async_after_reset();
+	ehci_reclaim_interrupt_after_reset();
+	result = ehci_common_init(ctrl, 0);
+	if (result < 0)
+		return result;
+	ehci_recovery_required = 0;
+	return 0;
+}
+
 
 /*
  * Interrupt-xfer poll budget: keep it short so the ZZ9000 main loop can
@@ -1690,9 +1916,11 @@ static int _ehci_submit_int_msg(struct usb_device *dev, unsigned long pipe,
 	if (!queue)
 		return -1;
 
-	timeout = get_timer(0) + EHCI_INT_POLL_MS;
+	timeout = get_timer(0);
 	while ((backbuffer = _ehci_poll_int_queue(dev, queue)) == NULL)
-		if (get_timer(0) > timeout) {
+		if (ehci_deadline_expired_u32((uint32_t)get_timer(0),
+					      (uint32_t)timeout,
+					      EHCI_INT_POLL_MS)) {
 			/*
 			 * No qTD retired within our poll window. For an
 			 * interrupt endpoint this is normal USB behavior —
@@ -1719,8 +1947,6 @@ static int _ehci_submit_int_msg(struct usb_device *dev, unsigned long pipe,
 	 * before returning so the periodic list stays clean.
 	 */
 	if (backbuffer && backbuffer != buffer) {
-		printf("got wrong buffer back (%p instead of %p)\n",
-		      backbuffer, buffer);
 		dev->status = USB_ST_BUF_ERR;
 		result = -EINVAL;
 	}
@@ -1761,6 +1987,11 @@ struct int_queue *create_int_queue(struct usb_device *dev,
 void *poll_int_queue(struct usb_device *dev, struct int_queue *queue)
 {
 	return _ehci_poll_int_queue(dev, queue);
+}
+
+int rearm_int_queue(struct usb_device *dev, struct int_queue *queue)
+{
+	return _ehci_rearm_int_queue(dev, queue);
 }
 
 int destroy_int_queue(struct usb_device *dev, struct int_queue *queue)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -1423,6 +1423,10 @@ static int _ehci_submit_control_msg(struct usb_device *dev, unsigned long pipe,
 	return ehci_submit_async(dev, pipe, buffer, length, setup);
 }
 
+#define EHCI_LONG_GATE_ARMED      0U
+#define EHCI_LONG_GATE_AFTER_WRAP 1U
+#define EHCI_LONG_GATE_WAIT       2U
+
 struct int_queue {
 	int elementsize;
 	unsigned long pipe;
@@ -1434,6 +1438,10 @@ struct int_queue {
 	struct int_queue *next_active;
 	int linked;
 	struct ehci_periodic_plan plan;
+	uint16_t gate_last_frame;
+	uint8_t gate_cycle_factor;
+	uint8_t gate_wait_cycles;
+	uint8_t gate_state;
 };
 
 static struct int_queue *quarantined_interrupt;
@@ -1676,6 +1684,9 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 	result->elementsize = elementsize;
 	result->pipe = pipe;
 	result->plan = plan;
+	result->gate_cycle_factor = ehci_periodic_frame_list_cycles(&plan);
+	result->gate_last_frame = (uint16_t)(
+		(ehci_readl(&ctrl->hcor->or_frindex) >> 3) & 0x3ffU);
 	result->first = memalign(USB_DMA_MINALIGN,
 				 sizeof(struct QH) * queuesize); // FIXME dynamic allocation
 	if (!result->first) {
@@ -1785,6 +1796,73 @@ fail1:
 	return NULL;
 }
 
+static void ehci_long_interval_set_active(struct int_queue *queue,
+					  struct qTD *td, int active)
+{
+	struct QH *qh = queue->current;
+	uint32_t td_token;
+	uint32_t overlay_token;
+
+	invalidate_dcache_range((unsigned long)qh,
+				ALIGN_END_ADDR(struct QH, qh, 1));
+	td_token = hc32_to_cpu(td->qt_token);
+	overlay_token = hc32_to_cpu(qh->qh_overlay.qt_token);
+	if (active) {
+		td_token |= QT_TOKEN_STATUS_ACTIVE;
+		overlay_token |= QT_TOKEN_STATUS_ACTIVE;
+	} else {
+		td_token &= ~QT_TOKEN_STATUS_ACTIVE;
+		overlay_token &= ~QT_TOKEN_STATUS_ACTIVE;
+	}
+	td->qt_token = cpu_to_hc32(td_token);
+	qh->qh_overlay.qt_token = cpu_to_hc32(overlay_token);
+	flush_dcache_range((unsigned long)td,
+			   ALIGN_END_ADDR(struct qTD, td, 1));
+	flush_dcache_range((unsigned long)qh,
+			   ALIGN_END_ADDR(struct QH, qh, 1));
+}
+
+static int ehci_long_interval_completion_ready(
+	struct ehci_ctrl *ctrl, struct int_queue *queue,
+	struct qTD *td, uint32_t token)
+{
+	uint16_t frame;
+	int wrapped;
+
+	if (queue->gate_cycle_factor <= 1U)
+		return 1;
+	frame = (uint16_t)(
+		(ehci_readl(&ctrl->hcor->or_frindex) >> 3) & 0x3ffU);
+	wrapped = frame < queue->gate_last_frame;
+	queue->gate_last_frame = frame;
+
+	if (queue->gate_state != EHCI_LONG_GATE_WAIT) {
+		if (!(QT_TOKEN_GET_STATUS(token) & QT_TOKEN_STATUS_ACTIVE))
+			return 1;
+		if (queue->gate_state == EHCI_LONG_GATE_ARMED && wrapped)
+			queue->gate_state = EHCI_LONG_GATE_AFTER_WRAP;
+		if (queue->gate_state == EHCI_LONG_GATE_AFTER_WRAP && frame != 0U) {
+			ehci_long_interval_set_active(queue, td, 0);
+			queue->gate_wait_cycles =
+				(uint8_t)(queue->gate_cycle_factor - 1U);
+			queue->gate_state = EHCI_LONG_GATE_WAIT;
+		}
+		return 0;
+	}
+
+	if (wrapped && queue->gate_wait_cycles)
+		queue->gate_wait_cycles--;
+	/*
+	 * Arm after frame zero of the final skipped list cycle. The QH is
+	 * reachable only in frame zero, so it cannot run until the next wrap.
+	 */
+	if (!queue->gate_wait_cycles && frame != 0U) {
+		ehci_long_interval_set_active(queue, td, 1);
+		queue->gate_state = EHCI_LONG_GATE_ARMED;
+	}
+	return 0;
+}
+
 static void *_ehci_poll_int_queue(struct usb_device *dev,
 				  struct int_queue *queue)
 {
@@ -1805,6 +1883,8 @@ static void *_ehci_poll_int_queue(struct usb_device *dev,
 	invalidate_dcache_range((unsigned long)cur_td,
 				ALIGN_END_ADDR(struct qTD, cur_td, 1));
 	token = hc32_to_cpu(cur_td->qt_token);
+	if (!ehci_long_interval_completion_ready(ctrl, queue, cur_td, token))
+		return NULL;
 	if (QT_TOKEN_GET_STATUS(token) & QT_TOKEN_STATUS_ACTIVE) {
 		/*
 		 * Silent hot path: mouse/keyboard NAK every microframe
@@ -1903,6 +1983,11 @@ static int _ehci_rearm_int_queue(struct usb_device *dev,
 	queue->current = qh;
 	flush_dcache_range((unsigned long)qh,
 			   ALIGN_END_ADDR(struct QH, qh, 1));
+	queue->gate_wait_cycles = 0;
+	queue->gate_state = EHCI_LONG_GATE_ARMED;
+	queue->gate_last_frame = (uint16_t)(
+		(ehci_readl(&ehci_get_ctrl(dev)->hcor->or_frindex) >> 3) &
+		0x3ffU);
 	return 0;
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -757,6 +757,8 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 	ret = ehci_stop_async_schedule(ctrl);
 	if (ret == 0)
 		descriptors_reclaimable = 1;
+	else
+		ehci_recovery_required = 1;
 
 	if (!ehci_dma_reclaimable(ret == 0, descriptors_reclaimable, 0)) {
 		dev->status = USB_ST_CRC_ERR;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -2078,9 +2078,9 @@ static int _ehci_submit_int_msg(struct usb_device *dev, unsigned long pipe,
 /*
  * Execute one high-speed interrupt opportunity at microframe zero of a
  * selected near-future frame. Unlike a persistent qTD, this queue is linked
- * into only that frame-list slot and retires immediately after a NAK, so
- * software can honor intervals longer than the 1024-frame EHCI list without
- * exposing the endpoint on adjacent frames or list rollovers.
+ * into only that frame-list slot and then unlinked, so software can honor
+ * intervals longer than the 1024-frame EHCI list without exposing the
+ * endpoint on adjacent frames or list rollovers.
  */
 static int _ehci_submit_int_msg_once(struct usb_device *dev,
 				     unsigned long pipe,
@@ -2118,7 +2118,8 @@ static int _ehci_submit_int_msg_once(struct usb_device *dev,
 			    (distance > 0U && distance < 512U)) {
 				backbuffer = _ehci_poll_int_queue(dev, queue);
 				if (!backbuffer) {
-					dev->status = 0;
+					dev->status = usb_pipein(pipe) ?
+						0 : USB_ST_NAK_REC;
 					dev->act_len = 0;
 				}
 				break;
@@ -2126,7 +2127,8 @@ static int _ehci_submit_int_msg_once(struct usb_device *dev,
 		}
 		if (ehci_deadline_expired_u32((uint32_t)get_timer(0),
 					      (uint32_t)timeout, 5U)) {
-			dev->status = 0;
+			dev->status = usb_pipein(pipe) ?
+				0 : USB_ST_NAK_REC;
 			dev->act_len = 0;
 			break;
 		}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -94,6 +94,8 @@ struct ehci_async_allocation {
 
 static struct ehci_async_allocation *quarantined_async;
 static int ehci_recovery_required;
+struct int_queue;
+static struct int_queue *active_interrupt_queues;
 
 static void ehci_release_async(struct ehci_async_allocation *allocation)
 {
@@ -1429,6 +1431,7 @@ struct int_queue {
 	struct QH *last;
 	struct qTD *tds;
 	struct int_queue *next_quarantined;
+	struct int_queue *next_active;
 	int linked;
 	struct ehci_periodic_plan plan;
 };
@@ -1459,6 +1462,7 @@ static void ehci_reclaim_interrupt_after_reset(void)
 		quarantined_interrupt = queue->next_quarantined;
 		ehci_release_int_queue(queue);
 	}
+	active_interrupt_queues = NULL;
 }
 
 #define NEXT_QH(qh) (struct QH *)((unsigned long)hc32_to_cpu((qh)->qh_link) & ~0x1f)
@@ -1524,6 +1528,102 @@ int ehci_periodic_schedule_resume(struct ehci_ctrl *ctrl, int delta)
 	if (ctrl->periodic_schedules > 0 && enable_periodic(ctrl) < 0) {
 		ehci_recovery_required = 1;
 		return -ETIMEDOUT;
+	}
+	return 0;
+}
+
+static unsigned ehci_interrupt_frame_interval(
+	const struct int_queue *queue)
+{
+	unsigned interval =
+		ehci_periodic_hardware_frame_interval(&queue->plan);
+
+	return interval;
+}
+
+static void ehci_insert_interrupt_queue(struct int_queue *queue)
+{
+	struct int_queue **link = &active_interrupt_queues;
+	unsigned interval = ehci_interrupt_frame_interval(queue);
+
+	while (*link &&
+	       ehci_interrupt_frame_interval(*link) >= interval)
+		link = &(*link)->next_active;
+	queue->next_active = *link;
+	*link = queue;
+}
+
+static int ehci_remove_interrupt_queue(struct int_queue *queue)
+{
+	struct int_queue **link = &active_interrupt_queues;
+
+	while (*link && *link != queue)
+		link = &(*link)->next_active;
+	if (!*link)
+		return 0;
+	*link = queue->next_active;
+	queue->next_active = NULL;
+	return 1;
+}
+
+static uint32_t *ehci_periodic_interrupt_link(struct ehci_ctrl *ctrl,
+					      unsigned frame)
+{
+	uint32_t *link = &ctrl->periodic_list[frame];
+	unsigned guard = 0;
+
+	while (guard++ < 128U) {
+		uint32_t value = hc32_to_cpu(*link);
+		uint32_t type;
+
+		if (value & QH_LINK_TERMINATE)
+			return link;
+		type = value & 0x06U;
+		if (type == QH_LINK_TYPE_QH)
+			return link;
+		if (type != QH_LINK_TYPE_ITD &&
+		    type != QH_LINK_TYPE_SITD)
+			return NULL;
+		link = (uint32_t *)(unsigned long)(value & ~0x1fU);
+	}
+	return NULL;
+}
+
+static int ehci_rebuild_interrupt_schedule(struct ehci_ctrl *ctrl)
+{
+	struct int_queue *queue;
+	unsigned frame;
+
+	for (queue = active_interrupt_queues; queue;
+	     queue = queue->next_active) {
+		uint32_t next = queue->next_active ?
+			(uint32_t)(unsigned long)queue->next_active->first :
+			(uint32_t)(unsigned long)&ctrl->periodic_queue;
+
+		queue->last->qh_link =
+			cpu_to_hc32(next | QH_LINK_TYPE_QH);
+		flush_dcache_range((unsigned long)queue->last,
+				   ALIGN_END_ADDR(struct QH, queue->last, 1));
+	}
+
+	for (frame = 0; frame < 1024U; frame++) {
+		uint32_t *link = ehci_periodic_interrupt_link(ctrl, frame);
+		uint32_t target;
+
+		if (!link)
+			return -EINVAL;
+		for (queue = active_interrupt_queues; queue;
+		     queue = queue->next_active) {
+			if (ehci_periodic_frame_due(&queue->plan,
+						    (uint16_t)frame))
+				break;
+		}
+		target = queue ?
+			(uint32_t)(unsigned long)queue->first :
+			(uint32_t)(unsigned long)&ctrl->periodic_queue;
+		*link = cpu_to_hc32(target | QH_LINK_TYPE_QH);
+		flush_dcache_range((unsigned long)link,
+				   ALIGN_END_ADDR(uint32_t, link, 1));
 	}
 	return 0;
 }
@@ -1656,16 +1756,15 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 		}
 	}
 
-	/* hook up to periodic list */
-	struct QH *list = &ctrl->periodic_queue;
-	result->last->qh_link = list->qh_link;
-	list->qh_link = cpu_to_hc32((unsigned long)result->first | QH_LINK_TYPE_QH);
+	/* Build a power-of-two frame skeleton so bInterval > 1 queues are
+	 * unreachable in frames where the endpoint must not be polled. */
+	ehci_insert_interrupt_queue(result);
 	result->linked = 1;
-
-	flush_dcache_range((unsigned long)result->last,
-			   ALIGN_END_ADDR(struct QH, result->last, 1));
-	flush_dcache_range((unsigned long)list,
-			   ALIGN_END_ADDR(struct QH, list, 1));
+	if (ehci_rebuild_interrupt_schedule(ctrl) < 0) {
+		ehci_recovery_required = 1;
+		ehci_quarantine_int_queue(result);
+		return NULL;
+	}
 
 	if (enable_periodic(ctrl) < 0) {
 		ehci_quarantine_int_queue(result);
@@ -1747,7 +1846,7 @@ static void *_ehci_poll_int_queue(struct usb_device *dev,
 		break;
 	}
 
-	if (!(cur->qh_link & QH_LINK_TERMINATE))
+	if (cur != queue->last)
 		queue->current++;
 	else
 		queue->current = NULL;
@@ -1811,8 +1910,6 @@ static int _ehci_destroy_int_queue(struct usb_device *dev,
 				   struct int_queue *queue)
 {
 	struct ehci_ctrl *ctrl = ehci_get_ctrl(dev);
-	struct QH *cur;
-	unsigned long start;
 	int result = 0;
 
 	if (!queue)
@@ -1829,28 +1926,14 @@ static int _ehci_destroy_int_queue(struct usb_device *dev,
 	if (ctrl->periodic_schedules > 0)
 		ctrl->periodic_schedules--;
 
-	cur = &ctrl->periodic_queue;
-	start = get_timer(0);
-	while (!(cur->qh_link & cpu_to_hc32(QH_LINK_TERMINATE))) {
-		if (NEXT_QH(cur) == queue->first) {
-			cur->qh_link = queue->last->qh_link;
-			flush_dcache_range((unsigned long)cur,
-					   ALIGN_END_ADDR(struct QH, cur, 1));
-			queue->linked = 0;
-			break;
-		}
-		cur = NEXT_QH(cur);
-		if (ehci_deadline_expired_u32((uint32_t)get_timer(0),
-					      (uint32_t)start, 20U)) {
-			ehci_quarantine_int_queue(queue);
-			return -ETIMEDOUT;
-		}
+	if (!ehci_remove_interrupt_queue(queue) ||
+	    ehci_rebuild_interrupt_schedule(ctrl) < 0) {
+		ehci_recovery_required = 1;
+		ehci_quarantine_int_queue(queue);
+		return -ETIMEDOUT;
 	}
 
-	/*
-	 * PSS=0 is the retirement acknowledgement for periodic memory. If the
-	 * queue was not found, the stopped schedule cannot reference it.
-	 */
+	/* PSS=0 acknowledged retirement before the queue left every frame. */
 	queue->linked = 0;
 	if (ctrl->periodic_schedules > 0 && enable_periodic(ctrl) < 0) {
 		ehci_recovery_required = 1;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -720,6 +720,7 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 	vtd = &qtd[qtd_counter - 1];
 	timeout = timeout_ms ? timeout_ms : USB_TIMEOUT_MS(pipe);
 	do {
+		usb_proxy_iso_pump();
 		usb_proxy_poll_maintenance();
 		/* Invalidate dcache */
 		invalidate_dcache_range((unsigned long)&ctrl->qh_list,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -25,6 +25,7 @@
 #include "memalign.h"
 #include "ehci_lifecycle.h"
 #include "ehci_periodic.h"
+#include "usb_proxy.h"
 
 
 void flush_dcache_range(unsigned long start, unsigned long stop) {
@@ -719,6 +720,7 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 	vtd = &qtd[qtd_counter - 1];
 	timeout = timeout_ms ? timeout_ms : USB_TIMEOUT_MS(pipe);
 	do {
+		usb_proxy_poll_maintenance();
 		/* Invalidate dcache */
 		invalidate_dcache_range((unsigned long)&ctrl->qh_list,
 			ALIGN_END_ADDR(struct QH, &ctrl->qh_list, 1));

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -1834,6 +1834,7 @@ static void *_ehci_poll_int_queue(struct usb_device *dev,
 		dev->status = USB_ST_STALLED;
 		break;
 	case QT_TOKEN_STATUS_ACTIVE | QT_TOKEN_STATUS_DATBUFERR:
+	case QT_TOKEN_STATUS_HALTED | QT_TOKEN_STATUS_DATBUFERR:
 	case QT_TOKEN_STATUS_DATBUFERR:
 		dev->status = USB_ST_BUF_ERR;
 		break;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -1423,10 +1423,6 @@ static int _ehci_submit_control_msg(struct usb_device *dev, unsigned long pipe,
 	return ehci_submit_async(dev, pipe, buffer, length, setup);
 }
 
-#define EHCI_LONG_GATE_ARMED      0U
-#define EHCI_LONG_GATE_AFTER_WRAP 1U
-#define EHCI_LONG_GATE_WAIT       2U
-
 struct int_queue {
 	int elementsize;
 	unsigned long pipe;
@@ -1438,10 +1434,6 @@ struct int_queue {
 	struct int_queue *next_active;
 	int linked;
 	struct ehci_periodic_plan plan;
-	uint16_t gate_last_frame;
-	uint8_t gate_cycle_factor;
-	uint8_t gate_wait_cycles;
-	uint8_t gate_state;
 };
 
 static struct int_queue *quarantined_interrupt;
@@ -1684,9 +1676,6 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 	result->elementsize = elementsize;
 	result->pipe = pipe;
 	result->plan = plan;
-	result->gate_cycle_factor = ehci_periodic_frame_list_cycles(&plan);
-	result->gate_last_frame = (uint16_t)(
-		(ehci_readl(&ctrl->hcor->or_frindex) >> 3) & 0x3ffU);
 	result->first = memalign(USB_DMA_MINALIGN,
 				 sizeof(struct QH) * queuesize); // FIXME dynamic allocation
 	if (!result->first) {
@@ -1796,72 +1785,6 @@ fail1:
 	return NULL;
 }
 
-static void ehci_long_interval_set_active(struct int_queue *queue,
-					  struct qTD *td, int active)
-{
-	struct QH *qh = queue->current;
-	uint32_t td_token;
-	uint32_t overlay_token;
-
-	invalidate_dcache_range((unsigned long)qh,
-				ALIGN_END_ADDR(struct QH, qh, 1));
-	td_token = hc32_to_cpu(td->qt_token);
-	overlay_token = hc32_to_cpu(qh->qh_overlay.qt_token);
-	if (active) {
-		td_token |= QT_TOKEN_STATUS_ACTIVE;
-		overlay_token |= QT_TOKEN_STATUS_ACTIVE;
-	} else {
-		td_token &= ~QT_TOKEN_STATUS_ACTIVE;
-		overlay_token &= ~QT_TOKEN_STATUS_ACTIVE;
-	}
-	td->qt_token = cpu_to_hc32(td_token);
-	qh->qh_overlay.qt_token = cpu_to_hc32(overlay_token);
-	flush_dcache_range((unsigned long)td,
-			   ALIGN_END_ADDR(struct qTD, td, 1));
-	flush_dcache_range((unsigned long)qh,
-			   ALIGN_END_ADDR(struct QH, qh, 1));
-}
-
-static int ehci_long_interval_completion_ready(
-	struct ehci_ctrl *ctrl, struct int_queue *queue,
-	struct qTD *td, uint32_t token)
-{
-	uint16_t frame;
-	int wrapped;
-
-	if (queue->gate_cycle_factor <= 1U)
-		return 1;
-	frame = (uint16_t)(
-		(ehci_readl(&ctrl->hcor->or_frindex) >> 3) & 0x3ffU);
-	wrapped = frame < queue->gate_last_frame;
-	queue->gate_last_frame = frame;
-
-	if (queue->gate_state != EHCI_LONG_GATE_WAIT) {
-		if (!(QT_TOKEN_GET_STATUS(token) & QT_TOKEN_STATUS_ACTIVE))
-			return 1;
-		if (queue->gate_state == EHCI_LONG_GATE_ARMED && wrapped)
-			queue->gate_state = EHCI_LONG_GATE_AFTER_WRAP;
-		if (queue->gate_state == EHCI_LONG_GATE_AFTER_WRAP && frame != 0U) {
-			ehci_long_interval_set_active(queue, td, 0);
-			queue->gate_wait_cycles =
-				(uint8_t)(queue->gate_cycle_factor - 1U);
-			queue->gate_state = EHCI_LONG_GATE_WAIT;
-		}
-		return 0;
-	}
-
-	if (wrapped && queue->gate_wait_cycles)
-		queue->gate_wait_cycles--;
-	/*
-	 * Arm after frame zero of the final skipped list cycle. The QH is
-	 * reachable only in frame zero, so it cannot run until the next wrap.
-	 */
-	if (!queue->gate_wait_cycles && frame != 0U) {
-		ehci_long_interval_set_active(queue, td, 1);
-		queue->gate_state = EHCI_LONG_GATE_ARMED;
-	}
-	return 0;
-}
 
 static void *_ehci_poll_int_queue(struct usb_device *dev,
 				  struct int_queue *queue)
@@ -1870,9 +1793,6 @@ static void *_ehci_poll_int_queue(struct usb_device *dev,
 	struct qTD *cur_td;
 	uint32_t token, toggle;
 	unsigned long pipe = queue->pipe;
-	struct ehci_ctrl *ctrl = ehci_get_ctrl(dev);
-
-	(void)ctrl;
 
 	/* depleted queue */
 	if (cur == NULL) {
@@ -1883,8 +1803,6 @@ static void *_ehci_poll_int_queue(struct usb_device *dev,
 	invalidate_dcache_range((unsigned long)cur_td,
 				ALIGN_END_ADDR(struct qTD, cur_td, 1));
 	token = hc32_to_cpu(cur_td->qt_token);
-	if (!ehci_long_interval_completion_ready(ctrl, queue, cur_td, token))
-		return NULL;
 	if (QT_TOKEN_GET_STATUS(token) & QT_TOKEN_STATUS_ACTIVE) {
 		/*
 		 * Silent hot path: mouse/keyboard NAK every microframe
@@ -1983,11 +1901,6 @@ static int _ehci_rearm_int_queue(struct usb_device *dev,
 	queue->current = qh;
 	flush_dcache_range((unsigned long)qh,
 			   ALIGN_END_ADDR(struct QH, qh, 1));
-	queue->gate_wait_cycles = 0;
-	queue->gate_state = EHCI_LONG_GATE_ARMED;
-	queue->gate_last_frame = (uint16_t)(
-		(ehci_readl(&ehci_get_ctrl(dev)->hcor->or_frindex) >> 3) &
-		0x3ffU);
 	return 0;
 }
 
@@ -2126,6 +2039,62 @@ static int _ehci_submit_int_msg(struct usb_device *dev, unsigned long pipe,
 
 	return result;
 }
+/*
+ * Execute one high-speed interrupt opportunity at microframe zero of the
+ * next frame. Unlike a persistent qTD, this retires the queue immediately
+ * after a NAK, so software can honor intervals longer than the 1024-frame
+ * EHCI list without leaving the endpoint reachable on every list rollover.
+ */
+static int _ehci_submit_int_msg_once(struct usb_device *dev,
+				     unsigned long pipe,
+				     void *buffer, int length)
+{
+	struct ehci_ctrl *ctrl = ehci_get_ctrl(dev);
+	struct int_queue *queue;
+	void *backbuffer = NULL;
+	unsigned long timeout;
+	uint16_t start_frame;
+	int result = 0;
+	int ret;
+
+	if (!ctrl || dev->speed != USB_SPEED_HIGH)
+		return -EINVAL;
+	queue = _ehci_create_int_queue(dev, pipe, 1, length, buffer, 4);
+	if (!queue)
+		return -1;
+	start_frame = (uint16_t)(
+		(ehci_readl(&ctrl->hcor->or_frindex) >> 3) & 0x3ffU);
+	timeout = get_timer(0);
+	for (;;) {
+		uint32_t frame_index;
+
+		backbuffer = _ehci_poll_int_queue(dev, queue);
+		if (backbuffer)
+			break;
+		frame_index = ehci_readl(&ctrl->hcor->or_frindex);
+		if (((frame_index >> 3) & 0x3ffU) != start_frame &&
+		    (frame_index & 7U) != 0U) {
+			dev->status = 0;
+			dev->act_len = 0;
+			break;
+		}
+		if (ehci_deadline_expired_u32((uint32_t)get_timer(0),
+					      (uint32_t)timeout, 3U)) {
+			dev->status = 0;
+			dev->act_len = 0;
+			break;
+		}
+	}
+	if (backbuffer && backbuffer != buffer) {
+		dev->status = USB_ST_BUF_ERR;
+		result = -EINVAL;
+	}
+	ret = _ehci_destroy_int_queue(dev, queue);
+	if (ret < 0 && result == 0)
+		result = ret;
+	return result;
+}
+
 
 int submit_bulk_msg(struct usb_device *dev, unsigned long pipe,
 			    void *buffer, int length)
@@ -2144,6 +2113,12 @@ int submit_int_msg(struct usb_device *dev, unsigned long pipe,
 {
 	return _ehci_submit_int_msg(dev, pipe, buffer, length, interval);
 }
+int submit_int_msg_once(struct usb_device *dev, unsigned long pipe,
+			void *buffer, int length)
+{
+	return _ehci_submit_int_msg_once(dev, pipe, buffer, length);
+}
+
 
 struct int_queue *create_int_queue(struct usb_device *dev,
 		unsigned long pipe, int queuesize, int elementsize,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -721,6 +721,7 @@ ehci_submit_async_internal(struct usb_device *dev, unsigned long pipe,
 	timeout = timeout_ms ? timeout_ms : USB_TIMEOUT_MS(pipe);
 	do {
 		usb_proxy_iso_pump();
+		usb_proxy_periodic_pump();
 		usb_proxy_poll_maintenance();
 		/* Invalidate dcache */
 		invalidate_dcache_range((unsigned long)&ctrl->qh_list,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -1433,6 +1433,7 @@ struct int_queue {
 	struct int_queue *next_quarantined;
 	struct int_queue *next_active;
 	int linked;
+	int one_shot;
 	struct ehci_periodic_plan plan;
 };
 
@@ -1596,12 +1597,16 @@ static int ehci_rebuild_interrupt_schedule(struct ehci_ctrl *ctrl)
 
 	for (queue = active_interrupt_queues; queue;
 	     queue = queue->next_active) {
-		uint32_t next = queue->next_active ?
-			(uint32_t)(unsigned long)queue->next_active->first :
-			(uint32_t)(unsigned long)&ctrl->periodic_queue;
+		struct int_queue *next = queue->next_active;
+		uint32_t target;
 
+		while (next && next->one_shot)
+			next = next->next_active;
+		target = (!queue->one_shot && next) ?
+			(uint32_t)(unsigned long)next->first :
+			(uint32_t)(unsigned long)&ctrl->periodic_queue;
 		queue->last->qh_link =
-			cpu_to_hc32(next | QH_LINK_TYPE_QH);
+			cpu_to_hc32(target | QH_LINK_TYPE_QH);
 		flush_dcache_range((unsigned long)queue->last,
 				   ALIGN_END_ADDR(struct QH, queue->last, 1));
 	}
@@ -1612,11 +1617,24 @@ static int ehci_rebuild_interrupt_schedule(struct ehci_ctrl *ctrl)
 
 		if (!link)
 			return -EINVAL;
-		for (queue = active_interrupt_queues; queue;
-		     queue = queue->next_active) {
-			if (ehci_periodic_frame_due(&queue->plan,
-						    (uint16_t)frame))
+		queue = NULL;
+		for (struct int_queue *candidate = active_interrupt_queues;
+		     candidate; candidate = candidate->next_active) {
+			if (candidate->one_shot &&
+			    ehci_periodic_frame_due(
+				    &candidate->plan, (uint16_t)frame)) {
+				queue = candidate;
 				break;
+			}
+		}
+		if (!queue) {
+			for (queue = active_interrupt_queues; queue;
+			     queue = queue->next_active) {
+				if (!queue->one_shot &&
+				    ehci_periodic_frame_due(
+					    &queue->plan, (uint16_t)frame))
+					break;
+			}
 		}
 		target = queue ?
 			(uint32_t)(unsigned long)queue->first :
@@ -1691,6 +1709,7 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 	if (!result->first) {
 		goto fail2;
 	}
+	result->one_shot = one_shot;
 	result->current = result->first;
 	result->last = result->first + queuesize - 1;
 	result->tds = memalign(USB_DMA_MINALIGN,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-hcd.c
@@ -1630,7 +1630,7 @@ static int ehci_rebuild_interrupt_schedule(struct ehci_ctrl *ctrl)
 
 static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 			unsigned long pipe, int queuesize, int elementsize,
-			void *buffer, int interval)
+			void *buffer, int interval, int one_shot)
 {
 	struct ehci_ctrl *ctrl = ehci_get_ctrl(dev);
 	struct int_queue *result = NULL;
@@ -1646,6 +1646,16 @@ static struct int_queue *_ehci_create_int_queue(struct usb_device *dev,
 		return NULL;
 	if (ehci_recovery_required)
 		return NULL;
+	if (one_shot) {
+		uint32_t frame_index = ehci_readl(&ctrl->hcor->or_frindex);
+
+		plan.interval_microframes = 8192U;
+		plan.frame_interval = 1024U;
+		plan.frame_phase = (uint16_t)(
+			((frame_index >> 3) + 2U) & 0x3ffU);
+		plan.start_mask = 0x01U;
+		plan.complete_mask = 0;
+	}
 
 	/*
 	 * Each queue element must fit in one transaction and one qTD. Persistent
@@ -1994,7 +2004,8 @@ static int _ehci_submit_int_msg(struct usb_device *dev, unsigned long pipe,
 	unsigned long timeout;
 	int result = 0, ret;
 
-	queue = _ehci_create_int_queue(dev, pipe, 1, length, buffer, interval);
+	queue = _ehci_create_int_queue(dev, pipe, 1, length, buffer, interval,
+				       0);
 	if (!queue)
 		return -1;
 
@@ -2040,10 +2051,11 @@ static int _ehci_submit_int_msg(struct usb_device *dev, unsigned long pipe,
 	return result;
 }
 /*
- * Execute one high-speed interrupt opportunity at microframe zero of the
- * next frame. Unlike a persistent qTD, this retires the queue immediately
- * after a NAK, so software can honor intervals longer than the 1024-frame
- * EHCI list without leaving the endpoint reachable on every list rollover.
+ * Execute one high-speed interrupt opportunity at microframe zero of a
+ * selected near-future frame. Unlike a persistent qTD, this queue is linked
+ * into only that frame-list slot and retires immediately after a NAK, so
+ * software can honor intervals longer than the 1024-frame EHCI list without
+ * exposing the endpoint on adjacent frames or list rollovers.
  */
 static int _ehci_submit_int_msg_once(struct usb_device *dev,
 				     unsigned long pipe,
@@ -2053,17 +2065,16 @@ static int _ehci_submit_int_msg_once(struct usb_device *dev,
 	struct int_queue *queue;
 	void *backbuffer = NULL;
 	unsigned long timeout;
-	uint16_t start_frame;
+	uint16_t target_frame;
 	int result = 0;
 	int ret;
 
 	if (!ctrl || dev->speed != USB_SPEED_HIGH)
 		return -EINVAL;
-	queue = _ehci_create_int_queue(dev, pipe, 1, length, buffer, 4);
+	queue = _ehci_create_int_queue(dev, pipe, 1, length, buffer, 4, 1);
 	if (!queue)
 		return -1;
-	start_frame = (uint16_t)(
-		(ehci_readl(&ctrl->hcor->or_frindex) >> 3) & 0x3ffU);
+	target_frame = queue->plan.frame_phase;
 	timeout = get_timer(0);
 	for (;;) {
 		uint32_t frame_index;
@@ -2072,14 +2083,24 @@ static int _ehci_submit_int_msg_once(struct usb_device *dev,
 		if (backbuffer)
 			break;
 		frame_index = ehci_readl(&ctrl->hcor->or_frindex);
-		if (((frame_index >> 3) & 0x3ffU) != start_frame &&
-		    (frame_index & 7U) != 0U) {
-			dev->status = 0;
-			dev->act_len = 0;
-			break;
+		{
+			uint16_t frame = (uint16_t)(
+				(frame_index >> 3) & 0x3ffU);
+			uint16_t distance = (uint16_t)(
+				(frame - target_frame) & 0x3ffU);
+
+			if ((distance == 0U && (frame_index & 7U) != 0U) ||
+			    (distance > 0U && distance < 512U)) {
+				backbuffer = _ehci_poll_int_queue(dev, queue);
+				if (!backbuffer) {
+					dev->status = 0;
+					dev->act_len = 0;
+				}
+				break;
+			}
 		}
 		if (ehci_deadline_expired_u32((uint32_t)get_timer(0),
-					      (uint32_t)timeout, 3U)) {
+					      (uint32_t)timeout, 5U)) {
 			dev->status = 0;
 			dev->act_len = 0;
 			break;
@@ -2125,7 +2146,7 @@ struct int_queue *create_int_queue(struct usb_device *dev,
 		void *buffer, int interval)
 {
 	return _ehci_create_int_queue(dev, pipe, queuesize, elementsize,
-				      buffer, interval);
+				      buffer, interval, 0);
 }
 
 void *poll_int_queue(struct usb_device *dev, struct int_queue *queue)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.c
@@ -91,10 +91,7 @@ static int frame_has_passed(uint16_t current, uint16_t scheduled)
 static uint8_t packet_status_itd(uint32_t transaction, uint16_t requested,
                                  int direction_in, uint16_t *actual)
 {
-    uint16_t residual = (uint16_t)((transaction >> 16) &
-                                   EHCI_ITD_LENGTH_MASK);
-
-    *actual = residual <= requested ? (uint16_t)(requested - residual) : 0;
+    *actual = ehci_iso_itd_actual(transaction, requested);
     if (transaction & EHCI_ITD_DBE)
         return direction_in ? EHCI_ISO_PACKET_OVERRUN :
                               EHCI_ISO_PACKET_UNDERRUN;
@@ -135,6 +132,7 @@ int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
                       unsigned packet_count, uint8_t *buffer)
 {
     uint16_t current;
+    uint16_t base_distance;
     uint32_t absolute_uframe;
     uint32_t step;
     unsigned packet_index;
@@ -142,7 +140,9 @@ int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
 
     if (!transfer || !ctrl || !config || !packets || !buffer ||
         packet_count == 0 || packet_count > EHCI_ISO_MAX_PACKETS ||
-        config->endpoint == 0 || config->interval == 0)
+        config->endpoint == 0 || config->interval == 0 ||
+        packets[0].frame > EHCI_ISO_FRAME_MASK ||
+        packets[0].microframe > 7U)
         return EHCI_ISO_ERR_INVALID;
     if (config->speed == 3U) {
         if (config->split || config->interval > 16U)
@@ -161,8 +161,17 @@ int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
     transfer->packet_count = (uint8_t)packet_count;
     absolute_uframe = (uint32_t)packets[0].frame * 8U +
                       packets[0].microframe;
+    current = ehci_iso_current_frame(ctrl);
+    base_distance = ehci_iso_frame_distance(packets[0].frame, current);
+    if (!ehci_iso_frame_schedulable(packets[0].frame, current))
+        return EHCI_ISO_ERR_MISSED;
     for (packet_index = 0; packet_index < packet_count; packet_index++) {
         struct ehci_iso_packet *packet = &transfer->packets[packet_index];
+        uint32_t frame_offset =
+            (absolute_uframe >> 3) - packets[0].frame;
+
+        if ((uint32_t)base_distance + frame_offset >= 1024U)
+            return EHCI_ISO_ERR_MISSED;
 
         *packet = packets[packet_index];
         packet->frame = (uint16_t)((absolute_uframe >> 3) &
@@ -173,11 +182,6 @@ int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
         absolute_uframe += step;
     }
 
-    current = ehci_iso_current_frame(ctrl);
-    if (ehci_iso_frame_distance(transfer->packets[0].frame, current) < 4U ||
-        ehci_iso_frame_distance(transfer->packets[0].frame, current) >=
-        1024U)
-        return EHCI_ISO_ERR_MISSED;
 
     for (packet_index = 0; packet_index < packet_count; packet_index++) {
         struct ehci_iso_packet *packet = &transfer->packets[packet_index];

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.c
@@ -137,6 +137,7 @@ int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
     uint32_t step;
     unsigned packet_index;
     int result = EHCI_ISO_ERR_INVALID;
+    int missed;
 
     if (!transfer || !ctrl || !config || !packets || !buffer ||
         packet_count == 0 || packet_count > EHCI_ISO_MAX_PACKETS ||
@@ -163,15 +164,11 @@ int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
                       packets[0].microframe;
     current = ehci_iso_current_frame(ctrl);
     base_distance = ehci_iso_frame_distance(packets[0].frame, current);
-    if (!ehci_iso_frame_schedulable(packets[0].frame, current))
-        return EHCI_ISO_ERR_MISSED;
+    missed = !ehci_iso_frame_schedulable(packets[0].frame, current);
     for (packet_index = 0; packet_index < packet_count; packet_index++) {
         struct ehci_iso_packet *packet = &transfer->packets[packet_index];
         uint32_t frame_offset =
             (absolute_uframe >> 3) - packets[0].frame;
-
-        if ((uint32_t)base_distance + frame_offset >= 1024U)
-            return EHCI_ISO_ERR_MISSED;
 
         *packet = packets[packet_index];
         packet->frame = (uint16_t)((absolute_uframe >> 3) &
@@ -179,7 +176,16 @@ int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
         packet->microframe = (uint8_t)(absolute_uframe & 7U);
         packet->actual = 0;
         packet->status = EHCI_ISO_PACKET_PENDING;
+        if ((uint32_t)base_distance + frame_offset >= 1024U)
+            missed = 1;
         absolute_uframe += step;
+    }
+    if (missed) {
+        for (packet_index = 0; packet_index < packet_count; packet_index++)
+            transfer->packets[packet_index].status =
+                EHCI_ISO_PACKET_MISSED;
+        transfer->complete = 1;
+        return EHCI_ISO_ERR_MISSED;
     }
 
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.c
@@ -1,0 +1,396 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <stdint.h>
+#include <string.h>
+
+#include "ehci.h"
+#include "ehci-iso.h"
+#include "io.h"
+#include "memalign.h"
+
+#define EHCI_ISO_UFRAME_BUDGET 4915U
+
+static uint16_t iso_bandwidth[1024][8];
+
+static uint32_t descriptor_next(union ehci_iso_descriptor *descriptor,
+                                int split)
+{
+    return split ? descriptor->sitd.next : descriptor->itd.next;
+}
+
+static uint32_t descriptor_address(union ehci_iso_descriptor *descriptor)
+{
+    return (uint32_t)(unsigned long)descriptor;
+}
+
+static int reserve_bandwidth(struct ehci_iso_transfer *transfer,
+                             unsigned packet_index, uint16_t frame,
+                             uint8_t mask, uint16_t bytes)
+{
+    unsigned uframe;
+    unsigned slot = frame & EHCI_ISO_LIST_MASK;
+
+    for (uframe = 0; uframe < 8U; uframe++) {
+        if (!(mask & (1U << uframe)))
+            continue;
+        if ((unsigned)iso_bandwidth[slot][uframe] + bytes >
+            EHCI_ISO_UFRAME_BUDGET)
+            return 0;
+    }
+    for (uframe = 0; uframe < 8U; uframe++)
+        if (mask & (1U << uframe))
+            iso_bandwidth[slot][uframe] += bytes;
+    transfer->reserved_masks[packet_index] = mask;
+    transfer->reserved_bytes[packet_index] = bytes;
+    transfer->frame_slots[packet_index] = (uint16_t)slot;
+    return 1;
+}
+
+static void release_bandwidth(struct ehci_iso_transfer *transfer)
+{
+    unsigned packet_index;
+
+    for (packet_index = 0; packet_index < transfer->packet_count;
+         packet_index++) {
+        unsigned uframe;
+        unsigned slot = transfer->frame_slots[packet_index];
+        uint8_t mask = transfer->reserved_masks[packet_index];
+        uint16_t bytes = transfer->reserved_bytes[packet_index];
+
+        for (uframe = 0; uframe < 8U; uframe++) {
+            if (!(mask & (1U << uframe)))
+                continue;
+            if (iso_bandwidth[slot][uframe] >= bytes)
+                iso_bandwidth[slot][uframe] -= bytes;
+            else
+                iso_bandwidth[slot][uframe] = 0;
+        }
+        transfer->reserved_masks[packet_index] = 0;
+        transfer->reserved_bytes[packet_index] = 0;
+    }
+}
+
+void ehci_iso_reset_bandwidth(void)
+{
+    memset(iso_bandwidth, 0, sizeof(iso_bandwidth));
+}
+
+uint16_t ehci_iso_current_frame(struct ehci_ctrl *ctrl)
+{
+    if (!ctrl || !ctrl->hcor)
+        return 0;
+    return (uint16_t)((ehci_readl(&ctrl->hcor->or_frindex) >> 3) &
+                      EHCI_ISO_FRAME_MASK);
+}
+
+static int frame_has_passed(uint16_t current, uint16_t scheduled)
+{
+    uint16_t distance = ehci_iso_frame_distance(current, scheduled);
+    return distance > 0 && distance < 1024U;
+}
+
+static uint8_t packet_status_itd(uint32_t transaction, uint16_t requested,
+                                 int direction_in, uint16_t *actual)
+{
+    uint16_t residual = (uint16_t)((transaction >> 16) &
+                                   EHCI_ITD_LENGTH_MASK);
+
+    *actual = residual <= requested ? (uint16_t)(requested - residual) : 0;
+    if (transaction & EHCI_ITD_DBE)
+        return direction_in ? EHCI_ISO_PACKET_OVERRUN :
+                              EHCI_ISO_PACKET_UNDERRUN;
+    if (transaction & EHCI_ITD_BABBLE)
+        return EHCI_ISO_PACKET_BABBLE;
+    if (transaction & EHCI_ITD_XACTERR)
+        return EHCI_ISO_PACKET_XACT;
+    if (direction_in && *actual < requested)
+        return EHCI_ISO_PACKET_SHORT;
+    return EHCI_ISO_PACKET_OK;
+}
+
+static uint8_t packet_status_sitd(uint32_t results, uint16_t requested,
+                                  int direction_in, uint16_t *actual)
+{
+    uint16_t residual = (uint16_t)((results >> 16) &
+                                   EHCI_SITD_LENGTH_MASK);
+
+    *actual = residual <= requested ? (uint16_t)(requested - residual) : 0;
+    if (results & EHCI_SITD_MISSED)
+        return EHCI_ISO_PACKET_MISSED;
+    if (results & EHCI_SITD_DBE)
+        return direction_in ? EHCI_ISO_PACKET_OVERRUN :
+                              EHCI_ISO_PACKET_UNDERRUN;
+    if (results & EHCI_SITD_BABBLE)
+        return EHCI_ISO_PACKET_BABBLE;
+    if (results & (EHCI_SITD_XACTERR | EHCI_SITD_ERR))
+        return EHCI_ISO_PACKET_XACT;
+    if (direction_in && *actual < requested)
+        return EHCI_ISO_PACKET_SHORT;
+    return EHCI_ISO_PACKET_OK;
+}
+
+int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
+                      struct ehci_ctrl *ctrl,
+                      const struct ehci_iso_config *config,
+                      struct ehci_iso_packet *packets,
+                      unsigned packet_count, uint8_t *buffer)
+{
+    uint16_t current;
+    uint32_t absolute_uframe;
+    uint32_t step;
+    unsigned packet_index;
+    int result = EHCI_ISO_ERR_INVALID;
+
+    if (!transfer || !ctrl || !config || !packets || !buffer ||
+        packet_count == 0 || packet_count > EHCI_ISO_MAX_PACKETS ||
+        config->endpoint == 0 || config->interval == 0)
+        return EHCI_ISO_ERR_INVALID;
+    if (config->speed == 3U) {
+        if (config->split || config->interval > 16U)
+            return EHCI_ISO_ERR_INVALID;
+        step = 1U << (config->interval - 1U);
+    } else {
+        if (!config->split || config->speed != 2U ||
+            config->interval > 16U)
+            return EHCI_ISO_ERR_INVALID;
+        step = (uint32_t)(1U << (config->interval - 1U)) * 8U;
+    }
+
+    memset(transfer, 0, sizeof(*transfer));
+    transfer->ctrl = ctrl;
+    transfer->config = *config;
+    transfer->packet_count = (uint8_t)packet_count;
+    absolute_uframe = (uint32_t)packets[0].frame * 8U +
+                      packets[0].microframe;
+    for (packet_index = 0; packet_index < packet_count; packet_index++) {
+        struct ehci_iso_packet *packet = &transfer->packets[packet_index];
+
+        *packet = packets[packet_index];
+        packet->frame = (uint16_t)((absolute_uframe >> 3) &
+                                   EHCI_ISO_FRAME_MASK);
+        packet->microframe = (uint8_t)(absolute_uframe & 7U);
+        packet->actual = 0;
+        packet->status = EHCI_ISO_PACKET_PENDING;
+        absolute_uframe += step;
+    }
+
+    current = ehci_iso_current_frame(ctrl);
+    if (ehci_iso_frame_distance(transfer->packets[0].frame, current) < 4U ||
+        ehci_iso_frame_distance(transfer->packets[0].frame, current) >=
+        1024U)
+        return EHCI_ISO_ERR_MISSED;
+
+    for (packet_index = 0; packet_index < packet_count; packet_index++) {
+        struct ehci_iso_packet *packet = &transfer->packets[packet_index];
+        uint8_t smask = 0;
+        uint8_t cmask = 0;
+        uint8_t reservation_mask;
+        uint16_t reservation_bytes;
+
+        if (config->split) {
+            if (!ehci_iso_split_masks(
+                    packet->requested, config->direction_in,
+                    config->tt_think_time, config->multi_tt,
+                    config->endpoint + config->hub_port,
+                    &smask, &cmask))
+                goto fail;
+            reservation_mask = (uint8_t)(smask | cmask);
+            reservation_bytes = packet->requested > 188U ?
+                                188U : packet->requested;
+            if (!reservation_bytes)
+                reservation_bytes = 1;
+        } else {
+            reservation_mask = (uint8_t)(1U << packet->microframe);
+            reservation_bytes = packet->requested ? packet->requested : 1;
+        }
+        if (!reserve_bandwidth(transfer, packet_index, packet->frame,
+                               reservation_mask, reservation_bytes)) {
+            result = EHCI_ISO_ERR_BANDWIDTH;
+            goto fail;
+        }
+    }
+
+    if (ehci_periodic_schedule_pause(ctrl) < 0) {
+        result = EHCI_ISO_ERR_TIMEOUT;
+        goto fail;
+    }
+
+    for (packet_index = 0; packet_index < packet_count; packet_index++) {
+        struct ehci_iso_packet *packet = &transfer->packets[packet_index];
+        union ehci_iso_descriptor *descriptor =
+            &transfer->descriptors[packet_index];
+        uint16_t slot = transfer->frame_slots[packet_index];
+        uint32_t next = ctrl->periodic_list[slot];
+        uint32_t address = (uint32_t)(unsigned long)(buffer + packet->offset);
+        int built;
+
+        if (config->split) {
+            uint8_t smask = 0;
+            uint8_t cmask = 0;
+            ehci_iso_split_masks(packet->requested, config->direction_in,
+                                 config->tt_think_time, config->multi_tt,
+                                 config->endpoint + config->hub_port,
+                                 &smask, &cmask);
+            built = ehci_iso_build_sitd(&descriptor->sitd, config,
+                                        address, packet->requested,
+                                        smask, cmask, next);
+        } else {
+            built = ehci_iso_build_itd(&descriptor->itd, config, address,
+                                       packet->requested,
+                                       packet->microframe, next);
+        }
+        if (!built) {
+            result = EHCI_ISO_ERR_INVALID;
+            goto unlink_partial;
+        }
+        flush_dcache_range((unsigned long)descriptor,
+                           ALIGN_END_ADDR(union ehci_iso_descriptor,
+                                          descriptor, 1));
+        ctrl->periodic_list[slot] =
+            descriptor_address(descriptor) |
+            (config->split ? EHCI_ISO_LINK_SITD : EHCI_ISO_LINK_ITD);
+        flush_dcache_range((unsigned long)&ctrl->periodic_list[slot],
+                           ALIGN_END_ADDR(uint32_t,
+                                          &ctrl->periodic_list[slot], 1));
+    }
+    if (config->direction_in)
+        invalidate_dcache_range((unsigned long)buffer,
+            ALIGN_END_ADDR(char, buffer,
+                           packets[packet_count - 1].offset +
+                           packets[packet_count - 1].requested));
+    else
+        flush_dcache_range((unsigned long)buffer,
+            ALIGN_END_ADDR(char, buffer,
+                           packets[packet_count - 1].offset +
+                           packets[packet_count - 1].requested));
+
+    transfer->linked = 1;
+    if (ehci_periodic_schedule_resume(ctrl, 1) < 0)
+        return EHCI_ISO_ERR_TIMEOUT;
+    return 0;
+
+unlink_partial:
+    transfer->linked = 1;
+    ehci_periodic_schedule_resume(ctrl, 1);
+    ehci_iso_retire(transfer, EHCI_ISO_PACKET_CANCELLED);
+    return result;
+
+fail:
+    release_bandwidth(transfer);
+    memset(transfer, 0, sizeof(*transfer));
+    return result;
+}
+
+int ehci_iso_poll(struct ehci_iso_transfer *transfer)
+{
+    uint16_t current;
+    unsigned packet_index;
+    unsigned pending = 0;
+
+    if (!transfer || !transfer->linked)
+        return EHCI_ISO_ERR_INVALID;
+    current = ehci_iso_current_frame(transfer->ctrl);
+    for (packet_index = 0; packet_index < transfer->packet_count;
+         packet_index++) {
+        struct ehci_iso_packet *packet = &transfer->packets[packet_index];
+        union ehci_iso_descriptor *descriptor =
+            &transfer->descriptors[packet_index];
+        uint32_t state;
+
+        if (packet->status != EHCI_ISO_PACKET_PENDING)
+            continue;
+        invalidate_dcache_range((unsigned long)descriptor,
+            ALIGN_END_ADDR(union ehci_iso_descriptor, descriptor, 1));
+        if (transfer->config.split) {
+            state = descriptor->sitd.results;
+            if (state & EHCI_SITD_ACTIVE) {
+                if (frame_has_passed(current, packet->frame))
+                    packet->status = EHCI_ISO_PACKET_MISSED;
+                else
+                    pending++;
+                continue;
+            }
+            packet->status = packet_status_sitd(
+                state, packet->requested, transfer->config.direction_in,
+                &packet->actual);
+        } else {
+            state = descriptor->itd.transaction[packet->microframe];
+            if (state & EHCI_ITD_ACTIVE) {
+                if (frame_has_passed(current, packet->frame))
+                    packet->status = EHCI_ISO_PACKET_MISSED;
+                else
+                    pending++;
+                continue;
+            }
+            packet->status = packet_status_itd(
+                state, packet->requested, transfer->config.direction_in,
+                &packet->actual);
+        }
+    }
+    if (pending)
+        return 0;
+    transfer->complete = 1;
+    return 1;
+}
+
+static int unlink_descriptor(struct ehci_iso_transfer *transfer,
+                             unsigned packet_index)
+{
+    uint16_t slot = transfer->frame_slots[packet_index];
+    uint32_t target = descriptor_address(
+        &transfer->descriptors[packet_index]);
+    uint32_t *link = &transfer->ctrl->periodic_list[slot];
+    unsigned guard = 0;
+
+    while (guard++ < 128U) {
+        uint32_t value = *link;
+        uint32_t type;
+        uint32_t address;
+
+        if (value & EHCI_ISO_LINK_TERMINATE)
+            return 0;
+        type = value & EHCI_ISO_LINK_TYPE_MASK;
+        if (type != EHCI_ISO_LINK_ITD && type != EHCI_ISO_LINK_SITD)
+            return 0;
+        address = value & ~0x1fU;
+        if (address == target) {
+            *link = descriptor_next(&transfer->descriptors[packet_index],
+                                    transfer->config.split);
+            flush_dcache_range((unsigned long)link,
+                               ALIGN_END_ADDR(uint32_t, link, 1));
+            return 1;
+        }
+        link = (uint32_t *)(unsigned long)address;
+        invalidate_dcache_range((unsigned long)link,
+                                ALIGN_END_ADDR(uint32_t, link, 1));
+    }
+    return 0;
+}
+
+int ehci_iso_retire(struct ehci_iso_transfer *transfer,
+                    uint8_t unfinished_status)
+{
+    unsigned packet_index;
+    int resume_result;
+
+    if (!transfer)
+        return EHCI_ISO_ERR_INVALID;
+    if (!transfer->linked) {
+        release_bandwidth(transfer);
+        return 0;
+    }
+    if (ehci_periodic_schedule_pause(transfer->ctrl) < 0)
+        return EHCI_ISO_ERR_TIMEOUT;
+    for (packet_index = 0; packet_index < transfer->packet_count;
+         packet_index++)
+        unlink_descriptor(transfer, packet_index);
+    resume_result = ehci_periodic_schedule_resume(transfer->ctrl, -1);
+    release_bandwidth(transfer);
+    transfer->linked = 0;
+    for (packet_index = 0; packet_index < transfer->packet_count;
+         packet_index++) {
+        if (transfer->packets[packet_index].status ==
+            EHCI_ISO_PACKET_PENDING)
+            transfer->packets[packet_index].status = unfinished_status;
+    }
+    return resume_result;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.c
@@ -4,12 +4,15 @@
 
 #include "ehci.h"
 #include "ehci-iso.h"
+#include "ehci_periodic.h"
 #include "io.h"
 #include "memalign.h"
 
 #define EHCI_ISO_UFRAME_BUDGET 4915U
 
 static uint16_t iso_bandwidth[1024][8];
+static int unlink_descriptor(struct ehci_iso_transfer *transfer,
+                             unsigned packet_index);
 
 static uint32_t descriptor_next(union ehci_iso_descriptor *descriptor,
                                 int split)
@@ -72,6 +75,56 @@ static void release_bandwidth(struct ehci_iso_transfer *transfer)
 void ehci_iso_reset_bandwidth(void)
 {
     memset(iso_bandwidth, 0, sizeof(iso_bandwidth));
+}
+
+int ehci_periodic_reserve_bandwidth(
+    const struct ehci_periodic_plan *plan, uint8_t mask, uint16_t bytes)
+{
+    unsigned frame;
+    unsigned uframe;
+
+    if (!plan || !mask || !bytes)
+        return 0;
+    for (frame = 0; frame < 1024U; frame++) {
+        if (!ehci_periodic_frame_due(plan, (uint16_t)frame))
+            continue;
+        for (uframe = 0; uframe < 8U; uframe++) {
+            if ((mask & (1U << uframe)) &&
+                (unsigned)iso_bandwidth[frame][uframe] + bytes >
+                    EHCI_ISO_UFRAME_BUDGET)
+                return 0;
+        }
+    }
+    for (frame = 0; frame < 1024U; frame++) {
+        if (!ehci_periodic_frame_due(plan, (uint16_t)frame))
+            continue;
+        for (uframe = 0; uframe < 8U; uframe++)
+            if (mask & (1U << uframe))
+                iso_bandwidth[frame][uframe] += bytes;
+    }
+    return 1;
+}
+
+void ehci_periodic_release_bandwidth(
+    const struct ehci_periodic_plan *plan, uint8_t mask, uint16_t bytes)
+{
+    unsigned frame;
+    unsigned uframe;
+
+    if (!plan || !mask || !bytes)
+        return;
+    for (frame = 0; frame < 1024U; frame++) {
+        if (!ehci_periodic_frame_due(plan, (uint16_t)frame))
+            continue;
+        for (uframe = 0; uframe < 8U; uframe++) {
+            if (!(mask & (1U << uframe)))
+                continue;
+            if (iso_bandwidth[frame][uframe] >= bytes)
+                iso_bandwidth[frame][uframe] -= bytes;
+            else
+                iso_bandwidth[frame][uframe] = 0;
+        }
+    }
 }
 
 uint16_t ehci_iso_current_frame(struct ehci_ctrl *ctrl)
@@ -219,10 +272,6 @@ int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
         }
     }
 
-    if (ehci_periodic_schedule_pause(ctrl) < 0) {
-        result = EHCI_ISO_ERR_TIMEOUT;
-        goto fail;
-    }
 
     for (packet_index = 0; packet_index < packet_count; packet_index++) {
         struct ehci_iso_packet *packet = &transfer->packets[packet_index];
@@ -279,9 +328,12 @@ int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
     return 0;
 
 unlink_partial:
-    transfer->linked = 1;
-    ehci_periodic_schedule_resume(ctrl, 1);
-    ehci_iso_retire(transfer, EHCI_ISO_PACKET_CANCELLED);
+    while (packet_index > 0) {
+        packet_index--;
+        unlink_descriptor(transfer, packet_index);
+    }
+    release_bandwidth(transfer);
+    memset(transfer, 0, sizeof(*transfer));
     return result;
 
 fail:
@@ -381,14 +433,22 @@ int ehci_iso_retire(struct ehci_iso_transfer *transfer,
 {
     unsigned packet_index;
     int resume_result;
-
+    int has_pending = 0;
     if (!transfer)
         return EHCI_ISO_ERR_INVALID;
     if (!transfer->linked) {
         release_bandwidth(transfer);
         return 0;
     }
-    if (ehci_periodic_schedule_pause(transfer->ctrl) < 0)
+    for (packet_index = 0; packet_index < transfer->packet_count;
+         packet_index++)
+        if (transfer->packets[packet_index].status ==
+            EHCI_ISO_PACKET_PENDING) {
+            has_pending = 1;
+            break;
+        }
+    if ((has_pending || transfer->ctrl->periodic_schedules == 1) &&
+        ehci_periodic_schedule_pause(transfer->ctrl) < 0)
         return EHCI_ISO_ERR_TIMEOUT;
     for (packet_index = 0; packet_index < transfer->packet_count;
          packet_index++)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.h
@@ -1,0 +1,228 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef ZZUSB_EHCI_ISO_H
+#define ZZUSB_EHCI_ISO_H
+
+#include <stdint.h>
+#include <string.h>
+
+#define EHCI_ISO_MAX_PACKETS 32U
+#define EHCI_ISO_FRAME_MASK  0x07ffU
+#define EHCI_ISO_LIST_MASK   0x03ffU
+#define EHCI_ISO_LINK_TERMINATE 0x00000001U
+#define EHCI_ISO_LINK_TYPE_MASK 0x00000006U
+#define EHCI_ISO_LINK_ITD    0x00000000U
+#define EHCI_ISO_LINK_SITD   0x00000004U
+#define EHCI_ISO_LINK_QH     0x00000002U
+
+#define EHCI_ISO_ERR_INVALID   (-1)
+#define EHCI_ISO_ERR_MISSED    (-2)
+#define EHCI_ISO_ERR_BANDWIDTH (-3)
+#define EHCI_ISO_ERR_TIMEOUT   (-4)
+
+#define EHCI_ITD_ACTIVE      (1U << 31)
+#define EHCI_ITD_DBE         (1U << 30)
+#define EHCI_ITD_BABBLE      (1U << 29)
+#define EHCI_ITD_XACTERR     (1U << 28)
+#define EHCI_ITD_IOC         (1U << 15)
+#define EHCI_ITD_LENGTH_MASK 0x0fffU
+
+#define EHCI_SITD_IOC        (1U << 31)
+#define EHCI_SITD_ACTIVE     (1U << 7)
+#define EHCI_SITD_ERR        (1U << 6)
+#define EHCI_SITD_DBE        (1U << 5)
+#define EHCI_SITD_BABBLE     (1U << 4)
+#define EHCI_SITD_XACTERR    (1U << 3)
+#define EHCI_SITD_MISSED     (1U << 2)
+#define EHCI_SITD_LENGTH_MASK 0x03ffU
+
+#define EHCI_ISO_PACKET_OK        0U
+#define EHCI_ISO_PACKET_PENDING   1U
+#define EHCI_ISO_PACKET_SHORT     2U
+#define EHCI_ISO_PACKET_MISSED    3U
+#define EHCI_ISO_PACKET_UNDERRUN  4U
+#define EHCI_ISO_PACKET_OVERRUN   5U
+#define EHCI_ISO_PACKET_CANCELLED 6U
+#define EHCI_ISO_PACKET_OFFLINE   7U
+#define EHCI_ISO_PACKET_XACT      8U
+#define EHCI_ISO_PACKET_BABBLE    9U
+
+struct ehci_iso_itd {
+    uint32_t next;
+    uint32_t transaction[8];
+    uint32_t buffer[7];
+} __attribute__((aligned(32)));
+
+struct ehci_ctrl;
+
+struct ehci_iso_sitd {
+    uint32_t next;
+    uint32_t endpoint;
+    uint32_t uframe;
+    uint32_t results;
+    uint32_t buffer[2];
+    uint32_t back;
+    uint32_t reserved;
+} __attribute__((aligned(32)));
+
+union ehci_iso_descriptor {
+    struct ehci_iso_itd itd;
+    struct ehci_iso_sitd sitd;
+} __attribute__((aligned(32)));
+
+struct ehci_iso_config {
+    uint8_t address;
+    uint8_t endpoint;
+    uint8_t direction_in;
+    uint8_t speed;
+    uint8_t split;
+    uint8_t multi_tt;
+    uint8_t tt_think_time;
+    uint8_t interval;
+    uint8_t hub_address;
+    uint8_t hub_port;
+    uint16_t max_packet;
+};
+
+struct ehci_iso_packet {
+    uint32_t offset;
+    uint16_t requested;
+    uint16_t actual;
+    uint16_t frame;
+    uint8_t microframe;
+    uint8_t status;
+};
+
+struct ehci_iso_transfer {
+    struct ehci_ctrl *ctrl;
+    struct ehci_iso_config config;
+    struct ehci_iso_packet packets[EHCI_ISO_MAX_PACKETS];
+    union ehci_iso_descriptor descriptors[EHCI_ISO_MAX_PACKETS];
+    uint16_t reserved_bytes[EHCI_ISO_MAX_PACKETS];
+    uint16_t frame_slots[EHCI_ISO_MAX_PACKETS];
+    uint8_t reserved_masks[EHCI_ISO_MAX_PACKETS];
+    uint8_t packet_count;
+    uint8_t linked;
+    uint8_t complete;
+};
+
+static inline uint16_t ehci_iso_frame_distance(uint16_t future,
+                                                uint16_t current)
+{
+    return (uint16_t)((future - current) & EHCI_ISO_FRAME_MASK);
+}
+
+static inline int ehci_iso_split_masks(uint16_t length, int direction_in,
+                                       unsigned think_time, int multi_tt,
+                                       unsigned seed, uint8_t *smask,
+                                       uint8_t *cmask)
+{
+    unsigned transactions;
+    unsigned start = (multi_tt && think_time < 3U) ? (seed & 1U) : 0U;
+
+    if (!smask || !cmask || length > 1023U || think_time > 3U)
+        return 0;
+    transactions = (length + 187U) / 188U;
+    if (transactions == 0)
+        transactions = 1;
+    if (transactions > 6U)
+        return 0;
+
+    if (!direction_in) {
+        if (start + transactions > 6U)
+            start = 0;
+        *smask = (uint8_t)(((1U << transactions) - 1U) << start);
+        *cmask = 0;
+        return 1;
+    }
+
+    *smask = (uint8_t)(1U << start);
+    start += 2U + think_time;
+    if (start > 5U)
+        return 0;
+    transactions += 2U;
+    if (transactions > 8U - start)
+        transactions = 8U - start;
+    *cmask = (uint8_t)(((1U << transactions) - 1U) << start);
+    return transactions >= 3U;
+}
+
+static inline int ehci_iso_build_itd(struct ehci_iso_itd *itd,
+                                     const struct ehci_iso_config *config,
+                                     uint32_t buffer_address,
+                                     uint16_t length, uint8_t microframe,
+                                     uint32_t next)
+{
+    uint32_t page;
+    uint32_t base_packet;
+    uint32_t multiplier;
+
+    if (!itd || !config || microframe > 7U)
+        return 0;
+    base_packet = config->max_packet & 0x07ffU;
+    multiplier = 1U + ((config->max_packet >> 11) & 0x03U);
+    if (!base_packet || multiplier > 3U ||
+        length > base_packet * multiplier)
+        return 0;
+
+    memset(itd, 0, sizeof(*itd));
+    page = buffer_address & 0xfffff000U;
+    itd->next = next;
+    itd->transaction[microframe] = EHCI_ITD_ACTIVE | EHCI_ITD_IOC |
+        ((uint32_t)length << 16) | (buffer_address & 0x0fffU);
+    itd->buffer[0] = page | (config->address & 0x7fU) |
+                     ((uint32_t)(config->endpoint & 0x0fU) << 8);
+    itd->buffer[1] = (page + 0x1000U) | base_packet;
+    itd->buffer[2] = (page + 0x2000U) |
+                     (config->direction_in ? (1U << 11) : 0U) |
+                     multiplier;
+    for (unsigned index = 3; index < 7; index++)
+        itd->buffer[index] = page + index * 0x1000U;
+    return 1;
+}
+
+static inline int ehci_iso_build_sitd(struct ehci_iso_sitd *sitd,
+                                      const struct ehci_iso_config *config,
+                                      uint32_t buffer_address,
+                                      uint16_t length, uint8_t smask,
+                                      uint8_t cmask, uint32_t next)
+{
+    unsigned transactions;
+
+    if (!sitd || !config || length > 1023U || !smask)
+        return 0;
+    memset(sitd, 0, sizeof(*sitd));
+    sitd->next = next;
+    sitd->endpoint = (config->address & 0x7fU) |
+        ((uint32_t)(config->endpoint & 0x0fU) << 8) |
+        ((uint32_t)(config->hub_address & 0x7fU) << 16) |
+        ((uint32_t)(config->hub_port & 0x7fU) << 24) |
+        (config->direction_in ? (1U << 31) : 0U);
+    sitd->uframe = smask | ((uint32_t)cmask << 8);
+    sitd->results = EHCI_SITD_IOC | EHCI_SITD_ACTIVE |
+                    ((uint32_t)length << 16);
+    sitd->buffer[0] = buffer_address;
+    sitd->buffer[1] = (buffer_address + length) & 0xfffff000U;
+    if (!config->direction_in) {
+        transactions = (length + 187U) / 188U;
+        if (!transactions)
+            transactions = 1;
+        sitd->buffer[1] |= transactions;
+        if (transactions > 1U)
+            sitd->buffer[1] |= 1U << 3;
+    }
+    sitd->back = EHCI_ISO_LINK_TERMINATE;
+    return 1;
+}
+
+uint16_t ehci_iso_current_frame(struct ehci_ctrl *ctrl);
+int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
+                      struct ehci_ctrl *ctrl,
+                      const struct ehci_iso_config *config,
+                      struct ehci_iso_packet *packets,
+                      unsigned packet_count, uint8_t *buffer);
+int ehci_iso_poll(struct ehci_iso_transfer *transfer);
+int ehci_iso_retire(struct ehci_iso_transfer *transfer,
+                    uint8_t unfinished_status);
+void ehci_iso_reset_bandwidth(void);
+
+#endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.h
@@ -111,6 +111,23 @@ static inline uint16_t ehci_iso_frame_distance(uint16_t future,
     return (uint16_t)((future - current) & EHCI_ISO_FRAME_MASK);
 }
 
+static inline int ehci_iso_frame_schedulable(uint16_t future,
+                                              uint16_t current)
+{
+    uint16_t distance = ehci_iso_frame_distance(future, current);
+
+    return distance >= 4U && distance < 1024U;
+}
+
+static inline uint16_t ehci_iso_itd_actual(uint32_t transaction,
+                                           uint16_t requested)
+{
+    uint16_t transferred = (uint16_t)((transaction >> 16) &
+                                      EHCI_ITD_LENGTH_MASK);
+
+    return transferred <= requested ? transferred : 0;
+}
+
 static inline int ehci_iso_split_masks(uint16_t length, int direction_in,
                                        unsigned think_time, int multi_tt,
                                        unsigned seed, uint8_t *smask,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci-iso.h
@@ -53,6 +53,7 @@ struct ehci_iso_itd {
 } __attribute__((aligned(32)));
 
 struct ehci_ctrl;
+struct ehci_periodic_plan;
 
 struct ehci_iso_sitd {
     uint32_t next;
@@ -241,5 +242,9 @@ int ehci_iso_poll(struct ehci_iso_transfer *transfer);
 int ehci_iso_retire(struct ehci_iso_transfer *transfer,
                     uint8_t unfinished_status);
 void ehci_iso_reset_bandwidth(void);
+int ehci_periodic_reserve_bandwidth(
+    const struct ehci_periodic_plan *plan, uint8_t mask, uint16_t bytes);
+void ehci_periodic_release_bandwidth(
+    const struct ehci_periodic_plan *plan, uint8_t mask, uint16_t bytes);
 
 #endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci.h
@@ -330,6 +330,8 @@ int ehci_controller_needs_recovery(void);
 int ehci_controller_recover(void);
 int ehci_periodic_schedule_pause(struct ehci_ctrl *ctrl);
 int ehci_periodic_schedule_resume(struct ehci_ctrl *ctrl, int delta);
+int submit_int_msg_once(struct usb_device *dev, unsigned long pipe,
+			void *buffer, int transfer_len);
 struct int_queue *create_int_queue(struct usb_device *dev,
 		unsigned long pipe, int queuesize, int elementsize,
 		void *buffer, int interval);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci.h
@@ -49,6 +49,7 @@ struct ehci_hcor {
 #define STS_ASS		(1 << 15)
 #define	STS_PSS		(1 << 14)
 #define STS_HALT	(1 << 12)
+#define STS_IAA		(1 << 5)
 #define STS_RUNNING	(1 << 4)
 	uint32_t or_usbintr;
 #define INTR_UE         (1 << 0)                /* USB interrupt enable */
@@ -325,5 +326,15 @@ int ehci_submit_async(struct usb_device *dev, unsigned long pipe,
 int ehci_submit_async_timeout(struct usb_device *dev, unsigned long pipe,
 		      void *buffer, int length, struct devrequest *req,
 		      unsigned long timeout_ms);
+int ehci_controller_needs_recovery(void);
+int ehci_controller_recover(void);
+int ehci_periodic_schedule_pause(struct ehci_ctrl *ctrl);
+int ehci_periodic_schedule_resume(struct ehci_ctrl *ctrl, int delta);
+struct int_queue *create_int_queue(struct usb_device *dev,
+		unsigned long pipe, int queuesize, int elementsize,
+		void *buffer, int interval);
+void *poll_int_queue(struct usb_device *dev, struct int_queue *queue);
+int rearm_int_queue(struct usb_device *dev, struct int_queue *queue);
+int destroy_int_queue(struct usb_device *dev, struct int_queue *queue);
 
 #endif /* USB_EHCI_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_lifecycle.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_lifecycle.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0+ */
+#ifndef ZZ9000_EHCI_LIFECYCLE_H
+#define ZZ9000_EHCI_LIFECYCLE_H
+
+#include <stdint.h>
+
+/* Unsigned subtraction keeps deadlines correct across a 32-bit wrap. */
+static inline int ehci_deadline_expired_u32(uint32_t now, uint32_t start,
+                                            uint32_t duration)
+{
+    return (uint32_t)(now - start) >= duration;
+}
+
+/* DMA memory is reusable only after hardware can no longer reference it. */
+static inline int ehci_dma_reclaimable(int unlink_acknowledged,
+                                       int schedule_stopped,
+                                       int controller_reset)
+{
+    return unlink_acknowledged || schedule_stopped || controller_reset;
+}
+
+#endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_lifecycle.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_lifecycle.h
@@ -11,6 +11,12 @@ static inline int ehci_deadline_expired_u32(uint32_t now, uint32_t start,
     return (uint32_t)(now - start) >= duration;
 }
 
+/* Signed subtraction handles absolute deadlines less than 2^31 ms away. */
+static inline int ehci_deadline_reached_u32(uint32_t now, uint32_t deadline)
+{
+    return (int32_t)(now - deadline) >= 0;
+}
+
 /* DMA memory is reusable only after hardware can no longer reference it. */
 static inline int ehci_dma_reclaimable(int unlink_acknowledged,
                                        int schedule_stopped,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
@@ -11,6 +11,7 @@
 struct ehci_periodic_plan {
     uint32_t interval_microframes;
     uint16_t frame_interval;
+    uint16_t frame_phase;
     uint8_t start_mask;
     uint8_t complete_mask;
 };
@@ -27,7 +28,10 @@ static inline uint16_t ehci_periodic_hardware_frame_interval(
 static inline int ehci_periodic_frame_due(
     const struct ehci_periodic_plan *plan, uint16_t frame)
 {
-    return frame % ehci_periodic_hardware_frame_interval(plan) == 0;
+    uint16_t interval = ehci_periodic_hardware_frame_interval(plan);
+    uint16_t phase = plan ? (uint16_t)(plan->frame_phase % interval) : 0;
+
+    return (uint16_t)((frame + interval - phase) % interval) == 0;
 }
 
 static inline int ehci_periodic_build_plan(
@@ -40,6 +44,7 @@ static inline int ehci_periodic_build_plan(
 
     if (!plan || interval == 0)
         return 0;
+    plan->frame_phase = 0;
 
     if (speed == EHCI_PERIODIC_SPEED_HIGH) {
         if (interval > 16U || split)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
@@ -16,6 +16,16 @@ struct ehci_periodic_plan {
     uint8_t complete_mask;
 };
 
+/*
+ * A timed-out transient QH can still reference its endpoint-owned buffer
+ * until controller recovery removes every quarantined descriptor.
+ */
+static inline int ehci_periodic_buffer_reclaimable(
+    int controller_recovery_pending)
+{
+    return !controller_recovery_pending;
+}
+
 static inline uint16_t ehci_periodic_hardware_frame_interval(
     const struct ehci_periodic_plan *plan)
 {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef ZZUSB_EHCI_PERIODIC_H
+#define ZZUSB_EHCI_PERIODIC_H
+
+#include <stdint.h>
+
+#define EHCI_PERIODIC_SPEED_LOW  1U
+#define EHCI_PERIODIC_SPEED_FULL 2U
+#define EHCI_PERIODIC_SPEED_HIGH 3U
+
+struct ehci_periodic_plan {
+    uint32_t interval_microframes;
+    uint16_t frame_interval;
+    uint8_t start_mask;
+    uint8_t complete_mask;
+};
+
+static inline int ehci_periodic_build_plan(
+    unsigned speed, unsigned interval, int split,
+    unsigned think_time, int multi_tt, unsigned slot_seed,
+    struct ehci_periodic_plan *plan)
+{
+    uint32_t microframes;
+    uint8_t start = 0;
+
+    if (!plan || interval == 0)
+        return 0;
+
+    if (speed == EHCI_PERIODIC_SPEED_HIGH) {
+        if (interval > 16U || split)
+            return 0;
+        microframes = 1UL << (interval - 1U);
+        plan->interval_microframes = microframes;
+        plan->frame_interval = (uint16_t)(
+            microframes > 8U ? microframes / 8U : 1U);
+        plan->complete_mask = 0;
+        if (microframes >= 8U) {
+            plan->start_mask = 0x01U;
+        } else {
+            uint8_t mask = 0;
+            for (unsigned uframe = 0; uframe < 8U;
+                 uframe += microframes)
+                mask |= (uint8_t)(1U << uframe);
+            plan->start_mask = mask;
+        }
+        return 1;
+    }
+
+    if ((speed != EHCI_PERIODIC_SPEED_LOW &&
+         speed != EHCI_PERIODIC_SPEED_FULL) || interval > 255U)
+        return 0;
+
+    plan->interval_microframes = interval * 8U;
+    plan->frame_interval = (uint16_t)interval;
+    plan->complete_mask = 0;
+    if (!split) {
+        plan->start_mask = 0x01U;
+        return 1;
+    }
+    if (think_time > 3U)
+        return 0;
+
+    if (multi_tt && think_time < 3U)
+        start = (uint8_t)(slot_seed & 1U);
+    plan->start_mask = (uint8_t)(1U << start);
+    start = (uint8_t)(start + 2U + think_time);
+    if (start > 5U)
+        return 0;
+    plan->complete_mask = (uint8_t)(0x07U << start);
+    return 1;
+}
+
+#endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
@@ -23,6 +23,13 @@ static inline uint16_t ehci_periodic_hardware_frame_interval(
     return plan->frame_interval > 1024U ? 1024U :
                                              plan->frame_interval;
 }
+static inline uint8_t ehci_periodic_frame_list_cycles(
+    const struct ehci_periodic_plan *plan)
+{
+    if (!plan || plan->frame_interval <= 1024U)
+        return 1U;
+    return (uint8_t)(plan->frame_interval / 1024U);
+}
 
 static inline int ehci_periodic_frame_due(
     const struct ehci_periodic_plan *plan, uint16_t frame)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
@@ -15,6 +15,21 @@ struct ehci_periodic_plan {
     uint8_t complete_mask;
 };
 
+static inline uint16_t ehci_periodic_hardware_frame_interval(
+    const struct ehci_periodic_plan *plan)
+{
+    if (!plan || plan->frame_interval == 0)
+        return 1U;
+    return plan->frame_interval > 1024U ? 1024U :
+                                             plan->frame_interval;
+}
+
+static inline int ehci_periodic_frame_due(
+    const struct ehci_periodic_plan *plan, uint16_t frame)
+{
+    return frame % ehci_periodic_hardware_frame_interval(plan) == 0;
+}
+
 static inline int ehci_periodic_build_plan(
     unsigned speed, unsigned interval, int split,
     unsigned think_time, int multi_tt, unsigned slot_seed,
@@ -50,8 +65,12 @@ static inline int ehci_periodic_build_plan(
          speed != EHCI_PERIODIC_SPEED_FULL) || interval > 255U)
         return 0;
 
-    plan->interval_microframes = interval * 8U;
-    plan->frame_interval = (uint16_t)interval;
+    plan->frame_interval = 1U;
+    while ((uint32_t)plan->frame_interval * 2U <= interval &&
+           plan->frame_interval < 1024U)
+        plan->frame_interval = (uint16_t)(plan->frame_interval * 2U);
+    plan->interval_microframes =
+        (uint32_t)plan->frame_interval * 8U;
     plan->complete_mask = 0;
     if (!split) {
         plan->start_mask = 0x01U;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/ehci_periodic.h
@@ -23,13 +23,6 @@ static inline uint16_t ehci_periodic_hardware_frame_interval(
     return plan->frame_interval > 1024U ? 1024U :
                                              plan->frame_interval;
 }
-static inline uint8_t ehci_periodic_frame_list_cycles(
-    const struct ehci_periodic_plan *plan)
-{
-    if (!plan || plan->frame_interval <= 1024U)
-        return 1U;
-    return (uint8_t)(plan->frame_interval / 1024U);
-}
 
 static inline int ehci_periodic_frame_due(
     const struct ehci_periodic_plan *plan, uint16_t frame)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/usb.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/usb.h
@@ -150,6 +150,8 @@ struct usb_device {
 	int portnr;			/* Port number, 1=first */
 	/* parent hub, or NULL if this is the root hub */
 	struct usb_device *parent;
+	unsigned char tt_think_time;
+	unsigned char tt_multi;
 	struct usb_device *children[USB_MAXCHILDREN];
 	void *controller;		/* hardware controller private data */
 	/* slot_id - for xHCI enabled devices */
@@ -191,6 +193,7 @@ struct int_queue *create_int_queue(struct usb_device *dev, unsigned long pipe,
 	int queuesize, int elementsize, void *buffer, int interval);
 int destroy_int_queue(struct usb_device *dev, struct int_queue *queue);
 void *poll_int_queue(struct usb_device *dev, struct int_queue *queue);
+int rearm_int_queue(struct usb_device *dev, struct int_queue *queue);
 #endif
 
 /* Defines */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/usb.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/usb.h
@@ -187,6 +187,8 @@ int submit_control_msg(struct usb_device *dev, unsigned long pipe, void *buffer,
 			int transfer_len, struct devrequest *setup);
 int submit_int_msg(struct usb_device *dev, unsigned long pipe, void *buffer,
 			int transfer_len, int interval);
+int submit_int_msg_once(struct usb_device *dev, unsigned long pipe,
+			void *buffer, int transfer_len);
 
 #if defined CONFIG_USB_EHCI_HCD || defined CONFIG_USB_MUSB_HOST
 struct int_queue *create_int_queue(struct usb_device *dev, unsigned long pipe,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb/usb_hub.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb/usb_hub.c
@@ -36,9 +36,11 @@
 #include <asm/byteorder.h>
 //#include <asm/unaligned.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "usb.h"
+#include "ehci_lifecycle.h"
 
 unsigned long get_timer(unsigned long i);
 void mdelay(int ms);
@@ -55,6 +57,7 @@ void mdelay(int ms);
 #define HUB_LONG_RESET_TIME	200
 
 #define PORT_OVERCURRENT_MAX_SCAN_COUNT		3
+
 
 struct usb_device_scan {
 	struct usb_device *dev;		/* USB hub device to scan */
@@ -387,13 +390,16 @@ static int usb_scan_port(struct usb_device_scan *usb_scan)
 	 * Don't talk to the device before the query delay is expired.
 	 * This is needed for voltages to stabalize.
 	 */
-	if (get_timer(0) < hub->query_delay)
+	if (!ehci_deadline_reached_u32((uint32_t)get_timer(0),
+					 (uint32_t)hub->query_delay))
 		return 0;
 
 	ret = usb_get_port_status(dev, i + 1, portsts);
 	if (ret < 0) {
 		printf("get_port_status failed\n");
-		if (get_timer(0) >= hub->connect_timeout) {
+		if (ehci_deadline_reached_u32(
+				(uint32_t)get_timer(0),
+				(uint32_t)hub->connect_timeout)) {
 			printf("[usb-hub] devnum=%d port=%d: timeout\n",
 			      dev->devnum, i + 1);
 			/* Remove this device from scanning list */
@@ -417,7 +423,9 @@ static int usb_scan_port(struct usb_device_scan *usb_scan)
 	 */
 	if (!(portchange & USB_PORT_STAT_C_CONNECTION) &&
 	    !(portstatus & USB_PORT_STAT_CONNECTION)) {
-		if (get_timer(0) >= hub->connect_timeout) {
+		if (ehci_deadline_reached_u32(
+				(uint32_t)get_timer(0),
+				(uint32_t)hub->connect_timeout)) {
 			printf("[usb-hub] devnum=%d port=%d: timeout\n",
 			      dev->devnum, i + 1);
 			/* Remove this device from scanning list */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_event_irq.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_event_irq.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef ZZUSB_EVENT_IRQ_H
+#define ZZUSB_EVENT_IRQ_H
+
+#include <stdint.h>
+
+#define ZZUSB_EVENT_INTERRUPT_BIT (1U << 4)
+#define ZZUSB_EVENT_ACK_GATE      (1U << 3)
+#define ZZUSB_EVENT_ACK_USB       (1U << 8)
+
+static inline uint32_t zzusb_event_ack_mask(uint16_t write_value)
+{
+    if ((write_value & (ZZUSB_EVENT_ACK_GATE | ZZUSB_EVENT_ACK_USB)) ==
+        (ZZUSB_EVENT_ACK_GATE | ZZUSB_EVENT_ACK_USB))
+        return ZZUSB_EVENT_INTERRUPT_BIT;
+    return 0;
+}
+
+#endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -88,6 +88,11 @@ struct ehci_ctrl *usb_proxy_get_ehci_controller(void)
 {
     return get_ehci_ctrl();
 }
+int usb_proxy_can_stage_payload(void)
+{
+    return !ehci_controller_needs_recovery();
+}
+
 
 static int wait_port_reset_clear(uint32_t *portsc, uint32_t timeout_us,
                                  uint32_t *observed)
@@ -654,6 +659,11 @@ static uint16_t handle_periodic_arm(volatile struct ZZUSBCommand *cmd,
         &endpoint->dev, pipe, 1, (int)length, endpoint->buffer,
         key.interval);
     if (!endpoint->queue) {
+        if (ehci_controller_needs_recovery()) {
+            endpoint->used = 1;
+            endpoint->failed = 1;
+            return ZZUSB_STATUS_HOSTERROR;
+        }
         memset(endpoint, 0, sizeof(*endpoint));
         return ZZUSB_STATUS_NOMEM;
     }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -1442,6 +1442,7 @@ uint16_t usb_proxy_handle_command(volatile struct ZZUSBCommand *cmd,
     }
 
     if (command != ZZUSB_CMD_RESET_PORT &&
+        command != ZZUSB_CMD_DIAG_SNAPSHOT &&
         !is_port_connected()) {
         result = ZZUSB_STATUS_OFFLINE;
     } else {
@@ -1494,11 +1495,13 @@ uint16_t usb_proxy_handle_command(volatile struct ZZUSBCommand *cmd,
         case ZZUSB_CMD_ISO_STOP:
             result = usb_proxy_iso_handle_stop(cmd);
             break;
+        case ZZUSB_CMD_DIAG_SNAPSHOT:
+            result = ZZUSB_STATUS_OK;
+            break;
         case ZZUSB_CMD_RESUME_PORT:
         case ZZUSB_CMD_SUSPEND_PORT:
         case ZZUSB_CMD_QUERY_DEVICE:
         case ZZUSB_CMD_SET_ADDRESS:
-        case ZZUSB_CMD_DIAG_SNAPSHOT:
         case ZZUSB_CMD_ISO_XFER:
             result = ZZUSB_STATUS_UNSUPPORTED;
             break;

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -264,12 +264,13 @@ static void save_toggle(int addr, struct usb_device *dev)
     }
 }
 
-static uint16_t usb_status_to_zz(unsigned long status)
+static uint16_t usb_status_to_zz(unsigned long status, int direction_in)
 {
     if (status & USB_ST_BABBLE_DET)
         return ZZUSB_STATUS_BABBLE;
     if (status & USB_ST_BUF_ERR)
-        return ZZUSB_STATUS_OVERRUN;
+        return direction_in ? ZZUSB_STATUS_OVERRUN :
+                              ZZUSB_STATUS_UNDERRUN;
     if (status & USB_ST_CRC_ERR)
         return ZZUSB_STATUS_CRC;
     if (status & USB_ST_STALLED)
@@ -455,7 +456,8 @@ static uint16_t periodic_poll_software(struct periodic_endpoint *endpoint,
         return ZZUSB_STATUS_OK;
     }
     *actual = 0;
-    return usb_status_to_zz(endpoint->dev.status);
+    return usb_status_to_zz(endpoint->dev.status,
+                            endpoint->key.direction & 0x80);
 }
 
 
@@ -515,7 +517,9 @@ void usb_proxy_periodic_pump(void)
         if (endpoint->dev.status != 0) {
             endpoint->failed = 1;
             periodic_queue_completion(
-                index, usb_status_to_zz(endpoint->dev.status), 0);
+                index, usb_status_to_zz(
+                    endpoint->dev.status,
+                    endpoint->key.direction & 0x80), 0);
         } else if (endpoint->dev.act_len > 0) {
             periodic_queue_completion(index, ZZUSB_STATUS_OK,
                                       endpoint->dev.act_len);
@@ -1120,7 +1124,7 @@ static uint16_t handle_control_xfer(volatile struct ZZUSBCommand *cmd,
     } else {
         diag_detail = (uint32_t)dev.status;
         put_be32(&cmd->actual_length, 0);
-        return usb_status_to_zz(dev.status);
+        return usb_status_to_zz(dev.status, is_in);
     }
 }
 
@@ -1195,7 +1199,7 @@ static uint16_t handle_bulk_xfer(volatile struct ZZUSBCommand *cmd,
     } else {
         diag_detail = (uint32_t)dev.status;
         put_be32(&cmd->actual_length, 0);
-        return usb_status_to_zz(dev.status);
+        return usb_status_to_zz(dev.status, is_in);
     }
 }
 
@@ -1266,7 +1270,7 @@ static uint16_t handle_int_xfer(volatile struct ZZUSBCommand *cmd,
     } else {
         put_be32(&cmd->actual_length, 0);
         diag_detail = (uint32_t)dev.status;
-        return usb_status_to_zz(dev.status);
+        return usb_status_to_zz(dev.status, is_in);
     }
 }
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -368,7 +368,13 @@ static int periodic_release_slot(unsigned index)
 
     if (!endpoint->used)
         return 0;
-    if (!endpoint->software_polled) {
+    if (endpoint->software_polled) {
+        if (!ehci_periodic_buffer_reclaimable(
+                ehci_controller_needs_recovery())) {
+            endpoint->failed = 1;
+            return -1;
+        }
+    } else {
         if (!endpoint->queue)
             return -1;
         if (destroy_int_queue(&endpoint->dev, endpoint->queue) < 0) {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -20,13 +20,19 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <stdio.h>
 #include <string.h>
 #include <sleep.h>
+#include <xtime_l.h>
 #include "xil_cache.h"
 #include "usb_proxy.h"
 #include "usb/usb.h"
+#include "usb_proxy_diag.h"
+#include "usb_proxy_iso.h"
+#include "usb_proxy_periodic_ring.h"
 #include "usb/ehci.h"
+#include "usb/ehci-iso.h"
+#include "usb/ehci_periodic.h"
+#include "interrupt.h"
 #include "memorymap.h"
 
 #ifndef ALIGN
@@ -44,12 +50,70 @@
 static unsigned int toggle_bits[128][2];
 static uint8_t dma_buf[24576] __attribute__((aligned(32)));
 static int root_port_speed_zz = ZZUSB_SPEED_FULL;
+static int root_port_connected;
+static uint32_t controller_epoch = 1;
+static uint32_t last_request_id = 0;
+static uint32_t diag_detail;
+
+static void periodic_stop_all(void);
+
+uint32_t usb_proxy_get_controller_epoch(void)
+{
+    return controller_epoch;
+}
+
+void usb_proxy_advance_controller_epoch(void)
+{
+    periodic_stop_all();
+    usb_proxy_iso_stop_all(EHCI_ISO_PACKET_OFFLINE);
+    controller_epoch++;
+    if (controller_epoch == 0)
+        controller_epoch = 1;
+    last_request_id = 0;
+}
+
+static int request_id_after(uint32_t request_id, uint32_t previous)
+{
+    return previous == 0 || (int32_t)(request_id - previous) > 0;
+}
 
 static struct ehci_ctrl *get_ehci_ctrl(void)
 {
     struct usb_device *root = usb_get_dev_index(0);
     if (!root) return NULL;
     return (struct ehci_ctrl *)root->controller;
+}
+
+struct ehci_ctrl *usb_proxy_get_ehci_controller(void)
+{
+    return get_ehci_ctrl();
+}
+
+static int wait_port_reset_clear(uint32_t *portsc, uint32_t timeout_us,
+                                 uint32_t *observed)
+{
+    XTime start;
+    XTime now;
+    uint64_t budget = ((uint64_t)timeout_us * COUNTS_PER_SECOND +
+                       999999ULL) / 1000000ULL;
+
+    XTime_GetTime(&start);
+    for (;;) {
+        uint32_t reg = ehci_readl(portsc);
+
+        if (!(reg & EHCI_PS_PR)) {
+            if (observed)
+                *observed = reg;
+            return 0;
+        }
+        XTime_GetTime(&now);
+        if ((uint64_t)(now - start) >= budget) {
+            if (observed)
+                *observed = reg;
+            return -1;
+        }
+        udelay(5);
+    }
 }
 
 static int zz_speed_to_usb(int zz)
@@ -78,8 +142,7 @@ static int read_data_length(volatile struct ZZUSBCommand *cmd,
 {
     *data_len = be32(&cmd->data_length);
     if (*data_len > ZZUSB_MAX_XFER) {
-        printf("[usb-proxy] bad data_length=%lu max=%lu\n",
-               (unsigned long)*data_len, (unsigned long)ZZUSB_MAX_XFER);
+        diag_detail = *data_len;
         put_be32(&cmd->actual_length, 0);
         return 0;
     }
@@ -113,7 +176,7 @@ static int read_split(volatile struct ZZUSBCommand *cmd,
         return 0;
     if (*hub_addr <= 0 || *hub_addr >= 128)
         return 0;
-    if (*hub_port <= 0 || *hub_port > 15)
+    if (*hub_port <= 0 || *hub_port > 127)
         return 0;
 
     return 1;
@@ -127,6 +190,7 @@ static void drop_direct_root_split(struct ehci_ctrl *ctrl,
                                    int *split_hub_port)
 {
     uint32_t portsc_now;
+    (void)tag;
 
     if (!ctrl || !split_hub_ptr || !*split_hub_ptr)
         return;
@@ -137,9 +201,7 @@ static void drop_direct_root_split(struct ehci_ctrl *ctrl,
     if (PORTSC_PSPD(portsc_now) == PORTSC_PSPD_HS)
         return;
 
-    printf("[usb-proxy] %s direct root: ignoring split hub=%d port=%d portsc=%08x\n",
-           tag, *split_hub_addr, *split_hub_port,
-           (unsigned int)portsc_now);
+    diag_detail = portsc_now;
     *split_hub_ptr = NULL;
     *split_hub_addr = 0;
     *split_hub_port = 0;
@@ -199,15 +261,401 @@ static void save_toggle(int addr, struct usb_device *dev)
 
 static uint16_t usb_status_to_zz(unsigned long status)
 {
-    if (status & (USB_ST_BABBLE_DET | USB_ST_BUF_ERR))
+    if (status & USB_ST_BABBLE_DET)
         return ZZUSB_STATUS_BABBLE;
+    if (status & USB_ST_BUF_ERR)
+        return ZZUSB_STATUS_OVERRUN;
     if (status & USB_ST_CRC_ERR)
         return ZZUSB_STATUS_CRC;
     if (status & USB_ST_STALLED)
         return ZZUSB_STATUS_STALL;
     if (status & USB_ST_NAK_REC)
         return ZZUSB_STATUS_NAK;
-    return ZZUSB_STATUS_ERROR;
+    return ZZUSB_STATUS_HOSTERROR;
+}
+
+#define ZZUSB_PERIODIC_ENDPOINTS ZZUSB_PERIODIC_RING_CAPACITY
+#define ZZUSB_PERIODIC_PUMP_BUDGET 4U
+
+struct periodic_key {
+    uint32_t epoch;
+    uint16_t generation;
+    uint16_t address;
+    uint16_t endpoint;
+    uint16_t direction;
+    uint16_t speed;
+    uint16_t max_packet;
+    uint16_t interval;
+    uint16_t hub_address;
+    uint16_t hub_port;
+    uint16_t flags;
+};
+
+struct periodic_endpoint {
+    struct periodic_key key;
+    struct usb_device dev;
+    struct usb_device split_hub;
+    struct int_queue *queue;
+    struct ehci_periodic_plan plan;
+    uint64_t interval_ticks;
+    uint64_t next_due;
+    uint32_t length;
+    uint32_t actual;
+    uint16_t completion_status;
+    uint8_t used;
+    uint8_t completion_pending;
+    uint8_t needs_rearm;
+    uint8_t failed;
+    uint8_t buffer[1024] __attribute__((aligned(32)));
+} __attribute__((aligned(32)));
+
+static struct periodic_endpoint periodic_endpoints[ZZUSB_PERIODIC_ENDPOINTS]
+    __attribute__((aligned(32)));
+static uint8_t periodic_ready[ZZUSB_PERIODIC_ENDPOINTS];
+static uint8_t periodic_ready_head;
+static uint8_t periodic_ready_count;
+static uint8_t periodic_pump_cursor;
+
+static int periodic_identity_matches(
+    const struct periodic_endpoint *endpoint,
+    volatile struct ZZUSBCommand *cmd)
+{
+    return endpoint->used &&
+           endpoint->key.epoch == controller_epoch &&
+           endpoint->key.generation == be16(&cmd->reserved) &&
+           endpoint->key.address == be32(&cmd->dev_addr) &&
+           endpoint->key.endpoint == be16(&cmd->endpoint) &&
+           endpoint->key.direction == be16(&cmd->direction);
+}
+
+static int periodic_keys_equal(const struct periodic_key *left,
+                               const struct periodic_key *right)
+{
+    return memcmp(left, right, sizeof(*left)) == 0;
+}
+
+static void periodic_remove_ready(unsigned position)
+{
+    zzusb_periodic_ring_remove(periodic_ready, &periodic_ready_head,
+                               &periodic_ready_count, position);
+}
+
+static void periodic_release_slot(unsigned index)
+{
+    struct periodic_endpoint *endpoint = &periodic_endpoints[index];
+    unsigned position;
+
+    if (!endpoint->used)
+        return;
+    for (position = 0; position < periodic_ready_count; position++) {
+        if (periodic_ready[(periodic_ready_head + position) %
+                           ZZUSB_PERIODIC_ENDPOINTS] == index) {
+            periodic_remove_ready(position);
+            break;
+        }
+    }
+    if (endpoint->queue)
+        destroy_int_queue(&endpoint->dev, endpoint->queue);
+    save_toggle(endpoint->key.address, &endpoint->dev);
+    memset(endpoint, 0, sizeof(*endpoint));
+}
+
+static void periodic_stop_all(void)
+{
+    unsigned index;
+
+    for (index = 0; index < ZZUSB_PERIODIC_ENDPOINTS; index++)
+        periodic_release_slot(index);
+    periodic_ready_head = 0;
+    periodic_ready_count = 0;
+    amiga_interrupt_clear(AMIGA_INTERRUPT_USB);
+}
+
+static void periodic_queue_completion(unsigned index, uint16_t status,
+                                      uint32_t actual)
+{
+    struct periodic_endpoint *endpoint = &periodic_endpoints[index];
+
+    if (endpoint->completion_pending ||
+        !zzusb_periodic_ring_push(periodic_ready, periodic_ready_head,
+                                  &periodic_ready_count, (uint8_t)index))
+        return;
+    endpoint->completion_pending = 1;
+    endpoint->completion_status = status;
+    endpoint->actual = actual;
+    zzusb_diag_high_water(periodic_ready_count);
+    amiga_interrupt_set(AMIGA_INTERRUPT_USB);
+}
+
+static uint64_t periodic_now(void)
+{
+    XTime now;
+
+    XTime_GetTime(&now);
+    return (uint64_t)now;
+}
+
+void usb_proxy_periodic_pump(void)
+{
+    uint64_t now = periodic_now();
+    unsigned visited;
+
+    for (visited = 0; visited < ZZUSB_PERIODIC_PUMP_BUDGET; visited++) {
+        unsigned index = periodic_pump_cursor;
+        struct periodic_endpoint *endpoint = &periodic_endpoints[index];
+        void *completed;
+
+        periodic_pump_cursor =
+            (uint8_t)((periodic_pump_cursor + 1U) %
+                      ZZUSB_PERIODIC_ENDPOINTS);
+        if (!endpoint->used || endpoint->completion_pending)
+            continue;
+        if (endpoint->needs_rearm) {
+            if (now < endpoint->next_due)
+                continue;
+            if (rearm_int_queue(&endpoint->dev, endpoint->queue) < 0) {
+                endpoint->failed = 1;
+                periodic_queue_completion(index, ZZUSB_STATUS_HOSTERROR, 0);
+                continue;
+            }
+            endpoint->needs_rearm = 0;
+        }
+
+        completed = poll_int_queue(&endpoint->dev, endpoint->queue);
+        if (!completed)
+            continue;
+        save_toggle(endpoint->key.address, &endpoint->dev);
+        endpoint->next_due = now + endpoint->interval_ticks;
+        if (endpoint->dev.status != 0) {
+            endpoint->failed = 1;
+            periodic_queue_completion(
+                index, usb_status_to_zz(endpoint->dev.status), 0);
+        } else if (endpoint->dev.act_len > 0) {
+            periodic_queue_completion(index, ZZUSB_STATUS_OK,
+                                      endpoint->dev.act_len);
+        } else {
+            endpoint->needs_rearm = 1;
+        }
+    }
+}
+uint32_t usb_proxy_periodic_queue_state(void)
+{
+    unsigned index;
+    uint32_t active = 0;
+
+    for (index = 0; index < ZZUSB_PERIODIC_ENDPOINTS; index++)
+        if (periodic_endpoints[index].used)
+            active++;
+    return (active << 16) | ((uint32_t)periodic_ready_count << 8);
+}
+
+uint32_t usb_proxy_periodic_schedule_bits(void)
+{
+    unsigned index;
+    uint32_t masks = 0;
+
+    for (index = 0; index < ZZUSB_PERIODIC_ENDPOINTS; index++) {
+        if (!periodic_endpoints[index].used)
+            continue;
+        masks |= periodic_endpoints[index].plan.start_mask;
+        masks |= (uint32_t)periodic_endpoints[index].plan.complete_mask << 8;
+    }
+    return masks;
+}
+
+void usb_proxy_refresh_event_irq(void)
+{
+    if (periodic_ready_count ||
+        (usb_proxy_iso_queue_state() & 0xf0000000U))
+        amiga_interrupt_set(AMIGA_INTERRUPT_USB);
+    else
+        amiga_interrupt_clear(AMIGA_INTERRUPT_USB);
+}
+
+static uint16_t handle_periodic_arm(volatile struct ZZUSBCommand *cmd,
+                                    uint8_t *data_buf)
+{
+    struct ehci_ctrl *ctrl = get_ehci_ctrl();
+    struct periodic_key key;
+    struct periodic_endpoint *endpoint = NULL;
+    struct usb_device dev;
+    struct usb_device split_hub;
+    struct usb_device *split_hub_ptr;
+    struct ehci_periodic_plan plan;
+    unsigned long pipe;
+    uint32_t length;
+    uint16_t flags;
+    int split_hub_addr = 0;
+    int split_hub_port = 0;
+    int speed_usb;
+    int is_in;
+    unsigned index;
+    unsigned free_index = ZZUSB_PERIODIC_ENDPOINTS;
+
+    if (!ctrl || !read_data_length(cmd, &length) ||
+        length == 0 || length > 1024U)
+        return ZZUSB_STATUS_BADPARAM;
+
+    flags = be16(&cmd->flags);
+    speed_usb = zz_speed_to_usb(be16(&cmd->speed));
+    is_in = (be16(&cmd->direction) & 0x80) != 0;
+    split_hub_ptr =
+        read_split(cmd, &split_hub_addr, &split_hub_port) ?
+        &split_hub : NULL;
+    drop_direct_root_split(ctrl, "periodic", speed_usb, &split_hub_ptr,
+                           &split_hub_addr, &split_hub_port);
+    if (!split_hub_ptr)
+        flags &= (uint16_t)~(ZZUSB_FLAG_SPLIT | ZZUSB_FLAG_MULTI_TT |
+                            ZZUSB_FLAG_TT_THINK_MASK);
+
+    memset(&key, 0, sizeof(key));
+    key.epoch = controller_epoch;
+    key.generation = be16(&cmd->reserved);
+    key.address = (uint16_t)be32(&cmd->dev_addr);
+    key.endpoint = be16(&cmd->endpoint);
+    key.direction = be16(&cmd->direction);
+    key.speed = be16(&cmd->speed);
+    key.max_packet = be16(&cmd->max_pkt_size);
+    key.interval = be16(&cmd->interval);
+    key.hub_address = (uint16_t)split_hub_addr;
+    key.hub_port = (uint16_t)split_hub_port;
+    key.flags = flags;
+
+    for (index = 0; index < ZZUSB_PERIODIC_ENDPOINTS; index++) {
+        if (!periodic_endpoints[index].used) {
+            if (free_index == ZZUSB_PERIODIC_ENDPOINTS)
+                free_index = index;
+            continue;
+        }
+        if (periodic_keys_equal(&periodic_endpoints[index].key, &key)) {
+            if (periodic_endpoints[index].completion_pending)
+                amiga_interrupt_set(AMIGA_INTERRUPT_USB);
+            put_be32(&cmd->actual_length, 0);
+            return ZZUSB_STATUS_OK;
+        }
+        if (periodic_identity_matches(&periodic_endpoints[index], cmd)) {
+            periodic_release_slot(index);
+            if (free_index == ZZUSB_PERIODIC_ENDPOINTS)
+                free_index = index;
+        }
+    }
+    if (free_index == ZZUSB_PERIODIC_ENDPOINTS)
+        return ZZUSB_STATUS_BUSY;
+
+    prep_dev(&dev, key.address, speed_usb, key.max_packet, key.endpoint,
+             split_hub_ptr, split_hub_addr, split_hub_port);
+    dev.tt_think_time =
+        (uint8_t)((flags & ZZUSB_FLAG_TT_THINK_MASK) >>
+                  ZZUSB_FLAG_TT_THINK_SHIFT);
+    dev.tt_multi = (flags & ZZUSB_FLAG_MULTI_TT) != 0;
+    if (!ehci_periodic_build_plan(
+            dev.speed, key.interval, split_hub_ptr != NULL,
+            dev.tt_think_time, dev.tt_multi,
+            key.endpoint + key.hub_port, &plan))
+        return ZZUSB_STATUS_BADPARAM;
+
+    endpoint = &periodic_endpoints[free_index];
+    memset(endpoint, 0, sizeof(*endpoint));
+    endpoint->key = key;
+    endpoint->dev = dev;
+    endpoint->plan = plan;
+    endpoint->length = length;
+    endpoint->interval_ticks =
+        ((uint64_t)plan.interval_microframes * COUNTS_PER_SECOND + 7999ULL) /
+        8000ULL;
+    if (!endpoint->interval_ticks)
+        endpoint->interval_ticks = 1;
+    if (split_hub_ptr) {
+        endpoint->split_hub = split_hub;
+        endpoint->dev.parent = &endpoint->split_hub;
+    }
+    if (!is_in)
+        memcpy(endpoint->buffer, data_buf, length);
+    if (is_in)
+        pipe = usb_rcvintpipe(&endpoint->dev, key.endpoint);
+    else
+        pipe = usb_sndintpipe(&endpoint->dev, key.endpoint);
+    endpoint->queue = create_int_queue(
+        &endpoint->dev, pipe, 1, (int)length, endpoint->buffer,
+        key.interval);
+    if (!endpoint->queue) {
+        memset(endpoint, 0, sizeof(*endpoint));
+        return ZZUSB_STATUS_NOMEM;
+    }
+    endpoint->used = 1;
+    zzusb_diag_count(ZZUSB_DIAG_COUNT_PERIODIC_ARM);
+    put_be32(&cmd->actual_length, 0);
+    return ZZUSB_STATUS_OK;
+}
+
+static uint16_t handle_periodic_reap(volatile struct ZZUSBCommand *cmd,
+                                     uint8_t *data_buf)
+{
+    uint32_t capacity = be32(&cmd->data_length);
+    unsigned position;
+
+    for (position = 0; position < periodic_ready_count; position++) {
+        unsigned index = periodic_ready[
+            (periodic_ready_head + position) % ZZUSB_PERIODIC_ENDPOINTS];
+        struct periodic_endpoint *endpoint = &periodic_endpoints[index];
+        uint16_t status;
+        uint32_t actual;
+
+        if (!periodic_identity_matches(endpoint, cmd))
+            continue;
+        status = endpoint->completion_status;
+        actual = endpoint->actual;
+        if (status == ZZUSB_STATUS_OK && actual > capacity)
+            return ZZUSB_STATUS_BADPARAM;
+        if (status == ZZUSB_STATUS_OK && actual)
+            memcpy(data_buf, endpoint->buffer, actual);
+        put_be32(&cmd->actual_length,
+                 status == ZZUSB_STATUS_OK ? actual : 0);
+        periodic_remove_ready(position);
+        endpoint->completion_pending = 0;
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_PERIODIC_REAP);
+        if (endpoint->failed || endpoint->key.direction == 0) {
+            periodic_release_slot(index);
+        } else {
+            endpoint->needs_rearm = 1;
+        }
+        if (periodic_ready_count)
+            amiga_interrupt_set(AMIGA_INTERRUPT_USB);
+        usb_proxy_refresh_event_irq();
+        return status;
+    }
+
+    put_be32(&cmd->actual_length, 0);
+    return ZZUSB_STATUS_NAK;
+}
+
+static uint16_t handle_periodic_stop(volatile struct ZZUSBCommand *cmd)
+{
+    unsigned index;
+    int stopped = 0;
+
+    for (index = 0; index < ZZUSB_PERIODIC_ENDPOINTS; index++) {
+        if (periodic_identity_matches(&periodic_endpoints[index], cmd)) {
+            periodic_release_slot(index);
+            stopped = 1;
+        }
+    }
+    usb_proxy_refresh_event_irq();
+    put_be32(&cmd->actual_length, 0);
+    return stopped ? ZZUSB_STATUS_OK : ZZUSB_STATUS_NAK;
+}
+
+static uint16_t handle_cancel_ep(volatile struct ZZUSBCommand *cmd)
+{
+    uint16_t periodic = handle_periodic_stop(cmd);
+    uint16_t iso = usb_proxy_iso_handle_stop(cmd);
+
+    if (periodic == ZZUSB_STATUS_HOSTERROR ||
+        iso == ZZUSB_STATUS_HOSTERROR)
+        return ZZUSB_STATUS_HOSTERROR;
+    if (periodic == ZZUSB_STATUS_OK || iso == ZZUSB_STATUS_OK)
+        return ZZUSB_STATUS_OK;
+    return ZZUSB_STATUS_NAK;
 }
 
 static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
@@ -215,17 +663,19 @@ static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
     struct ehci_ctrl *ctrl = get_ehci_ctrl();
     if (!ctrl)
         return ZZUSB_STATUS_ERROR;
+    periodic_stop_all();
+    usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED);
+    memset(toggle_bits, 0, sizeof(toggle_bits));
+    root_port_connected = 0;
 
     uint32_t *portsc = (uint32_t *)&ctrl->hcor->or_portsc[0];
-    uint32_t reg_pre, reg, reg_after_hold;
+    uint32_t reg_pre, reg;
     int ret;
     int reset_flags;
-    int speed_hint;
     int use_fsls_reset;
 
     reg_pre = ehci_readl(portsc);
     reset_flags = be16(&cmd->flags);
-    speed_hint = be16(&cmd->speed);
     use_fsls_reset = (reset_flags & ZZUSB_FLAG_RESET_FSLS) ? 1 : 0;
 
     /*
@@ -244,13 +694,10 @@ static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
             reg &= ~PORTSC_PFSC;
         reg &= ~EHCI_PS_PR;
         ehci_writel(portsc, reg);
-        for (int i = 0; i < 800; i++) {
-            reg_pre = ehci_readl(portsc);
-            if (!(reg_pre & EHCI_PS_PR))
-                break;
-            udelay(5);
+        if (wait_port_reset_clear(portsc, 4000U, &reg_pre) < 0) {
+            diag_detail = reg_pre;
+            return ZZUSB_STATUS_HOSTERROR;
         }
-        reg_pre = ehci_readl(portsc);
     }
 
     /*
@@ -300,7 +747,6 @@ static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
     /* USB 2.0 spec: hold reset for 50ms on root ports. */
     mdelay(50);
 
-    reg_after_hold = ehci_readl(portsc);
 
     /*
      * De-assert reset. Crucially, use the VALUE WE WROTE (with W1C
@@ -320,12 +766,7 @@ static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
      * but don't sit here forever — on failure we want to return
      * status to Poseidon promptly so the Zorro bus keeps flowing.
      */
-    ret = -1;
-    for (int i = 0; i < 800; i++) {  /* 800 * 5us = 4ms bound */
-        reg = ehci_readl(portsc);
-        if (!(reg & EHCI_PS_PR)) { ret = 0; break; }
-        udelay(5);
-    }
+    ret = wait_port_reset_clear(portsc, 4000U, &reg);
     if (ret < 0) {
         int stuck_speed;
 
@@ -333,14 +774,7 @@ static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
         stuck_speed = portsc_to_zz_speed(reg);
         root_port_speed_zz = stuck_speed;
         put_be16(&cmd->speed, stuck_speed);
-        printf("[usb-proxy] reset: PR didn't clear "
-               "(pre=%08x after_hold=%08x now=%08x hint=%d path=%d speed=%d)\n",
-               (unsigned int)reg_pre,
-               (unsigned int)reg_after_hold,
-               (unsigned int)reg,
-               speed_hint,
-               use_fsls_reset,
-               stuck_speed);
+        diag_detail = reg;
         if (stuck_speed == ZZUSB_SPEED_LOW)
             return ZZUSB_STATUS_OFFLINE;
         return ZZUSB_STATUS_ERROR;
@@ -351,21 +785,17 @@ static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
     if (!(reg & EHCI_PS_CS)) {
         root_port_speed_zz = ZZUSB_SPEED_FULL;
         ehci_zynq_set_phy_speed(USB_SPEED_HIGH);
-        printf("[usb-proxy] reset: no device connected after reset "
-               "(portsc=%08x)\n", (unsigned int)reg);
+        diag_detail = reg;
         return ZZUSB_STATUS_ERROR;
     }
 
     if (!(reg & EHCI_PS_PE)) {
-        printf("[usb-proxy] reset: port not enabled "
-               "(portsc=%08x pre=%08x)\n",
-               (unsigned int)reg, (unsigned int)reg_pre);
+        diag_detail = reg;
         return ZZUSB_STATUS_ERROR;
     }
 
     int zz_speed = portsc_to_zz_speed(reg);
     int usb_speed = zz_speed_to_usb(zz_speed);
-    int phy_rc;
     root_port_speed_zz = zz_speed;
 
     /*
@@ -374,20 +804,17 @@ static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
      * classified the device, switch the ULPI function-control register to
      * the actual wire speed before the first address-0 transaction.
      */
-    phy_rc = ehci_zynq_set_phy_speed(usb_speed);
+    ehci_zynq_set_phy_speed(usb_speed);
     udelay(100);
     reg = ehci_readl(portsc);
 
     /* USB 2.0 TRSTRCY recovery. 10 ms is the spec floor. */
     mdelay(10);
 
-    toggle_bits[0][0] = 0;
-    toggle_bits[0][1] = 0;
+    memset(toggle_bits, 0, sizeof(toggle_bits));
+    root_port_connected = 1;
 
-    printf("[usb-proxy] reset done: speed=%d portsc=%08x phy=%d%s\n",
-           zz_speed, (unsigned int)reg,
-           phy_rc,
-           use_fsls_reset ? " (FSLS/PFSC path)" : "");
+    diag_detail = reg;
     put_be16(&cmd->speed, zz_speed);
     return ZZUSB_STATUS_OK;
 }
@@ -433,9 +860,7 @@ static uint16_t handle_control_xfer(volatile struct ZZUSBCommand *cmd,
                         ? ZZUSB_SPEED_HIGH : root_port_speed_zz;
         if (root_pspd != PORTSC_PSPD_HS) {
             if (split_hub_ptr) {
-                printf("[usb-proxy] ctrl0 direct root: ignoring split hub=%d port=%d portsc=%08x\n",
-                       split_hub_addr, split_hub_port,
-                       (unsigned int)portsc_now);
+                diag_detail = portsc_now;
                 split_hub_ptr = NULL;
                 split_hub_addr = 0;
                 split_hub_port = 0;
@@ -443,8 +868,7 @@ static uint16_t handle_control_xfer(volatile struct ZZUSBCommand *cmd,
             direct_root_addr0 = 1;
         }
         if (root_speed_zz != speed_zz) {
-            printf("[usb-proxy] ctrl0 root speed override: cmd=%d port=%d portsc=%08x\n",
-                   speed_zz, root_speed_zz, (unsigned int)portsc_now);
+            diag_detail = portsc_now;
             speed_zz = root_speed_zz;
             speed_usb = zz_speed_to_usb(speed_zz);
             put_be16(&cmd->speed, speed_zz);
@@ -471,7 +895,7 @@ static uint16_t handle_control_xfer(volatile struct ZZUSBCommand *cmd,
          * long enough to crash the OS. LS behind a high-speed hub still
          * uses the split path above.
          */
-        printf("[usb-proxy] direct LS root EP0 unsupported; offline\n");
+        diag_detail = portsc_now;
         put_be32(&cmd->actual_length, 0);
         return ZZUSB_STATUS_OFFLINE;
     }
@@ -531,7 +955,7 @@ static uint16_t handle_control_xfer(volatile struct ZZUSBCommand *cmd,
 
         if (setup.requesttype == 0x00 && setup.request == 0x05) {
             int new_addr = setup.value;
-            printf("[usb-proxy] set_addr: %d -> %d\n", dev_addr, new_addr);
+            diag_detail = (uint32_t)new_addr;
             if (new_addr > 0 && new_addr < 128) {
                 toggle_bits[new_addr][0] = 0;
                 toggle_bits[new_addr][1] = 0;
@@ -568,8 +992,7 @@ static uint16_t handle_control_xfer(volatile struct ZZUSBCommand *cmd,
         }
         return ZZUSB_STATUS_OK;
     } else {
-        printf("[usb-proxy] ctrl fail: addr=%d ep=%d req=%02x/%02x result=%d status=%lx act_len=%d\n",
-               dev_addr, endpoint, setup.requesttype, setup.request, result, dev.status, dev.act_len);
+        diag_detail = (uint32_t)dev.status;
         put_be32(&cmd->actual_length, 0);
         return usb_status_to_zz(dev.status);
     }
@@ -644,10 +1067,7 @@ static uint16_t handle_bulk_xfer(volatile struct ZZUSBCommand *cmd,
         put_be32(&cmd->actual_length, dev.act_len);
         return ZZUSB_STATUS_OK;
     } else {
-        /* Keep the failure print — it's rare and tells us why a
-         * bulk transfer errored. */
-        printf("[bulk] FAIL addr=%d ep=%d result=%d status=%lx\n",
-               dev_addr, endpoint, result, dev.status);
+        diag_detail = (uint32_t)dev.status;
         put_be32(&cmd->actual_length, 0);
         return usb_status_to_zz(dev.status);
     }
@@ -719,8 +1139,7 @@ static uint16_t handle_int_xfer(volatile struct ZZUSBCommand *cmd,
         return ZZUSB_STATUS_OK;
     } else {
         put_be32(&cmd->actual_length, 0);
-        printf("[usb-proxy] int fail: addr=%d ep=%d result=%d status=%lx\n",
-               dev_addr, endpoint, result, dev.status);
+        diag_detail = (uint32_t)dev.status;
         return usb_status_to_zz(dev.status);
     }
 }
@@ -775,9 +1194,35 @@ static uint16_t handle_enumerate(volatile struct ZZUSBCommand *cmd,
 static int is_port_connected(void)
 {
     struct ehci_ctrl *ctrl = get_ehci_ctrl();
-    if (!ctrl) return 0;
-    uint32_t portsc = ehci_readl(&ctrl->hcor->or_portsc[0]);
-    return (portsc & EHCI_PS_CS) ? 1 : 0;
+    uint32_t portsc;
+    int connected;
+
+    if (!ctrl)
+        return 0;
+    portsc = ehci_readl(&ctrl->hcor->or_portsc[0]);
+    connected = (portsc & EHCI_PS_CS) ? 1 : 0;
+    if (!connected && root_port_connected) {
+        memset(toggle_bits, 0, sizeof(toggle_bits));
+        root_port_connected = 0;
+        usb_proxy_advance_controller_epoch();
+    } else if (connected && !root_port_connected) {
+        memset(toggle_bits, 0, sizeof(toggle_bits));
+        root_port_connected = 1;
+    }
+    return connected;
+}
+
+static uint16_t handle_retire_ep(volatile struct ZZUSBCommand *cmd)
+{
+    uint32_t address = be32(&cmd->dev_addr);
+    uint16_t endpoint = be16(&cmd->endpoint);
+    uint16_t direction = be16(&cmd->direction);
+
+    if (address > 127 || endpoint > 15)
+        return ZZUSB_STATUS_BADPARAM;
+    toggle_bits[address][(direction & 0x80) ? 1 : 0] &=
+        ~(1U << endpoint);
+    return ZZUSB_STATUS_OK;
 }
 
 static uint16_t handle_check_port(volatile struct ZZUSBCommand *cmd)
@@ -798,32 +1243,246 @@ static uint16_t handle_check_port(volatile struct ZZUSBCommand *cmd)
     return ZZUSB_STATUS_OK;
 }
 
+static uint32_t diag_timestamp(void)
+{
+    XTime now;
+    XTime_GetTime(&now);
+    return (uint32_t)now;
+}
+
+static void diag_flush(volatile void *address, size_t length)
+{
+    Xil_DCacheFlushRange((UINTPTR)address, (u32)length);
+}
+
+static uint32_t diag_request_id(
+    volatile struct ZZUSBProtocolExtension *ext, int is_v2)
+{
+    return is_v2 ? be32(&ext->request_id) : 0U;
+}
+
+static uint16_t diag_topology(volatile struct ZZUSBCommand *cmd)
+{
+    return (uint16_t)((be16(&cmd->split_hub_addr) << 8) |
+                      (be16(&cmd->split_hub_port) & 0xffU));
+}
+
+static void diag_begin_command(
+    volatile struct ZZUSBCommand *cmd,
+    volatile struct ZZUSBProtocolExtension *ext, int is_v2)
+{
+    diag_detail = 0;
+    zzusb_diag_count(ZZUSB_DIAG_COUNT_REQUEST);
+    zzusb_diag_record(ZZUSB_DIAG_EVENT_REQUEST, ZZUSB_STATUS_PENDING,
+                      diag_request_id(ext, is_v2), controller_epoch,
+                      (uint16_t)be32(&cmd->dev_addr),
+                      (uint8_t)be16(&cmd->endpoint),
+                      (uint8_t)be16(&cmd->direction),
+                      diag_topology(cmd), be16(&cmd->flags),
+                      be16(&cmd->cmd), diag_timestamp());
+}
+
+static uint16_t diag_complete_command(
+    volatile struct ZZUSBCommand *cmd,
+    volatile struct ZZUSBProtocolExtension *ext, int is_v2,
+    uint16_t result)
+{
+    uint16_t event_type = ZZUSB_DIAG_EVENT_COMPLETION;
+    uint16_t command = be16(&cmd->cmd);
+
+    zzusb_diag_count(ZZUSB_DIAG_COUNT_COMPLETION);
+    if (command == ZZUSB_CMD_RESET_PORT) {
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_RESET);
+        event_type = ZZUSB_DIAG_EVENT_RESET;
+    } else if (result == ZZUSB_STATUS_TIMEOUT) {
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_TIMEOUT);
+        event_type = ZZUSB_DIAG_EVENT_TIMEOUT;
+    } else if (result == ZZUSB_STATUS_CANCELLED) {
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_CANCELLATION);
+        event_type = ZZUSB_DIAG_EVENT_CANCELLATION;
+    } else if (result == ZZUSB_STATUS_STALE) {
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_STALE);
+        event_type = ZZUSB_DIAG_EVENT_STALE;
+    } else if (result == ZZUSB_STATUS_HOSTERROR) {
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_EHCI_ERROR);
+        event_type = ZZUSB_DIAG_EVENT_EHCI_ERROR;
+    }
+
+    zzusb_diag_record(event_type, result,
+                      diag_request_id(ext, is_v2), controller_epoch,
+                      (uint16_t)be32(&cmd->dev_addr),
+                      (uint8_t)be16(&cmd->endpoint),
+                      (uint8_t)be16(&cmd->direction),
+                      diag_topology(cmd), be16(&cmd->flags),
+                      diag_detail ? diag_detail : be32(&cmd->actual_length),
+                      diag_timestamp());
+    return result;
+}
+
+void usb_proxy_publish_diagnostics(volatile void *aperture,
+                                   uint32_t queue_state)
+{
+    struct ehci_ctrl *ctrl = get_ehci_ctrl();
+    uint32_t schedule_bits = 0;
+
+    if (ctrl) {
+        schedule_bits = ehci_readl(&ctrl->hcor->or_usbcmd) & 0x00000031U;
+        schedule_bits |=
+            (ehci_readl(&ctrl->hcor->or_usbsts) & 0x0000f03fU) << 8;
+    }
+    queue_state |= usb_proxy_periodic_queue_state();
+    queue_state |= usb_proxy_iso_queue_state();
+    schedule_bits |= usb_proxy_periodic_schedule_bits() << 16;
+    zzusb_diag_publish((volatile uint8_t *)aperture + ZZUSB_DIAG_OFFSET,
+                       ZZUSB_DIAG_SIZE, ZZUSB_CAP_BASE, controller_epoch,
+                       last_request_id, queue_state, schedule_bits,
+                       diag_flush);
+}
+
+void usb_proxy_note_late_completion(
+    volatile struct ZZUSBCommand *cmd,
+    volatile struct ZZUSBProtocolExtension *ext, int is_v2)
+{
+    zzusb_diag_count(ZZUSB_DIAG_COUNT_LATE_COMPLETION);
+    zzusb_diag_record(ZZUSB_DIAG_EVENT_LATE_COMPLETION,
+                      be16(&cmd->status), diag_request_id(ext, is_v2),
+                      controller_epoch, (uint16_t)be32(&cmd->dev_addr),
+                      (uint8_t)be16(&cmd->endpoint),
+                      (uint8_t)be16(&cmd->direction),
+                      diag_topology(cmd), be16(&cmd->flags),
+                      be32(&cmd->actual_length), diag_timestamp());
+}
+
 uint16_t usb_proxy_handle_command(volatile struct ZZUSBCommand *cmd,
-                              uint8_t *data_buf)
+                                  volatile struct ZZUSBProtocolExtension *ext,
+                                  uint8_t *data_buf, int is_v2)
 {
     uint16_t command = be16(&cmd->cmd);
+    uint16_t result;
+    uint16_t validation;
+
     put_be32(&cmd->actual_length, 0);
-
-    if (command != ZZUSB_CMD_RESET_PORT && command != ZZUSB_CMD_CHECK_PORT && !is_port_connected()) {
-        return ZZUSB_STATUS_OFFLINE;
+    diag_begin_command(cmd, ext, is_v2);
+    if (command != ZZUSB_CMD_QUERY_CAPS &&
+        ehci_controller_needs_recovery()) {
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_RECOVERY);
+        zzusb_diag_record(ZZUSB_DIAG_EVENT_RECOVERY, ZZUSB_STATUS_PENDING,
+                          diag_request_id(ext, is_v2), controller_epoch,
+                          0, 0, 0, 0, 0, command, diag_timestamp());
+        periodic_stop_all();
+        usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED);
+        if (ehci_controller_recover() < 0)
+            return diag_complete_command(cmd, ext, is_v2,
+                                         ZZUSB_STATUS_HOSTERROR);
+        usb_proxy_iso_after_controller_reset();
+        memset(toggle_bits, 0, sizeof(toggle_bits));
+        usb_proxy_advance_controller_epoch();
+        if (is_v2) {
+            put_be16(&ext->version, ZZUSB_PROTOCOL_VERSION);
+            put_be16(&ext->header_size, ZZUSB_V2_HEADER_SIZE);
+            put_be32(&ext->controller_epoch, controller_epoch);
+            put_be32(&ext->capabilities, ZZUSB_CAP_BASE);
+        }
+        return diag_complete_command(
+            cmd, ext, is_v2,
+            is_v2 ? ZZUSB_STATUS_STALE : ZZUSB_STATUS_HOSTERROR);
     }
 
-    switch (command) {
-    case ZZUSB_CMD_CONTROL_XFER:
-        return handle_control_xfer(cmd, data_buf);
-    case ZZUSB_CMD_BULK_XFER:
-        return handle_bulk_xfer(cmd, data_buf);
-    case ZZUSB_CMD_INT_XFER:
-        return handle_int_xfer(cmd, data_buf);
-    case ZZUSB_CMD_CLEAR_STALL:
-        return handle_clear_stall(cmd);
-    case ZZUSB_CMD_RESET_PORT:
-        return handle_reset_port(cmd);
-    case ZZUSB_CMD_CHECK_PORT:
-        return handle_check_port(cmd);
-    case ZZUSB_CMD_ENUMERATE:
-        return handle_enumerate(cmd, data_buf);
-    default:
-        return ZZUSB_STATUS_BADPARAM;
+    validation = zzusb_validate_command(cmd, ext, is_v2, controller_epoch);
+    if (validation != ZZUSB_STATUS_OK)
+        return diag_complete_command(cmd, ext, is_v2, validation);
+
+    if (is_v2) {
+        uint32_t request_id = be32(&ext->request_id);
+
+        if (command == ZZUSB_CMD_QUERY_CAPS) {
+            last_request_id = request_id;
+            put_be16(&ext->version, ZZUSB_PROTOCOL_VERSION);
+            put_be16(&ext->header_size, ZZUSB_V2_HEADER_SIZE);
+            put_be32(&ext->controller_epoch, controller_epoch);
+            put_be32(&ext->capabilities, ZZUSB_CAP_BASE);
+            return diag_complete_command(cmd, ext, is_v2,
+                                         ZZUSB_STATUS_OK);
+        }
+        if (!request_id_after(request_id, last_request_id))
+            return diag_complete_command(cmd, ext, is_v2,
+                                         ZZUSB_STATUS_STALE);
+        last_request_id = request_id;
     }
+
+    if (command != ZZUSB_CMD_RESET_PORT &&
+        command != ZZUSB_CMD_CHECK_PORT &&
+        !is_port_connected()) {
+        result = ZZUSB_STATUS_OFFLINE;
+    } else {
+        switch (command) {
+        case ZZUSB_CMD_CONTROL_XFER:
+            result = handle_control_xfer(cmd, data_buf);
+            break;
+        case ZZUSB_CMD_BULK_XFER:
+            result = handle_bulk_xfer(cmd, data_buf);
+            break;
+        case ZZUSB_CMD_INT_XFER:
+            result = handle_int_xfer(cmd, data_buf);
+            break;
+        case ZZUSB_CMD_CLEAR_STALL:
+            result = handle_clear_stall(cmd);
+            break;
+        case ZZUSB_CMD_RESET_PORT:
+            result = handle_reset_port(cmd);
+            if (result == ZZUSB_STATUS_OK)
+                usb_proxy_iso_after_controller_reset();
+            usb_proxy_advance_controller_epoch();
+            break;
+        case ZZUSB_CMD_CHECK_PORT:
+            result = handle_check_port(cmd);
+            break;
+        case ZZUSB_CMD_ENUMERATE:
+            result = handle_enumerate(cmd, data_buf);
+            break;
+        case ZZUSB_CMD_RETIRE_EP:
+            result = handle_retire_ep(cmd);
+            break;
+        case ZZUSB_CMD_CANCEL_EP:
+            result = handle_cancel_ep(cmd);
+            break;
+        case ZZUSB_CMD_PERIODIC_ARM:
+            result = handle_periodic_arm(cmd, data_buf);
+            break;
+        case ZZUSB_CMD_PERIODIC_REAP:
+            result = handle_periodic_reap(cmd, data_buf);
+            break;
+        case ZZUSB_CMD_PERIODIC_STOP:
+            result = handle_periodic_stop(cmd);
+            break;
+        case ZZUSB_CMD_ISO_QUEUE:
+            result = usb_proxy_iso_handle_queue(cmd, data_buf);
+            break;
+        case ZZUSB_CMD_ISO_REAP:
+            result = usb_proxy_iso_handle_reap(cmd, data_buf);
+            break;
+        case ZZUSB_CMD_ISO_STOP:
+            result = usb_proxy_iso_handle_stop(cmd);
+            break;
+        case ZZUSB_CMD_RESUME_PORT:
+        case ZZUSB_CMD_SUSPEND_PORT:
+        case ZZUSB_CMD_QUERY_DEVICE:
+        case ZZUSB_CMD_SET_ADDRESS:
+        case ZZUSB_CMD_DIAG_SNAPSHOT:
+        case ZZUSB_CMD_ISO_XFER:
+            result = ZZUSB_STATUS_UNSUPPORTED;
+            break;
+        default:
+            result = ZZUSB_STATUS_BADPARAM;
+            break;
+        }
+    }
+
+    if (is_v2) {
+        put_be16(&ext->version, ZZUSB_PROTOCOL_VERSION);
+        put_be16(&ext->header_size, ZZUSB_V2_HEADER_SIZE);
+        put_be32(&ext->controller_epoch, controller_epoch);
+        put_be32(&ext->capabilities, ZZUSB_CAP_BASE);
+    }
+    return diag_complete_command(cmd, ext, is_v2, result);
 }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -665,6 +665,11 @@ static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
         return ZZUSB_STATUS_ERROR;
     periodic_stop_all();
     usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED);
+    if (ehci_controller_needs_recovery()) {
+        if (ehci_controller_recover() < 0)
+            return ZZUSB_STATUS_HOSTERROR;
+        usb_proxy_iso_after_controller_reset();
+    }
     memset(toggle_bits, 0, sizeof(toggle_bits));
     root_port_connected = 0;
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -496,7 +496,8 @@ void usb_proxy_periodic_pump(void)
             if (status == ZZUSB_STATUS_OK &&
                 (endpoint->key.direction == 0 || actual != 0))
                 periodic_queue_completion(index, status, actual);
-            else if (status != ZZUSB_STATUS_OK) {
+            else if (status != ZZUSB_STATUS_OK &&
+                     status != ZZUSB_STATUS_NAK) {
                 endpoint->failed = 1;
                 periodic_queue_completion(index, status, 0);
             }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -302,6 +302,7 @@ struct periodic_endpoint {
     struct usb_device split_hub;
     struct int_queue *queue;
     struct ehci_periodic_plan plan;
+    struct ehci_periodic_plan bandwidth_plan;
     uint64_t interval_ticks;
     uint64_t next_due;
     uint32_t length;
@@ -312,6 +313,9 @@ struct periodic_endpoint {
     uint8_t needs_rearm;
     uint8_t failed;
     uint8_t software_polled;
+    uint8_t bandwidth_reserved;
+    uint8_t reservation_mask;
+    uint16_t reservation_bytes;
     uint8_t buffer[1024] __attribute__((aligned(32)));
 } __attribute__((aligned(32)));
 
@@ -346,6 +350,16 @@ static void periodic_remove_ready(unsigned position)
                                &periodic_ready_count, position);
 }
 
+
+static void periodic_release_bandwidth(struct periodic_endpoint *endpoint)
+{
+    if (!endpoint->bandwidth_reserved)
+        return;
+    ehci_periodic_release_bandwidth(
+        &endpoint->bandwidth_plan, endpoint->reservation_mask,
+        endpoint->reservation_bytes);
+    endpoint->bandwidth_reserved = 0;
+}
 static int periodic_release_slot(unsigned index)
 {
     struct periodic_endpoint *endpoint = &periodic_endpoints[index];
@@ -372,6 +386,7 @@ static int periodic_release_slot(unsigned index)
             break;
         }
     }
+    periodic_release_bandwidth(endpoint);
     memset(endpoint, 0, sizeof(*endpoint));
     return 0;
 }
@@ -637,6 +652,23 @@ static uint16_t handle_periodic_arm(volatile struct ZZUSBCommand *cmd,
         8000ULL;
     if (!endpoint->interval_ticks)
         endpoint->interval_ticks = 1;
+    endpoint->bandwidth_plan = plan;
+    if (endpoint->bandwidth_plan.frame_interval > 1024U) {
+        endpoint->bandwidth_plan.frame_interval = 1U;
+        endpoint->bandwidth_plan.frame_phase = 0;
+    }
+    endpoint->reservation_mask =
+        (uint8_t)(plan.start_mask | plan.complete_mask);
+    endpoint->reservation_bytes = key.max_packet;
+    if (split_hub_ptr && endpoint->reservation_bytes > 188U)
+        endpoint->reservation_bytes = 188U;
+    if (!ehci_periodic_reserve_bandwidth(
+            &endpoint->bandwidth_plan, endpoint->reservation_mask,
+            endpoint->reservation_bytes)) {
+        memset(endpoint, 0, sizeof(*endpoint));
+        return ZZUSB_STATUS_BUSY;
+    }
+    endpoint->bandwidth_reserved = 1;
     if (split_hub_ptr) {
         endpoint->split_hub = split_hub;
         endpoint->dev.parent = &endpoint->split_hub;
@@ -664,6 +696,7 @@ static uint16_t handle_periodic_arm(volatile struct ZZUSBCommand *cmd,
             endpoint->failed = 1;
             return ZZUSB_STATUS_HOSTERROR;
         }
+        periodic_release_bandwidth(endpoint);
         memset(endpoint, 0, sizeof(*endpoint));
         return ZZUSB_STATUS_NOMEM;
     }

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -306,6 +306,7 @@ struct periodic_endpoint {
     uint8_t completion_pending;
     uint8_t needs_rearm;
     uint8_t failed;
+    uint8_t software_polled;
     uint8_t buffer[1024] __attribute__((aligned(32)));
 } __attribute__((aligned(32)));
 
@@ -347,16 +348,18 @@ static int periodic_release_slot(unsigned index)
 
     if (!endpoint->used)
         return 0;
-    if (endpoint->queue &&
-        destroy_int_queue(&endpoint->dev, endpoint->queue) < 0) {
-        /* The queue is quarantined until controller reset. Preserve the
-         * endpoint-owned DMA buffer and suppress its pump in the meantime. */
-        endpoint->queue = NULL;
-        endpoint->failed = 1;
-        return -1;
+    if (!endpoint->software_polled) {
+        if (!endpoint->queue)
+            return -1;
+        if (destroy_int_queue(&endpoint->dev, endpoint->queue) < 0) {
+            /* The queue is quarantined until controller reset. Preserve the
+             * endpoint-owned DMA buffer and suppress its pump meanwhile. */
+            endpoint->queue = NULL;
+            endpoint->failed = 1;
+            return -1;
+        }
+        save_toggle(endpoint->key.address, &endpoint->dev);
     }
-    if (!endpoint->queue)
-        return -1;
     for (position = 0; position < periodic_ready_count; position++) {
         if (periodic_ready[(periodic_ready_head + position) %
                            ZZUSB_PERIODIC_ENDPOINTS] == index) {
@@ -364,7 +367,6 @@ static int periodic_release_slot(unsigned index)
             break;
         }
     }
-    save_toggle(endpoint->key.address, &endpoint->dev);
     memset(endpoint, 0, sizeof(*endpoint));
     return 0;
 }
@@ -413,6 +415,29 @@ static uint64_t periodic_now(void)
     XTime_GetTime(&now);
     return (uint64_t)now;
 }
+static uint16_t periodic_poll_software(struct periodic_endpoint *endpoint,
+                                       uint32_t *actual)
+{
+    unsigned long pipe;
+    int result;
+
+    if (endpoint->key.direction & 0x80)
+        pipe = usb_rcvintpipe(&endpoint->dev, endpoint->key.endpoint);
+    else
+        pipe = usb_sndintpipe(&endpoint->dev, endpoint->key.endpoint);
+    endpoint->dev.status = 0;
+    endpoint->dev.act_len = 0;
+    result = submit_int_msg_once(&endpoint->dev, pipe, endpoint->buffer,
+                                 (int)endpoint->length);
+    save_toggle(endpoint->key.address, &endpoint->dev);
+    if (result >= 0 && endpoint->dev.status == 0) {
+        *actual = endpoint->dev.act_len;
+        return ZZUSB_STATUS_OK;
+    }
+    *actual = 0;
+    return usb_status_to_zz(endpoint->dev.status);
+}
+
 
 void usb_proxy_periodic_pump(void)
 {
@@ -429,6 +454,26 @@ void usb_proxy_periodic_pump(void)
                       ZZUSB_PERIODIC_ENDPOINTS);
         if (!endpoint->used || endpoint->completion_pending)
             continue;
+        if (endpoint->software_polled) {
+            uint16_t status;
+            uint32_t actual;
+
+            if (now < endpoint->next_due)
+                continue;
+            endpoint->next_due = now + endpoint->interval_ticks;
+            actual = 0;
+            status = periodic_poll_software(endpoint, &actual);
+            if (actual > endpoint->length)
+                actual = endpoint->length;
+            if (status == ZZUSB_STATUS_OK &&
+                (endpoint->key.direction == 0 || actual != 0))
+                periodic_queue_completion(index, status, actual);
+            else if (status != ZZUSB_STATUS_OK) {
+                endpoint->failed = 1;
+                periodic_queue_completion(index, status, 0);
+            }
+            continue;
+        }
         if (!endpoint->queue)
             continue;
         if (endpoint->needs_rearm) {
@@ -593,6 +638,14 @@ static uint16_t handle_periodic_arm(volatile struct ZZUSBCommand *cmd,
     }
     if (!is_in)
         memcpy(endpoint->buffer, data_buf, length);
+    if (plan.frame_interval > 1024U) {
+        endpoint->software_polled = 1;
+        endpoint->next_due = periodic_now();
+        endpoint->used = 1;
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_PERIODIC_ARM);
+        put_be32(&cmd->actual_length, 0);
+        return ZZUSB_STATUS_OK;
+    }
     if (is_in)
         pipe = usb_rcvintpipe(&endpoint->dev, key.endpoint);
     else
@@ -639,7 +692,7 @@ static uint16_t handle_periodic_reap(volatile struct ZZUSBCommand *cmd,
         if (endpoint->failed || endpoint->key.direction == 0) {
             if (periodic_release_slot(index) < 0)
                 status = ZZUSB_STATUS_HOSTERROR;
-        } else {
+        } else if (!endpoint->software_polled) {
             endpoint->needs_rearm = 1;
         }
         if (periodic_ready_count)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.c
@@ -340,13 +340,23 @@ static void periodic_remove_ready(unsigned position)
                                &periodic_ready_count, position);
 }
 
-static void periodic_release_slot(unsigned index)
+static int periodic_release_slot(unsigned index)
 {
     struct periodic_endpoint *endpoint = &periodic_endpoints[index];
     unsigned position;
 
     if (!endpoint->used)
-        return;
+        return 0;
+    if (endpoint->queue &&
+        destroy_int_queue(&endpoint->dev, endpoint->queue) < 0) {
+        /* The queue is quarantined until controller reset. Preserve the
+         * endpoint-owned DMA buffer and suppress its pump in the meantime. */
+        endpoint->queue = NULL;
+        endpoint->failed = 1;
+        return -1;
+    }
+    if (!endpoint->queue)
+        return -1;
     for (position = 0; position < periodic_ready_count; position++) {
         if (periodic_ready[(periodic_ready_head + position) %
                            ZZUSB_PERIODIC_ENDPOINTS] == index) {
@@ -354,10 +364,9 @@ static void periodic_release_slot(unsigned index)
             break;
         }
     }
-    if (endpoint->queue)
-        destroy_int_queue(&endpoint->dev, endpoint->queue);
     save_toggle(endpoint->key.address, &endpoint->dev);
     memset(endpoint, 0, sizeof(*endpoint));
+    return 0;
 }
 
 static void periodic_stop_all(void)
@@ -368,6 +377,16 @@ static void periodic_stop_all(void)
         periodic_release_slot(index);
     periodic_ready_head = 0;
     periodic_ready_count = 0;
+    amiga_interrupt_clear(AMIGA_INTERRUPT_USB);
+}
+
+static void periodic_after_controller_reset(void)
+{
+    memset(periodic_endpoints, 0, sizeof(periodic_endpoints));
+    memset(periodic_ready, 0, sizeof(periodic_ready));
+    periodic_ready_head = 0;
+    periodic_ready_count = 0;
+    periodic_pump_cursor = 0;
     amiga_interrupt_clear(AMIGA_INTERRUPT_USB);
 }
 
@@ -409,6 +428,8 @@ void usb_proxy_periodic_pump(void)
             (uint8_t)((periodic_pump_cursor + 1U) %
                       ZZUSB_PERIODIC_ENDPOINTS);
         if (!endpoint->used || endpoint->completion_pending)
+            continue;
+        if (!endpoint->queue)
             continue;
         if (endpoint->needs_rearm) {
             if (now < endpoint->next_due)
@@ -534,7 +555,8 @@ static uint16_t handle_periodic_arm(volatile struct ZZUSBCommand *cmd,
             return ZZUSB_STATUS_OK;
         }
         if (periodic_identity_matches(&periodic_endpoints[index], cmd)) {
-            periodic_release_slot(index);
+            if (periodic_release_slot(index) < 0)
+                return ZZUSB_STATUS_HOSTERROR;
             if (free_index == ZZUSB_PERIODIC_ENDPOINTS)
                 free_index = index;
         }
@@ -615,7 +637,8 @@ static uint16_t handle_periodic_reap(volatile struct ZZUSBCommand *cmd,
         endpoint->completion_pending = 0;
         zzusb_diag_count(ZZUSB_DIAG_COUNT_PERIODIC_REAP);
         if (endpoint->failed || endpoint->key.direction == 0) {
-            periodic_release_slot(index);
+            if (periodic_release_slot(index) < 0)
+                status = ZZUSB_STATUS_HOSTERROR;
         } else {
             endpoint->needs_rearm = 1;
         }
@@ -636,7 +659,8 @@ static uint16_t handle_periodic_stop(volatile struct ZZUSBCommand *cmd)
 
     for (index = 0; index < ZZUSB_PERIODIC_ENDPOINTS; index++) {
         if (periodic_identity_matches(&periodic_endpoints[index], cmd)) {
-            periodic_release_slot(index);
+            if (periodic_release_slot(index) < 0)
+                return ZZUSB_STATUS_HOSTERROR;
             stopped = 1;
         }
     }
@@ -669,6 +693,7 @@ static uint16_t handle_reset_port(volatile struct ZZUSBCommand *cmd)
         if (ehci_controller_recover() < 0)
             return ZZUSB_STATUS_HOSTERROR;
         usb_proxy_iso_after_controller_reset();
+        periodic_after_controller_reset();
     }
     memset(toggle_bits, 0, sizeof(toggle_bits));
     root_port_connected = 0;
@@ -1380,6 +1405,7 @@ uint16_t usb_proxy_handle_command(volatile struct ZZUSBCommand *cmd,
             return diag_complete_command(cmd, ext, is_v2,
                                          ZZUSB_STATUS_HOSTERROR);
         usb_proxy_iso_after_controller_reset();
+        periodic_after_controller_reset();
         memset(toggle_bits, 0, sizeof(toggle_bits));
         usb_proxy_advance_controller_epoch();
         if (is_v2) {
@@ -1416,7 +1442,6 @@ uint16_t usb_proxy_handle_command(volatile struct ZZUSBCommand *cmd,
     }
 
     if (command != ZZUSB_CMD_RESET_PORT &&
-        command != ZZUSB_CMD_CHECK_PORT &&
         !is_port_connected()) {
         result = ZZUSB_STATUS_OFFLINE;
     } else {

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.h
@@ -190,6 +190,14 @@ static inline int zzusb_command_is_transfer(uint16_t command) {
            command == ZZUSB_CMD_INT_XFER ||
            command == ZZUSB_CMD_ISO_XFER;
 }
+static inline int zzusb_valid_hs_iso_max_packet(uint16_t encoded) {
+    uint16_t base = encoded & 0x07ffU;
+    uint16_t multiplier = (encoded >> 11) & 3U;
+
+    return base != 0 && base <= 1024U && multiplier <= 2U &&
+           (encoded & 0xe000U) == 0;
+}
+
 
 static inline uint16_t zzusb_validate_command(
     const volatile struct ZZUSBCommand *cmd,
@@ -252,7 +260,8 @@ static inline uint16_t zzusb_validate_command(
     case ZZUSB_CMD_CONTROL_XFER:
         if ((is_v2 && xfer_type != ZZUSB_XFER_CONTROL) ||
             endpoint != 0 || max_packet == 0 || max_packet > 64 ||
-            le16(&cmd->setup_wLength) != data_length)
+            le16(&cmd->setup_wLength) != data_length ||
+            direction != ((cmd->setup_bRequestType & 0x80U) ? 0x80U : 0U))
             return ZZUSB_STATUS_BADPARAM;
         break;
     case ZZUSB_CMD_BULK_XFER:
@@ -268,8 +277,11 @@ static inline uint16_t zzusb_validate_command(
         break;
     case ZZUSB_CMD_ISO_XFER:
         if ((is_v2 && xfer_type != ZZUSB_XFER_ISO) ||
-            endpoint == 0 || max_packet == 0 || max_packet > 0x13ff ||
-            be16(&cmd->interval) == 0)
+            endpoint == 0 || be16(&cmd->interval) == 0 ||
+            speed == ZZUSB_SPEED_LOW ||
+            (speed == ZZUSB_SPEED_HIGH &&
+             !zzusb_valid_hs_iso_max_packet(max_packet)) ||
+            (speed == ZZUSB_SPEED_FULL && max_packet > 1023U))
             return ZZUSB_STATUS_BADPARAM;
         break;
     case ZZUSB_CMD_QUERY_CAPS:
@@ -310,7 +322,8 @@ static inline uint16_t zzusb_validate_command(
             be16(&cmd->interval) == 0 ||
             speed == ZZUSB_SPEED_LOW ||
             (speed == ZZUSB_SPEED_HIGH &&
-             (max_packet > 0x13ff || be16(&cmd->interval) > 16 ||
+             (!zzusb_valid_hs_iso_max_packet(max_packet) ||
+              be16(&cmd->interval) > 16 ||
               (flags & ZZUSB_FLAG_SPLIT))) ||
             (speed == ZZUSB_SPEED_FULL &&
              (max_packet > 1023 || be16(&cmd->interval) > 16 ||

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.h
@@ -93,6 +93,11 @@ struct ehci_ctrl;
 #define ZZUSB_V2_DATA_MAX        16384
 #define ZZUSB_DIAG_SIZE          4096
 #define ZZUSB_DIAG_OFFSET        (ZZUSB_APERTURE_SIZE - ZZUSB_DIAG_SIZE)
+#define ZZUSB_MAINT_HEADER_OFFSET (ZZUSB_DATA_OFFSET + ZZUSB_V2_DATA_MAX)
+#define ZZUSB_MAINT_DATA_OFFSET   (ZZUSB_MAINT_HEADER_OFFSET + \
+                                   ZZUSB_V2_HEADER_SIZE)
+#define ZZUSB_MAINT_DATA_MAX      (ZZUSB_DIAG_OFFSET - \
+                                   ZZUSB_MAINT_DATA_OFFSET)
 #define ZZUSB_DOORBELL_V2        0x8000
 
 #define ZZUSB_CAP_PROTOCOL_V2      (1U << 0)
@@ -105,11 +110,13 @@ struct ehci_ctrl;
 #define ZZUSB_CAP_ISO_REALTIME     (1U << 7)
 #define ZZUSB_CAP_EVENT_IRQ        (1U << 8)
 #define ZZUSB_CAP_PRECISE_ERRORS   (1U << 9)
+#define ZZUSB_CAP_MAINTENANCE      (1U << 10)
 #define ZZUSB_CAP_BASE (ZZUSB_CAP_PROTOCOL_V2 | ZZUSB_CAP_REQUEST_ID | \
                         ZZUSB_CAP_CONTROLLER_EPOCH | ZZUSB_CAP_VALIDATION | \
                         ZZUSB_CAP_DIAGNOSTICS | ZZUSB_CAP_PERIODIC | \
                         ZZUSB_CAP_ISO_SIMPLE | ZZUSB_CAP_ISO_REALTIME | \
-                        ZZUSB_CAP_EVENT_IRQ | ZZUSB_CAP_PRECISE_ERRORS)
+                        ZZUSB_CAP_EVENT_IRQ | ZZUSB_CAP_PRECISE_ERRORS | \
+                        ZZUSB_CAP_MAINTENANCE)
 
 struct ZZUSBCommand {
     uint16_t cmd;
@@ -351,6 +358,7 @@ uint32_t usb_proxy_periodic_queue_state(void);
 uint32_t usb_proxy_periodic_schedule_bits(void);
 void usb_proxy_refresh_event_irq(void);
 void usb_proxy_iso_pump(void);
+void usb_proxy_poll_maintenance(void);
 uint16_t usb_proxy_handle_command(volatile struct ZZUSBCommand *cmd,
                                   volatile struct ZZUSBProtocolExtension *ext,
                                   uint8_t *data_buf, int is_v2);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.h
@@ -25,6 +25,8 @@
 
 #include <xil_types.h>
 
+struct ehci_ctrl;
+
 #define ZZUSB_CMD_CONTROL_XFER  0x01
 #define ZZUSB_CMD_BULK_XFER     0x02
 #define ZZUSB_CMD_INT_XFER      0x03
@@ -37,6 +39,16 @@
 #define ZZUSB_CMD_SET_ADDRESS   0x0A
 #define ZZUSB_CMD_CLEAR_STALL   0x0B
 #define ZZUSB_CMD_CHECK_PORT    0x0C
+#define ZZUSB_CMD_QUERY_CAPS     0x0D
+#define ZZUSB_CMD_RETIRE_EP      0x0E
+#define ZZUSB_CMD_CANCEL_EP      0x0F
+#define ZZUSB_CMD_DIAG_SNAPSHOT  0x10
+#define ZZUSB_CMD_PERIODIC_ARM    0x11
+#define ZZUSB_CMD_PERIODIC_REAP   0x12
+#define ZZUSB_CMD_PERIODIC_STOP   0x13
+#define ZZUSB_CMD_ISO_QUEUE       0x14
+#define ZZUSB_CMD_ISO_REAP        0x15
+#define ZZUSB_CMD_ISO_STOP        0x16
 
 #define ZZUSB_STATUS_OK         0x00
 #define ZZUSB_STATUS_PENDING    0x01
@@ -50,6 +62,12 @@
 #define ZZUSB_STATUS_UNDERRUN   0xF8
 #define ZZUSB_STATUS_OFFLINE    0xF7
 #define ZZUSB_STATUS_BADPARAM   0xF6
+#define ZZUSB_STATUS_UNSUPPORTED 0xF5
+#define ZZUSB_STATUS_STALE       0xF4
+#define ZZUSB_STATUS_CANCELLED   0xF3
+#define ZZUSB_STATUS_HOSTERROR   0xF2
+#define ZZUSB_STATUS_BUSY        0xF1
+#define ZZUSB_STATUS_NOMEM       0xF0
 
 #define ZZUSB_SPEED_LOW         0
 #define ZZUSB_SPEED_FULL        1
@@ -57,10 +75,41 @@
 
 #define ZZUSB_FLAG_SPLIT        0x0001
 #define ZZUSB_FLAG_RESET_FSLS   0x0002
+#define ZZUSB_FLAG_MULTI_TT     0x0004
+#define ZZUSB_FLAG_TT_THINK_SHIFT 4
+#define ZZUSB_FLAG_TT_THINK_MASK  0x0030
 
-#define ZZUSB_CMD_SIZE          48
-#define ZZUSB_DATA_OFFSET       64
-#define ZZUSB_MAX_XFER          (24576 - ZZUSB_DATA_OFFSET)
+#define ZZUSB_XFER_CONTROL      0
+#define ZZUSB_XFER_BULK         1
+#define ZZUSB_XFER_INTERRUPT    2
+#define ZZUSB_XFER_ISO          3
+
+#define ZZUSB_PROTOCOL_VERSION   2
+#define ZZUSB_CMD_SIZE           48
+#define ZZUSB_V2_HEADER_SIZE     64
+#define ZZUSB_DATA_OFFSET        64
+#define ZZUSB_APERTURE_SIZE      24576
+#define ZZUSB_MAX_XFER           (ZZUSB_APERTURE_SIZE - ZZUSB_DATA_OFFSET)
+#define ZZUSB_V2_DATA_MAX        16384
+#define ZZUSB_DIAG_SIZE          4096
+#define ZZUSB_DIAG_OFFSET        (ZZUSB_APERTURE_SIZE - ZZUSB_DIAG_SIZE)
+#define ZZUSB_DOORBELL_V2        0x8000
+
+#define ZZUSB_CAP_PROTOCOL_V2      (1U << 0)
+#define ZZUSB_CAP_REQUEST_ID       (1U << 1)
+#define ZZUSB_CAP_CONTROLLER_EPOCH (1U << 2)
+#define ZZUSB_CAP_VALIDATION       (1U << 3)
+#define ZZUSB_CAP_DIAGNOSTICS      (1U << 4)
+#define ZZUSB_CAP_PERIODIC         (1U << 5)
+#define ZZUSB_CAP_ISO_SIMPLE       (1U << 6)
+#define ZZUSB_CAP_ISO_REALTIME     (1U << 7)
+#define ZZUSB_CAP_EVENT_IRQ        (1U << 8)
+#define ZZUSB_CAP_PRECISE_ERRORS   (1U << 9)
+#define ZZUSB_CAP_BASE (ZZUSB_CAP_PROTOCOL_V2 | ZZUSB_CAP_REQUEST_ID | \
+                        ZZUSB_CAP_CONTROLLER_EPOCH | ZZUSB_CAP_VALIDATION | \
+                        ZZUSB_CAP_DIAGNOSTICS | ZZUSB_CAP_PERIODIC | \
+                        ZZUSB_CAP_ISO_SIMPLE | ZZUSB_CAP_ISO_REALTIME | \
+                        ZZUSB_CAP_EVENT_IRQ | ZZUSB_CAP_PRECISE_ERRORS)
 
 struct ZZUSBCommand {
     uint16_t cmd;
@@ -86,8 +135,19 @@ struct ZZUSBCommand {
     uint16_t reserved;
 } __attribute__((packed));
 
+struct ZZUSBProtocolExtension {
+    uint16_t version;
+    uint16_t header_size;
+    uint32_t request_id;
+    uint32_t controller_epoch;
+    uint32_t capabilities;
+} __attribute__((packed));
+
 typedef char ZZUSBCommand_size_must_match_protocol[
     (sizeof(struct ZZUSBCommand) == ZZUSB_CMD_SIZE) ? 1 : -1];
+typedef char ZZUSBProtocolExtension_size_must_fill_gap[
+    (sizeof(struct ZZUSBProtocolExtension) ==
+     (ZZUSB_DATA_OFFSET - ZZUSB_CMD_SIZE)) ? 1 : -1];
 
 static inline uint16_t be16(const volatile void *p) {
     volatile uint8_t *b = (volatile uint8_t *)p;
@@ -124,6 +184,166 @@ static inline void put_be32(volatile void *p, uint32_t v) {
     b[3] = v & 0xff;
 }
 
-uint16_t usb_proxy_handle_command(volatile struct ZZUSBCommand *cmd, uint8_t *data_buf);
+static inline int zzusb_command_is_transfer(uint16_t command) {
+    return command == ZZUSB_CMD_CONTROL_XFER ||
+           command == ZZUSB_CMD_BULK_XFER ||
+           command == ZZUSB_CMD_INT_XFER ||
+           command == ZZUSB_CMD_ISO_XFER;
+}
+
+static inline uint16_t zzusb_validate_command(
+    const volatile struct ZZUSBCommand *cmd,
+    const volatile struct ZZUSBProtocolExtension *ext,
+    int is_v2, uint32_t controller_epoch) {
+    uint16_t command;
+    uint16_t direction;
+    uint16_t endpoint;
+    uint16_t speed;
+    uint16_t flags;
+    uint16_t xfer_type;
+    uint16_t max_packet;
+    uint32_t data_length;
+    uint32_t max_length;
+
+    if (!cmd)
+        return ZZUSB_STATUS_BADPARAM;
+
+    command = be16(&cmd->cmd);
+    direction = be16(&cmd->direction);
+    endpoint = be16(&cmd->endpoint);
+    speed = be16(&cmd->speed);
+    flags = be16(&cmd->flags);
+    xfer_type = be16(&cmd->xfer_type);
+    max_packet = be16(&cmd->max_pkt_size);
+    data_length = be32(&cmd->data_length);
+    max_length = is_v2 ? ZZUSB_V2_DATA_MAX : ZZUSB_MAX_XFER;
+
+    if (is_v2) {
+        if (!ext ||
+            be16(&ext->version) != ZZUSB_PROTOCOL_VERSION ||
+            be16(&ext->header_size) != ZZUSB_V2_HEADER_SIZE ||
+            be32(&ext->request_id) == 0)
+            return ZZUSB_STATUS_BADPARAM;
+        if (command != ZZUSB_CMD_QUERY_CAPS &&
+            be32(&ext->controller_epoch) != controller_epoch)
+            return ZZUSB_STATUS_STALE;
+    }
+
+    if (be32(&cmd->dev_addr) > 127 || endpoint > 15 ||
+        (direction != 0 && direction != 0x80) ||
+        speed > ZZUSB_SPEED_HIGH || data_length > max_length)
+        return ZZUSB_STATUS_BADPARAM;
+
+    if (flags & ZZUSB_FLAG_SPLIT) {
+        uint16_t hub = be16(&cmd->split_hub_addr);
+        uint16_t port = be16(&cmd->split_hub_port);
+        if (speed == ZZUSB_SPEED_HIGH || hub == 0 || hub > 127 ||
+            port == 0 || port > 127)
+            return ZZUSB_STATUS_BADPARAM;
+    } else if (is_v2 &&
+               (be16(&cmd->split_hub_addr) != 0 ||
+                be16(&cmd->split_hub_port) != 0 ||
+                (flags & (ZZUSB_FLAG_MULTI_TT |
+                          ZZUSB_FLAG_TT_THINK_MASK)) != 0)) {
+        return ZZUSB_STATUS_BADPARAM;
+    }
+
+    switch (command) {
+    case ZZUSB_CMD_CONTROL_XFER:
+        if ((is_v2 && xfer_type != ZZUSB_XFER_CONTROL) ||
+            endpoint != 0 || max_packet == 0 || max_packet > 64 ||
+            le16(&cmd->setup_wLength) != data_length)
+            return ZZUSB_STATUS_BADPARAM;
+        break;
+    case ZZUSB_CMD_BULK_XFER:
+        if ((is_v2 && xfer_type != ZZUSB_XFER_BULK) ||
+            endpoint == 0 || max_packet == 0 || max_packet > 512)
+            return ZZUSB_STATUS_BADPARAM;
+        break;
+    case ZZUSB_CMD_INT_XFER:
+        if ((is_v2 && xfer_type != ZZUSB_XFER_INTERRUPT) ||
+            endpoint == 0 || max_packet == 0 || max_packet > 1024 ||
+            be16(&cmd->interval) == 0)
+            return ZZUSB_STATUS_BADPARAM;
+        break;
+    case ZZUSB_CMD_ISO_XFER:
+        if ((is_v2 && xfer_type != ZZUSB_XFER_ISO) ||
+            endpoint == 0 || max_packet == 0 || max_packet > 0x13ff ||
+            be16(&cmd->interval) == 0)
+            return ZZUSB_STATUS_BADPARAM;
+        break;
+    case ZZUSB_CMD_QUERY_CAPS:
+        if (!is_v2 || data_length != 0)
+            return ZZUSB_STATUS_BADPARAM;
+        break;
+    case ZZUSB_CMD_RESET_PORT:
+    case ZZUSB_CMD_RESUME_PORT:
+    case ZZUSB_CMD_SUSPEND_PORT:
+    case ZZUSB_CMD_ENUMERATE:
+    case ZZUSB_CMD_QUERY_DEVICE:
+    case ZZUSB_CMD_SET_ADDRESS:
+    case ZZUSB_CMD_CLEAR_STALL:
+    case ZZUSB_CMD_CHECK_PORT:
+    case ZZUSB_CMD_RETIRE_EP:
+    case ZZUSB_CMD_CANCEL_EP:
+    case ZZUSB_CMD_DIAG_SNAPSHOT:
+        break;
+    case ZZUSB_CMD_PERIODIC_ARM:
+    case ZZUSB_CMD_PERIODIC_REAP:
+        if (xfer_type != ZZUSB_XFER_INTERRUPT ||
+            endpoint == 0 || max_packet == 0 || max_packet > 1024 ||
+            data_length == 0 || data_length > 1024 ||
+            be16(&cmd->interval) == 0 ||
+            (speed == ZZUSB_SPEED_HIGH &&
+             be16(&cmd->interval) > 16))
+            return ZZUSB_STATUS_BADPARAM;
+        break;
+    case ZZUSB_CMD_PERIODIC_STOP:
+        if (xfer_type != ZZUSB_XFER_INTERRUPT || endpoint == 0)
+            return ZZUSB_STATUS_BADPARAM;
+        break;
+    case ZZUSB_CMD_ISO_QUEUE:
+    case ZZUSB_CMD_ISO_REAP:
+        if (!is_v2 || xfer_type != ZZUSB_XFER_ISO ||
+            endpoint == 0 || max_packet == 0 ||
+            data_length < 32 || data_length > ZZUSB_V2_DATA_MAX ||
+            be16(&cmd->interval) == 0 ||
+            speed == ZZUSB_SPEED_LOW ||
+            (speed == ZZUSB_SPEED_HIGH &&
+             (max_packet > 0x13ff || be16(&cmd->interval) > 16 ||
+              (flags & ZZUSB_FLAG_SPLIT))) ||
+            (speed == ZZUSB_SPEED_FULL &&
+             (max_packet > 1023 || be16(&cmd->interval) > 16 ||
+              !(flags & ZZUSB_FLAG_SPLIT))))
+            return ZZUSB_STATUS_BADPARAM;
+        break;
+    case ZZUSB_CMD_ISO_STOP:
+        if (!is_v2 || xfer_type != ZZUSB_XFER_ISO ||
+            endpoint == 0 || data_length != 0)
+            return ZZUSB_STATUS_BADPARAM;
+        break;
+    default:
+        return ZZUSB_STATUS_BADPARAM;
+    }
+
+    return ZZUSB_STATUS_OK;
+}
+
+uint32_t usb_proxy_get_controller_epoch(void);
+struct ehci_ctrl *usb_proxy_get_ehci_controller(void);
+void usb_proxy_advance_controller_epoch(void);
+void usb_proxy_periodic_pump(void);
+uint32_t usb_proxy_periodic_queue_state(void);
+uint32_t usb_proxy_periodic_schedule_bits(void);
+void usb_proxy_refresh_event_irq(void);
+void usb_proxy_iso_pump(void);
+uint16_t usb_proxy_handle_command(volatile struct ZZUSBCommand *cmd,
+                                  volatile struct ZZUSBProtocolExtension *ext,
+                                  uint8_t *data_buf, int is_v2);
+void usb_proxy_publish_diagnostics(volatile void *aperture,
+                                   uint32_t queue_state);
+void usb_proxy_note_late_completion(
+    volatile struct ZZUSBCommand *cmd,
+    volatile struct ZZUSBProtocolExtension *ext, int is_v2);
 
 #endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy.h
@@ -344,6 +344,7 @@ static inline uint16_t zzusb_validate_command(
 
 uint32_t usb_proxy_get_controller_epoch(void);
 struct ehci_ctrl *usb_proxy_get_ehci_controller(void);
+int usb_proxy_can_stage_payload(void);
 void usb_proxy_advance_controller_epoch(void);
 void usb_proxy_periodic_pump(void);
 uint32_t usb_proxy_periodic_queue_state(void);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_diag.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_diag.c
@@ -98,11 +98,11 @@ void zzusb_diag_publish(volatile void *page, size_t page_size,
                         uint32_t schedule_bits, zzusb_diag_flush_fn flush)
 {
     volatile uint8_t *wire = (volatile uint8_t *)page;
-    uint32_t next;
+    uint32_t next_sequence;
+    uint32_t next_index;
     uint32_t count;
     uint32_t first;
     uint32_t generation;
-    uint32_t encoded = 0;
 
     if (!page || page_size < ZZUSB_DIAG_PAGE_SIZE)
         return;
@@ -117,9 +117,12 @@ void zzusb_diag_publish(volatile void *page, size_t page_size,
     if (flush)
         flush(wire, 64U);
 
-    next = __atomic_load_n(&diag.next_sequence, __ATOMIC_ACQUIRE);
-    count = next < ZZUSB_DIAG_EVENT_COUNT ? next : ZZUSB_DIAG_EVENT_COUNT;
-    first = count ? next - count + 1U : 0U;
+    next_sequence =
+        __atomic_load_n(&diag.next_sequence, __ATOMIC_ACQUIRE);
+    count = next_sequence < ZZUSB_DIAG_EVENT_COUNT ?
+            next_sequence : ZZUSB_DIAG_EVENT_COUNT;
+    first = count ? next_sequence - count + 1U : 0U;
+    next_index = next_sequence % ZZUSB_DIAG_EVENT_COUNT;
 
     put_be32(wire + ZZUSB_DIAG_OFF_MAGIC, ZZUSB_DIAG_MAGIC);
     put_be16(wire + ZZUSB_DIAG_OFF_VERSION, ZZUSB_DIAG_VERSION);
@@ -128,7 +131,7 @@ void zzusb_diag_publish(volatile void *page, size_t page_size,
     put_be32(wire + ZZUSB_DIAG_OFF_CAPABILITIES, capabilities);
     put_be32(wire + ZZUSB_DIAG_OFF_EPOCH, epoch);
     put_be32(wire + ZZUSB_DIAG_OFF_LAST_ID, last_request_id);
-    put_be32(wire + ZZUSB_DIAG_OFF_EVENT_NEXT, next);
+    put_be32(wire + ZZUSB_DIAG_OFF_EVENT_NEXT, next_index);
     put_be32(wire + ZZUSB_DIAG_OFF_LOST_EVENTS,
              __atomic_load_n(&diag.lost_events, __ATOMIC_RELAXED));
     put_be32(wire + ZZUSB_DIAG_OFF_QUEUE_STATE, queue_state);
@@ -139,22 +142,22 @@ void zzusb_diag_publish(volatile void *page, size_t page_size,
                  __atomic_load_n(&diag.counters[i], __ATOMIC_RELAXED));
     }
 
+    for (uint32_t i = 0; i < ZZUSB_DIAG_EVENT_COUNT; i++)
+        put_be32(wire + ZZUSB_DIAG_OFF_EVENTS +
+                 i * ZZUSB_DIAG_EVENT_SIZE, 0U);
     for (uint32_t i = 0; i < count; i++) {
         uint32_t sequence = first + i;
-        const struct zzusb_diag_event *event =
-            &diag.events[(sequence - 1U) % ZZUSB_DIAG_EVENT_COUNT];
-        uint32_t committed = __atomic_load_n(&event->sequence, __ATOMIC_ACQUIRE);
+        uint32_t physical = (sequence - 1U) % ZZUSB_DIAG_EVENT_COUNT;
+        const struct zzusb_diag_event *event = &diag.events[physical];
+        uint32_t committed = __atomic_load_n(&event->sequence,
+                                              __ATOMIC_ACQUIRE);
 
         if (committed != sequence)
             continue;
         encode_event(wire + ZZUSB_DIAG_OFF_EVENTS +
-                     encoded * ZZUSB_DIAG_EVENT_SIZE, event, sequence);
-        encoded++;
+                     physical * ZZUSB_DIAG_EVENT_SIZE, event, sequence);
     }
-    put_be32(wire + ZZUSB_DIAG_OFF_EVENT_COUNT, encoded);
-    for (uint32_t i = encoded; i < ZZUSB_DIAG_EVENT_COUNT; i++)
-        put_be32(wire + ZZUSB_DIAG_OFF_EVENTS +
-                   i * ZZUSB_DIAG_EVENT_SIZE, 0U);
+    put_be32(wire + ZZUSB_DIAG_OFF_EVENT_COUNT, count);
 
     __atomic_thread_fence(__ATOMIC_RELEASE);
     if (flush)

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_diag.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_diag.c
@@ -1,0 +1,190 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include "usb_proxy_diag.h"
+#include "usb_proxy.h"
+
+#include <string.h>
+
+struct zzusb_diag_state {
+    volatile uint32_t next_sequence;
+    volatile uint32_t lost_events;
+    volatile uint32_t counters[ZZUSB_DIAG_COUNTER_COUNT];
+    struct zzusb_diag_event events[ZZUSB_DIAG_EVENT_COUNT];
+    uint32_t generation;
+};
+
+static struct zzusb_diag_state diag;
+
+_Static_assert(sizeof(struct zzusb_diag_event) == ZZUSB_DIAG_EVENT_SIZE,
+               "diagnostic event wire size changed");
+_Static_assert(ZZUSB_DIAG_OFF_EVENTS +
+               ZZUSB_DIAG_EVENT_COUNT * ZZUSB_DIAG_EVENT_SIZE <=
+               ZZUSB_DIAG_PAGE_SIZE,
+               "diagnostic page overflow");
+
+void zzusb_diag_reset(void)
+{
+    memset(&diag, 0, sizeof(diag));
+}
+
+void zzusb_diag_count(enum zzusb_diag_counter counter)
+{
+    if ((unsigned)counter < ZZUSB_DIAG_COUNTER_COUNT)
+        __atomic_add_fetch(&diag.counters[counter], 1U, __ATOMIC_RELAXED);
+}
+
+void zzusb_diag_high_water(uint32_t depth)
+{
+    uint32_t observed = __atomic_load_n(
+        &diag.counters[ZZUSB_DIAG_COUNT_QUEUE_HIGH_WATER], __ATOMIC_RELAXED);
+
+    while (depth > observed &&
+           !__atomic_compare_exchange_n(
+               &diag.counters[ZZUSB_DIAG_COUNT_QUEUE_HIGH_WATER],
+               &observed, depth, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+    }
+}
+
+void zzusb_diag_record(uint16_t type, uint16_t status,
+                       uint32_t request_id, uint32_t epoch,
+                       uint16_t address, uint8_t endpoint,
+                       uint8_t direction, uint16_t topology,
+                       uint16_t schedule, uint32_t detail,
+                       uint32_t timestamp)
+{
+    uint32_t sequence = __atomic_add_fetch(
+        &diag.next_sequence, 1U, __ATOMIC_RELAXED);
+    struct zzusb_diag_event *event =
+        &diag.events[(sequence - 1U) % ZZUSB_DIAG_EVENT_COUNT];
+
+    if (sequence > ZZUSB_DIAG_EVENT_COUNT)
+        __atomic_add_fetch(&diag.lost_events, 1U, __ATOMIC_RELAXED);
+
+    __atomic_store_n(&event->sequence, 0U, __ATOMIC_RELAXED);
+    event->request_id = request_id;
+    event->epoch = epoch;
+    event->detail = detail;
+    event->timestamp = timestamp;
+    event->type = type;
+    event->status = status;
+    event->address = address;
+    event->topology = topology;
+    event->endpoint = endpoint;
+    event->direction = direction;
+    event->schedule = schedule;
+    __atomic_store_n(&event->sequence, sequence, __ATOMIC_RELEASE);
+}
+
+static void encode_event(volatile uint8_t *dst,
+                         const struct zzusb_diag_event *event,
+                         uint32_t sequence)
+{
+    put_be32(dst + ZZUSB_DIAG_EVT_OFF_SEQUENCE, sequence);
+    put_be32(dst + ZZUSB_DIAG_EVT_OFF_REQUEST, event->request_id);
+    put_be32(dst + ZZUSB_DIAG_EVT_OFF_EPOCH, event->epoch);
+    put_be32(dst + ZZUSB_DIAG_EVT_OFF_DETAIL, event->detail);
+    put_be32(dst + ZZUSB_DIAG_EVT_OFF_TIMESTAMP, event->timestamp);
+    put_be16(dst + ZZUSB_DIAG_EVT_OFF_TYPE, event->type);
+    put_be16(dst + ZZUSB_DIAG_EVT_OFF_STATUS, event->status);
+    put_be16(dst + ZZUSB_DIAG_EVT_OFF_ADDRESS, event->address);
+    put_be16(dst + ZZUSB_DIAG_EVT_OFF_TOPOLOGY, event->topology);
+    dst[ZZUSB_DIAG_EVT_OFF_ENDPOINT] = event->endpoint;
+    dst[ZZUSB_DIAG_EVT_OFF_DIRECTION] = event->direction;
+    put_be16(dst + ZZUSB_DIAG_EVT_OFF_SCHEDULE, event->schedule);
+}
+
+void zzusb_diag_publish(volatile void *page, size_t page_size,
+                        uint32_t capabilities, uint32_t epoch,
+                        uint32_t last_request_id, uint32_t queue_state,
+                        uint32_t schedule_bits, zzusb_diag_flush_fn flush)
+{
+    volatile uint8_t *wire = (volatile uint8_t *)page;
+    uint32_t next;
+    uint32_t count;
+    uint32_t first;
+    uint32_t generation;
+    uint32_t encoded = 0;
+
+    if (!page || page_size < ZZUSB_DIAG_PAGE_SIZE)
+        return;
+
+    generation = (diag.generation + 2U) & ~1U;
+    if (generation == 0U)
+        generation = 2U;
+    diag.generation = generation;
+
+    put_be32(wire + ZZUSB_DIAG_OFF_GENERATION, generation - 1U);
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+    if (flush)
+        flush(wire, 64U);
+
+    next = __atomic_load_n(&diag.next_sequence, __ATOMIC_ACQUIRE);
+    count = next < ZZUSB_DIAG_EVENT_COUNT ? next : ZZUSB_DIAG_EVENT_COUNT;
+    first = count ? next - count + 1U : 0U;
+
+    put_be32(wire + ZZUSB_DIAG_OFF_MAGIC, ZZUSB_DIAG_MAGIC);
+    put_be16(wire + ZZUSB_DIAG_OFF_VERSION, ZZUSB_DIAG_VERSION);
+    put_be16(wire + ZZUSB_DIAG_OFF_HEADER_SIZE, ZZUSB_DIAG_OFF_EVENTS);
+    put_be32(wire + ZZUSB_DIAG_OFF_TOTAL_SIZE, ZZUSB_DIAG_PAGE_SIZE);
+    put_be32(wire + ZZUSB_DIAG_OFF_CAPABILITIES, capabilities);
+    put_be32(wire + ZZUSB_DIAG_OFF_EPOCH, epoch);
+    put_be32(wire + ZZUSB_DIAG_OFF_LAST_ID, last_request_id);
+    put_be32(wire + ZZUSB_DIAG_OFF_EVENT_NEXT, next);
+    put_be32(wire + ZZUSB_DIAG_OFF_LOST_EVENTS,
+             __atomic_load_n(&diag.lost_events, __ATOMIC_RELAXED));
+    put_be32(wire + ZZUSB_DIAG_OFF_QUEUE_STATE, queue_state);
+    put_be32(wire + ZZUSB_DIAG_OFF_SCHEDULE_BITS, schedule_bits);
+
+    for (uint32_t i = 0; i < ZZUSB_DIAG_COUNTER_COUNT; i++) {
+        put_be32(wire + ZZUSB_DIAG_OFF_COUNTERS + i * 4U,
+                 __atomic_load_n(&diag.counters[i], __ATOMIC_RELAXED));
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
+        uint32_t sequence = first + i;
+        const struct zzusb_diag_event *event =
+            &diag.events[(sequence - 1U) % ZZUSB_DIAG_EVENT_COUNT];
+        uint32_t committed = __atomic_load_n(&event->sequence, __ATOMIC_ACQUIRE);
+
+        if (committed != sequence)
+            continue;
+        encode_event(wire + ZZUSB_DIAG_OFF_EVENTS +
+                     encoded * ZZUSB_DIAG_EVENT_SIZE, event, sequence);
+        encoded++;
+    }
+    put_be32(wire + ZZUSB_DIAG_OFF_EVENT_COUNT, encoded);
+    for (uint32_t i = encoded; i < ZZUSB_DIAG_EVENT_COUNT; i++)
+        put_be32(wire + ZZUSB_DIAG_OFF_EVENTS +
+                   i * ZZUSB_DIAG_EVENT_SIZE, 0U);
+
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+    if (flush)
+        flush(wire, ZZUSB_DIAG_PAGE_SIZE);
+    put_be32(wire + ZZUSB_DIAG_OFF_GENERATION, generation);
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+    if (flush)
+        flush(wire, 8U);
+}
+
+int zzusb_diag_read_coherent(volatile const void *page, void *snapshot,
+                             size_t snapshot_size, unsigned retries)
+{
+    volatile const uint8_t *wire = (volatile const uint8_t *)page;
+    uint8_t *copy = (uint8_t *)snapshot;
+
+    if (!page || !snapshot || snapshot_size < ZZUSB_DIAG_PAGE_SIZE)
+        return 0;
+
+    while (retries--) {
+        uint32_t before = be32(wire + ZZUSB_DIAG_OFF_GENERATION);
+        if (before & 1U)
+            continue;
+        for (size_t i = 0; i < ZZUSB_DIAG_PAGE_SIZE; i++)
+            copy[i] = wire[i];
+        __atomic_thread_fence(__ATOMIC_ACQUIRE);
+        if (before == be32(wire + ZZUSB_DIAG_OFF_GENERATION) &&
+            before == be32(copy + ZZUSB_DIAG_OFF_GENERATION) &&
+            be32(copy + ZZUSB_DIAG_OFF_MAGIC) == ZZUSB_DIAG_MAGIC)
+            return 1;
+    }
+    return 0;
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_diag.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_diag.h
@@ -1,0 +1,109 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef ZZUSB_PROXY_DIAG_H
+#define ZZUSB_PROXY_DIAG_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define ZZUSB_DIAG_MAGIC             0x5a554447UL
+#define ZZUSB_DIAG_VERSION           1U
+#define ZZUSB_DIAG_PAGE_SIZE         4096U
+#define ZZUSB_DIAG_EVENT_COUNT       64U
+#define ZZUSB_DIAG_EVENT_SIZE        32U
+#define ZZUSB_DIAG_COUNTER_COUNT     16U
+
+#define ZZUSB_DIAG_OFF_MAGIC         0U
+#define ZZUSB_DIAG_OFF_GENERATION    4U
+#define ZZUSB_DIAG_OFF_VERSION       8U
+#define ZZUSB_DIAG_OFF_HEADER_SIZE   10U
+#define ZZUSB_DIAG_OFF_TOTAL_SIZE    12U
+#define ZZUSB_DIAG_OFF_CAPABILITIES  16U
+#define ZZUSB_DIAG_OFF_EPOCH         20U
+#define ZZUSB_DIAG_OFF_LAST_ID       24U
+#define ZZUSB_DIAG_OFF_EVENT_NEXT    28U
+#define ZZUSB_DIAG_OFF_EVENT_COUNT   32U
+#define ZZUSB_DIAG_OFF_LOST_EVENTS   36U
+#define ZZUSB_DIAG_OFF_QUEUE_STATE   40U
+#define ZZUSB_DIAG_OFF_SCHEDULE_BITS 44U
+#define ZZUSB_DIAG_OFF_COUNTERS      48U
+#define ZZUSB_DIAG_OFF_EVENTS        128U
+
+#define ZZUSB_DIAG_EVT_OFF_SEQUENCE  0U
+#define ZZUSB_DIAG_EVT_OFF_REQUEST   4U
+#define ZZUSB_DIAG_EVT_OFF_EPOCH     8U
+#define ZZUSB_DIAG_EVT_OFF_DETAIL    12U
+#define ZZUSB_DIAG_EVT_OFF_TIMESTAMP 16U
+#define ZZUSB_DIAG_EVT_OFF_TYPE      20U
+#define ZZUSB_DIAG_EVT_OFF_STATUS    22U
+#define ZZUSB_DIAG_EVT_OFF_ADDRESS   24U
+#define ZZUSB_DIAG_EVT_OFF_TOPOLOGY  26U
+#define ZZUSB_DIAG_EVT_OFF_ENDPOINT  28U
+#define ZZUSB_DIAG_EVT_OFF_DIRECTION 29U
+#define ZZUSB_DIAG_EVT_OFF_SCHEDULE  30U
+
+enum zzusb_diag_counter {
+    ZZUSB_DIAG_COUNT_REQUEST = 0,
+    ZZUSB_DIAG_COUNT_COMPLETION,
+    ZZUSB_DIAG_COUNT_TIMEOUT,
+    ZZUSB_DIAG_COUNT_LATE_COMPLETION,
+    ZZUSB_DIAG_COUNT_CANCELLATION,
+    ZZUSB_DIAG_COUNT_RESET,
+    ZZUSB_DIAG_COUNT_EHCI_ERROR,
+    ZZUSB_DIAG_COUNT_RECOVERY,
+    ZZUSB_DIAG_COUNT_STALE,
+    ZZUSB_DIAG_COUNT_QUEUE_HIGH_WATER,
+    ZZUSB_DIAG_COUNT_PERIODIC_ARM,
+    ZZUSB_DIAG_COUNT_PERIODIC_REAP,
+    ZZUSB_DIAG_COUNT_ISO_QUEUE,
+    ZZUSB_DIAG_COUNT_ISO_REAP
+};
+
+enum zzusb_diag_event_type {
+    ZZUSB_DIAG_EVENT_REQUEST = 1,
+    ZZUSB_DIAG_EVENT_COMPLETION,
+    ZZUSB_DIAG_EVENT_TIMEOUT,
+    ZZUSB_DIAG_EVENT_LATE_COMPLETION,
+    ZZUSB_DIAG_EVENT_CANCELLATION,
+    ZZUSB_DIAG_EVENT_RESET,
+    ZZUSB_DIAG_EVENT_EHCI_ERROR,
+    ZZUSB_DIAG_EVENT_RECOVERY,
+    ZZUSB_DIAG_EVENT_STALE,
+    ZZUSB_DIAG_EVENT_HIGH_WATER,
+    ZZUSB_DIAG_EVENT_PERIODIC,
+    ZZUSB_DIAG_EVENT_ISO
+};
+
+struct zzusb_diag_event {
+    volatile uint32_t sequence;
+    uint32_t request_id;
+    uint32_t epoch;
+    uint32_t detail;
+    uint32_t timestamp;
+    uint16_t type;
+    uint16_t status;
+    uint16_t address;
+    uint16_t topology;
+    uint8_t endpoint;
+    uint8_t direction;
+    uint16_t schedule;
+};
+
+typedef void (*zzusb_diag_flush_fn)(volatile void *address, size_t length);
+
+void zzusb_diag_reset(void);
+void zzusb_diag_count(enum zzusb_diag_counter counter);
+void zzusb_diag_high_water(uint32_t depth);
+void zzusb_diag_record(uint16_t type, uint16_t status,
+                       uint32_t request_id, uint32_t epoch,
+                       uint16_t address, uint8_t endpoint,
+                       uint8_t direction, uint16_t topology,
+                       uint16_t schedule, uint32_t detail,
+                       uint32_t timestamp);
+void zzusb_diag_publish(volatile void *page, size_t page_size,
+                        uint32_t capabilities, uint32_t epoch,
+                        uint32_t last_request_id, uint32_t queue_state,
+                        uint32_t schedule_bits, zzusb_diag_flush_fn flush);
+int zzusb_diag_read_coherent(volatile const void *page, void *snapshot,
+                             size_t snapshot_size, unsigned retries);
+
+#endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_iso.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_iso.c
@@ -125,6 +125,52 @@ static void iso_choose_asap(const struct usb_proxy_iso_batch *new_batch,
     *start_microframe = (uint8_t)(current & 7U);
 }
 
+static int iso_active_batch_overlaps(
+    const struct usb_proxy_iso_batch *new_batch,
+    const struct ehci_iso_config *config, uint16_t start_frame,
+    uint8_t start_microframe, unsigned packet_count)
+{
+    uint32_t start_uframe =
+        (uint32_t)start_frame * 8U + start_microframe;
+    uint32_t step = iso_interval_uframes(config);
+    unsigned slot;
+    unsigned packet;
+
+    for (slot = 0; slot < ZZUSB_ISO_MAX_BATCHES; slot++) {
+        const struct usb_proxy_iso_batch *batch = &iso_batches[slot];
+        unsigned existing_packet;
+        uint32_t absolute_uframe = start_uframe;
+
+        if (batch == new_batch || !batch->used || batch->ready ||
+            !batch->transfer.linked ||
+            batch->key.epoch != new_batch->key.epoch ||
+            batch->key.generation != new_batch->key.generation ||
+            batch->key.address != new_batch->key.address ||
+            batch->key.endpoint != new_batch->key.endpoint ||
+            batch->key.direction != new_batch->key.direction)
+            continue;
+        for (packet = 0; packet < packet_count; packet++) {
+            uint16_t frame = (uint16_t)(
+                (absolute_uframe >> 3) & EHCI_ISO_FRAME_MASK);
+            uint8_t microframe = (uint8_t)(absolute_uframe & 7U);
+
+            for (existing_packet = 0;
+                 existing_packet < batch->transfer.packet_count;
+                 existing_packet++) {
+                const struct ehci_iso_packet *existing =
+                    &batch->transfer.packets[existing_packet];
+
+                if (existing->frame == frame &&
+                    (config->split ||
+                     existing->microframe == microframe))
+                    return 1;
+            }
+            absolute_uframe += step;
+        }
+    }
+    return 0;
+}
+
 static void iso_mark_packets(struct usb_proxy_iso_batch *batch,
                              uint8_t status)
 {
@@ -263,6 +309,11 @@ uint16_t usb_proxy_iso_handle_queue(volatile struct ZZUSBCommand *cmd,
 
     if (flags & ZZUSB_ISO_FLAG_ASAP)
         iso_choose_asap(batch, ctrl, &start_frame, &start_microframe);
+    if (iso_active_batch_overlaps(batch, &config, start_frame,
+                                  start_microframe, packet_count)) {
+        memset(batch, 0, sizeof(*batch));
+        return ZZUSB_STATUS_BUSY;
+    }
     packets[0].frame = start_frame;
     packets[0].microframe = start_microframe;
     schedule_result = ehci_iso_schedule(&batch->transfer, ctrl, &config,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_iso.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_iso.c
@@ -100,7 +100,7 @@ static void iso_choose_asap(const struct usb_proxy_iso_batch *new_batch,
         uint32_t candidate;
         uint32_t distance;
 
-        if (batch == new_batch || !batch->used ||
+        if (batch == new_batch || !batch->used || batch->ready ||
             batch->key.epoch != new_batch->key.epoch ||
             batch->key.generation != new_batch->key.generation ||
             batch->key.address != new_batch->key.address ||

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_iso.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_iso.c
@@ -1,0 +1,440 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <stdint.h>
+#include <string.h>
+
+#include "xil_cache.h"
+#include "usb_proxy.h"
+#include "usb_proxy_diag.h"
+#include "usb_proxy_iso.h"
+#include "usb/ehci-iso.h"
+_Static_assert(ZZUSB_ISO_PACKET_OK == EHCI_ISO_PACKET_OK,
+               "ISO OK status drift");
+_Static_assert(ZZUSB_ISO_PACKET_PENDING == EHCI_ISO_PACKET_PENDING,
+               "ISO pending status drift");
+_Static_assert(ZZUSB_ISO_PACKET_SHORT == EHCI_ISO_PACKET_SHORT,
+               "ISO short status drift");
+_Static_assert(ZZUSB_ISO_PACKET_MISSED == EHCI_ISO_PACKET_MISSED,
+               "ISO missed status drift");
+_Static_assert(ZZUSB_ISO_PACKET_UNDERRUN == EHCI_ISO_PACKET_UNDERRUN,
+               "ISO underrun status drift");
+_Static_assert(ZZUSB_ISO_PACKET_OVERRUN == EHCI_ISO_PACKET_OVERRUN,
+               "ISO overrun status drift");
+_Static_assert(ZZUSB_ISO_PACKET_CANCELLED == EHCI_ISO_PACKET_CANCELLED,
+               "ISO cancelled status drift");
+_Static_assert(ZZUSB_ISO_PACKET_OFFLINE == EHCI_ISO_PACKET_OFFLINE,
+               "ISO offline status drift");
+_Static_assert(ZZUSB_ISO_PACKET_XACT == EHCI_ISO_PACKET_XACT,
+               "ISO transaction status drift");
+_Static_assert(ZZUSB_ISO_PACKET_BABBLE == EHCI_ISO_PACKET_BABBLE,
+               "ISO babble status drift");
+
+
+#ifndef ALIGN
+#define ALIGN(x, a) (((x) + ((a) - 1)) & ~((a) - 1))
+#endif
+
+#define ZZUSB_ISO_PUMP_BUDGET 2U
+
+struct usb_proxy_iso_key {
+    uint32_t epoch;
+    uint16_t generation;
+    uint16_t address;
+    uint16_t endpoint;
+    uint16_t direction;
+};
+
+struct usb_proxy_iso_batch {
+    struct usb_proxy_iso_key key;
+    struct ehci_iso_transfer transfer;
+    uint32_t batch_id;
+    uint32_t total_data;
+    uint16_t flags;
+    uint8_t used;
+    uint8_t ready;
+    uint8_t data[ZZUSB_ISO_DATA_MAX] __attribute__((aligned(32)));
+} __attribute__((aligned(32)));
+
+static struct usb_proxy_iso_batch iso_batches[ZZUSB_ISO_MAX_BATCHES]
+    __attribute__((aligned(32)));
+static uint8_t iso_pump_cursor;
+
+static struct ehci_ctrl *iso_controller(void)
+{
+    return usb_proxy_get_ehci_controller();
+}
+
+static int iso_identity_matches(const struct usb_proxy_iso_batch *batch,
+                                volatile struct ZZUSBCommand *cmd)
+{
+    return batch->used &&
+           batch->key.epoch == usb_proxy_get_controller_epoch() &&
+           batch->key.generation == be16(&cmd->reserved) &&
+           batch->key.address == be32(&cmd->dev_addr) &&
+           batch->key.endpoint == be16(&cmd->endpoint) &&
+           batch->key.direction == be16(&cmd->direction);
+}
+
+static unsigned iso_metadata_size(unsigned packet_count)
+{
+    return ZZUSB_ISO_HEADER_SIZE + packet_count * ZZUSB_ISO_PACKET_SIZE;
+}
+
+static uint32_t iso_interval_uframes(const struct ehci_iso_config *config)
+{
+    return (1U << (config->interval - 1U)) *
+           (config->speed == 3U ? 1U : 8U);
+}
+
+static void iso_choose_asap(const struct usb_proxy_iso_batch *new_batch,
+                            struct ehci_ctrl *ctrl,
+                            uint16_t *start_frame,
+                            uint8_t *start_microframe)
+{
+    uint32_t current = (uint32_t)ehci_iso_current_frame(ctrl) * 8U;
+    uint32_t best_distance = 32U;
+    unsigned slot;
+
+    for (slot = 0; slot < ZZUSB_ISO_MAX_BATCHES; slot++) {
+        const struct usb_proxy_iso_batch *batch = &iso_batches[slot];
+        const struct ehci_iso_packet *last;
+        uint32_t candidate;
+        uint32_t distance;
+
+        if (batch == new_batch || !batch->used ||
+            batch->key.epoch != new_batch->key.epoch ||
+            batch->key.generation != new_batch->key.generation ||
+            batch->key.address != new_batch->key.address ||
+            batch->key.endpoint != new_batch->key.endpoint ||
+            batch->key.direction != new_batch->key.direction ||
+            !batch->transfer.packet_count)
+            continue;
+        last = &batch->transfer.packets[
+            batch->transfer.packet_count - 1U];
+        candidate = ((uint32_t)last->frame * 8U +
+                     last->microframe +
+                     iso_interval_uframes(&batch->transfer.config)) &
+                    0x3fffU;
+        distance = (candidate - current) & 0x3fffU;
+        if (distance >= 32U && distance < 8192U &&
+            distance > best_distance)
+            best_distance = distance;
+    }
+
+    current = (current + best_distance) & 0x3fffU;
+    *start_frame = (uint16_t)(current >> 3);
+    *start_microframe = (uint8_t)(current & 7U);
+}
+
+static void iso_mark_packets(struct usb_proxy_iso_batch *batch,
+                             uint8_t status)
+{
+    unsigned packet;
+
+    batch->transfer.complete = 1;
+    for (packet = 0; packet < batch->transfer.packet_count; packet++) {
+        batch->transfer.packets[packet].actual = 0;
+        batch->transfer.packets[packet].status = status;
+    }
+    batch->ready = 1;
+    usb_proxy_refresh_event_irq();
+}
+
+static void iso_write_packet(uint8_t *wire, unsigned packet_index,
+                             const struct ehci_iso_packet *packet)
+{
+    uint8_t *entry = wire + ZZUSB_ISO_HEADER_SIZE +
+                     packet_index * ZZUSB_ISO_PACKET_SIZE;
+
+    put_be16(entry + ZZUSB_ISO_PKT_OFF_REQUESTED, packet->requested);
+    put_be16(entry + ZZUSB_ISO_PKT_OFF_ACTUAL, packet->actual);
+    put_be16(entry + ZZUSB_ISO_PKT_OFF_STATUS, packet->status);
+    put_be16(entry + ZZUSB_ISO_PKT_OFF_FRAME, packet->frame);
+    put_be32(entry + ZZUSB_ISO_PKT_OFF_DATA, packet->offset);
+    entry[ZZUSB_ISO_PKT_OFF_UFRAME] = packet->microframe;
+    entry[ZZUSB_ISO_PKT_OFF_UFRAME + 1U] = 0;
+    entry[ZZUSB_ISO_PKT_OFF_UFRAME + 2U] = 0;
+    entry[ZZUSB_ISO_PKT_OFF_UFRAME + 3U] = 0;
+}
+
+uint16_t usb_proxy_iso_handle_queue(volatile struct ZZUSBCommand *cmd,
+                                    uint8_t *wire)
+{
+    struct ehci_ctrl *ctrl = iso_controller();
+    struct usb_proxy_iso_batch *batch = NULL;
+    struct ehci_iso_config config;
+    struct ehci_iso_packet packets[ZZUSB_ISO_MAX_PACKETS];
+    uint32_t wire_length = be32(&cmd->data_length);
+    uint32_t total_data;
+    uint32_t batch_id;
+    uint32_t expected_offset = 0;
+    uint16_t packet_count;
+    uint16_t start_frame;
+    uint8_t start_microframe;
+    uint16_t flags;
+    unsigned metadata_size;
+    unsigned slot;
+    unsigned packet;
+    int schedule_result;
+
+    if (!ctrl || !wire || wire_length < ZZUSB_ISO_HEADER_SIZE ||
+        be32(wire + ZZUSB_ISO_HDR_OFF_MAGIC) != ZZUSB_ISO_MAGIC ||
+        be16(wire + ZZUSB_ISO_HDR_OFF_VERSION) != ZZUSB_ISO_VERSION)
+        return ZZUSB_STATUS_BADPARAM;
+
+    flags = be16(wire + ZZUSB_ISO_HDR_OFF_FLAGS);
+    batch_id = be32(wire + ZZUSB_ISO_HDR_OFF_BATCH_ID);
+    start_frame = be16(wire + ZZUSB_ISO_HDR_OFF_START) &
+                  EHCI_ISO_FRAME_MASK;
+    start_microframe = wire[ZZUSB_ISO_HDR_OFF_START_UFRAME];
+    packet_count = be16(wire + ZZUSB_ISO_HDR_OFF_COUNT);
+    total_data = be32(wire + ZZUSB_ISO_HDR_OFF_DATA_LEN);
+    if (!batch_id || !packet_count ||
+        packet_count > ZZUSB_ISO_MAX_PACKETS ||
+        total_data > ZZUSB_ISO_DATA_MAX || start_microframe > 7U)
+        return ZZUSB_STATUS_BADPARAM;
+    metadata_size = iso_metadata_size(packet_count);
+    if (wire_length < metadata_size ||
+        (be16(&cmd->direction) == 0 &&
+         wire_length != metadata_size + total_data) ||
+        (be16(&cmd->direction) == 0x80 && wire_length != metadata_size))
+        return ZZUSB_STATUS_BADPARAM;
+
+    for (slot = 0; slot < ZZUSB_ISO_MAX_BATCHES; slot++) {
+        if (!iso_batches[slot].used && !batch)
+            batch = &iso_batches[slot];
+        if (iso_identity_matches(&iso_batches[slot], cmd) &&
+            iso_batches[slot].batch_id == batch_id)
+            return ZZUSB_STATUS_STALE;
+    }
+    if (!batch)
+        return ZZUSB_STATUS_BUSY;
+
+    memset(batch, 0, sizeof(*batch));
+    batch->key.epoch = usb_proxy_get_controller_epoch();
+    batch->key.generation = be16(&cmd->reserved);
+    batch->key.address = (uint16_t)be32(&cmd->dev_addr);
+    batch->key.endpoint = be16(&cmd->endpoint);
+    batch->key.direction = be16(&cmd->direction);
+    batch->batch_id = batch_id;
+    batch->total_data = total_data;
+    batch->flags = flags;
+    batch->used = 1;
+
+    for (packet = 0; packet < packet_count; packet++) {
+        uint8_t *entry = wire + ZZUSB_ISO_HEADER_SIZE +
+                         packet * ZZUSB_ISO_PACKET_SIZE;
+        uint16_t requested = be16(entry + ZZUSB_ISO_PKT_OFF_REQUESTED);
+        uint32_t offset = be32(entry + ZZUSB_ISO_PKT_OFF_DATA);
+
+        if (offset != expected_offset ||
+            offset + requested > total_data) {
+            memset(batch, 0, sizeof(*batch));
+            return ZZUSB_STATUS_BADPARAM;
+        }
+        memset(&packets[packet], 0, sizeof(packets[packet]));
+        packets[packet].requested = requested;
+        packets[packet].offset = offset;
+        expected_offset += requested;
+    }
+    if (expected_offset != total_data) {
+        memset(batch, 0, sizeof(*batch));
+        return ZZUSB_STATUS_BADPARAM;
+    }
+    if (be16(&cmd->direction) == 0 && total_data)
+        memcpy(batch->data, wire + metadata_size, total_data);
+    else if (total_data)
+        memset(batch->data, 0, total_data);
+
+    memset(&config, 0, sizeof(config));
+    config.address = batch->key.address;
+    config.endpoint = batch->key.endpoint;
+    config.direction_in = batch->key.direction == 0x80;
+    config.speed = be16(&cmd->speed) == ZZUSB_SPEED_HIGH ? 3U :
+                   be16(&cmd->speed) == ZZUSB_SPEED_FULL ? 2U : 1U;
+    config.split = (be16(&cmd->flags) & ZZUSB_FLAG_SPLIT) != 0;
+    config.multi_tt = (be16(&cmd->flags) & ZZUSB_FLAG_MULTI_TT) != 0;
+    config.tt_think_time = (uint8_t)(
+        (be16(&cmd->flags) & ZZUSB_FLAG_TT_THINK_MASK) >>
+        ZZUSB_FLAG_TT_THINK_SHIFT);
+    config.interval = (uint8_t)be16(&cmd->interval);
+    config.hub_address = (uint8_t)be16(&cmd->split_hub_addr);
+    config.hub_port = (uint8_t)be16(&cmd->split_hub_port);
+    config.max_packet = be16(&cmd->max_pkt_size);
+
+    if (flags & ZZUSB_ISO_FLAG_ASAP)
+        iso_choose_asap(batch, ctrl, &start_frame, &start_microframe);
+    packets[0].frame = start_frame;
+    packets[0].microframe = start_microframe;
+    schedule_result = ehci_iso_schedule(&batch->transfer, ctrl, &config,
+                                        packets, packet_count, batch->data);
+    if (schedule_result == EHCI_ISO_ERR_MISSED) {
+        iso_mark_packets(batch, EHCI_ISO_PACKET_MISSED);
+    } else if (schedule_result < 0) {
+        if (batch->transfer.linked) {
+            iso_mark_packets(batch, EHCI_ISO_PACKET_OFFLINE);
+            return ZZUSB_STATUS_HOSTERROR;
+        }
+        memset(batch, 0, sizeof(*batch));
+        return schedule_result == EHCI_ISO_ERR_BANDWIDTH ?
+               ZZUSB_STATUS_BUSY : ZZUSB_STATUS_BADPARAM;
+    }
+
+    zzusb_diag_count(ZZUSB_DIAG_COUNT_ISO_QUEUE);
+    put_be32(&cmd->actual_length, 0);
+    return ZZUSB_STATUS_OK;
+}
+
+void usb_proxy_iso_pump(void)
+{
+    unsigned visited;
+
+    for (visited = 0; visited < ZZUSB_ISO_PUMP_BUDGET; visited++) {
+        struct usb_proxy_iso_batch *batch =
+            &iso_batches[iso_pump_cursor];
+
+        iso_pump_cursor = (uint8_t)((iso_pump_cursor + 1U) %
+                                    ZZUSB_ISO_MAX_BATCHES);
+        if (!batch->used || batch->ready || !batch->transfer.linked)
+            continue;
+        if (ehci_iso_poll(&batch->transfer) > 0) {
+            batch->ready = 1;
+            usb_proxy_refresh_event_irq();
+        }
+    }
+}
+
+uint16_t usb_proxy_iso_handle_reap(volatile struct ZZUSBCommand *cmd,
+                                   uint8_t *wire)
+{
+    uint32_t capacity = be32(&cmd->data_length);
+    unsigned slot;
+
+    for (slot = 0; slot < ZZUSB_ISO_MAX_BATCHES; slot++) {
+        struct usb_proxy_iso_batch *batch = &iso_batches[slot];
+        unsigned metadata_size;
+        unsigned output_size;
+        unsigned packet;
+
+        if (!batch->ready || !iso_identity_matches(batch, cmd))
+            continue;
+        metadata_size = iso_metadata_size(batch->transfer.packet_count);
+        output_size = metadata_size +
+            (batch->key.direction == 0x80 ? batch->total_data : 0U);
+        if (!wire || capacity < output_size)
+            return ZZUSB_STATUS_BADPARAM;
+        if (batch->transfer.linked &&
+            ehci_iso_retire(&batch->transfer,
+                            EHCI_ISO_PACKET_CANCELLED) < 0)
+            return ZZUSB_STATUS_HOSTERROR;
+
+        memset(wire, 0, output_size);
+        put_be32(wire + ZZUSB_ISO_HDR_OFF_MAGIC, ZZUSB_ISO_MAGIC);
+        put_be16(wire + ZZUSB_ISO_HDR_OFF_VERSION, ZZUSB_ISO_VERSION);
+        put_be16(wire + ZZUSB_ISO_HDR_OFF_FLAGS, batch->flags);
+        put_be32(wire + ZZUSB_ISO_HDR_OFF_BATCH_ID, batch->batch_id);
+        put_be16(wire + ZZUSB_ISO_HDR_OFF_START,
+                 batch->transfer.packets[0].frame);
+        put_be16(wire + ZZUSB_ISO_HDR_OFF_COUNT,
+                 batch->transfer.packet_count);
+        put_be32(wire + ZZUSB_ISO_HDR_OFF_DATA_LEN, batch->total_data);
+        wire[ZZUSB_ISO_HDR_OFF_START_UFRAME] =
+            batch->transfer.packets[0].microframe;
+        for (packet = 0; packet < batch->transfer.packet_count; packet++)
+            iso_write_packet(wire, packet,
+                             &batch->transfer.packets[packet]);
+        if (batch->key.direction == 0x80 && batch->total_data) {
+            Xil_DCacheInvalidateRange((u32)(uintptr_t)batch->data,
+                                      ALIGN(batch->total_data, 32));
+            memcpy(wire + metadata_size, batch->data, batch->total_data);
+        }
+        put_be32(&cmd->actual_length, output_size);
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_ISO_REAP);
+        memset(batch, 0, sizeof(*batch));
+        usb_proxy_refresh_event_irq();
+        return ZZUSB_STATUS_OK;
+    }
+    put_be32(&cmd->actual_length, 0);
+    return ZZUSB_STATUS_NAK;
+}
+
+uint16_t usb_proxy_iso_handle_stop(volatile struct ZZUSBCommand *cmd)
+{
+    unsigned slot;
+    int stopped = 0;
+
+    for (slot = 0; slot < ZZUSB_ISO_MAX_BATCHES; slot++) {
+        struct usb_proxy_iso_batch *batch = &iso_batches[slot];
+
+        if (!iso_identity_matches(batch, cmd))
+            continue;
+        if (batch->transfer.linked &&
+            ehci_iso_retire(&batch->transfer,
+                            EHCI_ISO_PACKET_CANCELLED) < 0)
+            return ZZUSB_STATUS_HOSTERROR;
+        memset(batch, 0, sizeof(*batch));
+        stopped = 1;
+    }
+    usb_proxy_refresh_event_irq();
+    put_be32(&cmd->actual_length, 0);
+    return stopped ? ZZUSB_STATUS_OK : ZZUSB_STATUS_NAK;
+}
+
+int usb_proxy_iso_stop_all(uint8_t unfinished_status)
+{
+    unsigned slot;
+    int result = 0;
+
+    for (slot = 0; slot < ZZUSB_ISO_MAX_BATCHES; slot++) {
+        struct usb_proxy_iso_batch *batch = &iso_batches[slot];
+
+        if (!batch->used)
+            continue;
+        if (batch->transfer.linked &&
+            ehci_iso_retire(&batch->transfer, unfinished_status) < 0) {
+            result = -1;
+            continue;
+        }
+        memset(batch, 0, sizeof(*batch));
+    }
+    usb_proxy_refresh_event_irq();
+    return result;
+}
+
+void usb_proxy_iso_after_controller_reset(void)
+{
+    memset(iso_batches, 0, sizeof(iso_batches));
+    ehci_iso_reset_bandwidth();
+    iso_pump_cursor = 0;
+}
+
+uint32_t usb_proxy_iso_queue_state(void)
+{
+    uint32_t active = 0;
+    uint32_t ready = 0;
+    unsigned slot;
+
+    for (slot = 0; slot < ZZUSB_ISO_MAX_BATCHES; slot++) {
+        if (iso_batches[slot].used)
+            active++;
+        if (iso_batches[slot].used && iso_batches[slot].ready)
+            ready++;
+    }
+    return (active << 24) | (ready << 28);
+}
+
+uint32_t usb_proxy_iso_schedule_bits(void)
+{
+    uint32_t high_speed = 0;
+    uint32_t split = 0;
+    unsigned slot;
+
+    for (slot = 0; slot < ZZUSB_ISO_MAX_BATCHES; slot++) {
+        if (!iso_batches[slot].used)
+            continue;
+        if (iso_batches[slot].transfer.config.split)
+            split++;
+        else
+            high_speed++;
+    }
+    return (high_speed & 0xffU) | ((split & 0xffU) << 8);
+}

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_iso.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_iso.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef ZZUSB_PROXY_ISO_H
+#define ZZUSB_PROXY_ISO_H
+
+#include <stdint.h>
+
+struct ZZUSBCommand;
+
+#define ZZUSB_ISO_MAGIC              0x5a49534fU
+#define ZZUSB_ISO_VERSION            1U
+#define ZZUSB_ISO_HEADER_SIZE        32U
+#define ZZUSB_ISO_PACKET_SIZE        16U
+#define ZZUSB_ISO_MAX_PACKETS        32U
+#define ZZUSB_ISO_MAX_BATCHES        8U
+#define ZZUSB_ISO_DATA_MAX           15840U
+
+#define ZZUSB_ISO_FLAG_ASAP          0x0001U
+#define ZZUSB_ISO_PACKET_OK         0U
+#define ZZUSB_ISO_PACKET_PENDING    1U
+#define ZZUSB_ISO_PACKET_SHORT      2U
+#define ZZUSB_ISO_PACKET_MISSED     3U
+#define ZZUSB_ISO_PACKET_UNDERRUN   4U
+#define ZZUSB_ISO_PACKET_OVERRUN    5U
+#define ZZUSB_ISO_PACKET_CANCELLED  6U
+#define ZZUSB_ISO_PACKET_OFFLINE    7U
+#define ZZUSB_ISO_PACKET_XACT       8U
+#define ZZUSB_ISO_PACKET_BABBLE     9U
+
+
+#define ZZUSB_ISO_HDR_OFF_MAGIC      0U
+#define ZZUSB_ISO_HDR_OFF_VERSION    4U
+#define ZZUSB_ISO_HDR_OFF_FLAGS      6U
+#define ZZUSB_ISO_HDR_OFF_BATCH_ID   8U
+#define ZZUSB_ISO_HDR_OFF_START      12U
+#define ZZUSB_ISO_HDR_OFF_COUNT      14U
+#define ZZUSB_ISO_HDR_OFF_DATA_LEN   16U
+#define ZZUSB_ISO_HDR_OFF_START_UFRAME 20U
+
+#define ZZUSB_ISO_PKT_OFF_REQUESTED  0U
+#define ZZUSB_ISO_PKT_OFF_ACTUAL     2U
+#define ZZUSB_ISO_PKT_OFF_STATUS     4U
+#define ZZUSB_ISO_PKT_OFF_FRAME      6U
+#define ZZUSB_ISO_PKT_OFF_DATA       8U
+#define ZZUSB_ISO_PKT_OFF_UFRAME     12U
+
+uint16_t usb_proxy_iso_handle_queue(volatile struct ZZUSBCommand *cmd,
+                                    uint8_t *wire);
+uint16_t usb_proxy_iso_handle_reap(volatile struct ZZUSBCommand *cmd,
+                                   uint8_t *wire);
+uint16_t usb_proxy_iso_handle_stop(volatile struct ZZUSBCommand *cmd);
+void usb_proxy_iso_pump(void);
+int usb_proxy_iso_stop_all(uint8_t unfinished_status);
+void usb_proxy_iso_after_controller_reset(void);
+uint32_t usb_proxy_iso_queue_state(void);
+uint32_t usb_proxy_iso_schedule_bits(void);
+
+#endif

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_periodic_ring.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/usb_proxy_periodic_ring.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef ZZUSB_PROXY_PERIODIC_RING_H
+#define ZZUSB_PROXY_PERIODIC_RING_H
+
+#include <stdint.h>
+
+#define ZZUSB_PERIODIC_RING_CAPACITY 16U
+
+static inline int zzusb_periodic_ring_push(
+    uint8_t entries[ZZUSB_PERIODIC_RING_CAPACITY],
+    uint8_t head, uint8_t *count, uint8_t value)
+{
+    unsigned position;
+    unsigned tail;
+
+    if (!entries || !count || *count >= ZZUSB_PERIODIC_RING_CAPACITY)
+        return 0;
+    for (position = 0; position < *count; position++)
+        if (entries[(head + position) % ZZUSB_PERIODIC_RING_CAPACITY] == value)
+            return 0;
+    tail = (head + *count) % ZZUSB_PERIODIC_RING_CAPACITY;
+    entries[tail] = value;
+    (*count)++;
+    return 1;
+}
+
+static inline int zzusb_periodic_ring_remove(
+    uint8_t entries[ZZUSB_PERIODIC_RING_CAPACITY],
+    uint8_t *head, uint8_t *count, unsigned position)
+{
+    unsigned current;
+
+    if (!entries || !head || !count || position >= *count)
+        return 0;
+    for (current = position; current + 1U < *count; current++)
+        entries[(*head + current) % ZZUSB_PERIODIC_RING_CAPACITY] =
+            entries[(*head + current + 1U) % ZZUSB_PERIODIC_RING_CAPACITY];
+    (*count)--;
+    if (!*count)
+        *head = 0;
+    return 1;
+}
+
+#endif

--- a/docs/usb-proxy-protocol.md
+++ b/docs/usb-proxy-protocol.md
@@ -1,0 +1,112 @@
+# ZZ9000 USB proxy protocol
+
+The USB proxy is a single-owner command/data aperture shared by Zynq firmware and `zzusbhw.device`. Multi-byte protocol fields are big-endian unless noted for USB setup packet fields. Commercial Poseidon 4.5 is above this contract and remains unchanged.
+
+## Aperture layout
+
+| Offset | Size | Owner while pending | Contents |
+|---|---:|---|---|
+| `0` | 48 | Driver, then firmware | Legacy `ZZUSBCommand` prefix |
+| `48` | 16 | Driver, then firmware | v2 extension |
+| `64` | 16384 | Matching request only | v2 transfer staging payload |
+| `16448` | 4032 | Reserved | Future bounded transport metadata |
+| `20480` | 4096 | Firmware publisher | v2 diagnostic snapshot page (capability-gated) |
+
+The physical aperture remains 24576 bytes. A legacy peer may use the historical payload extent from offset 64; v2 never stages more than 16 KiB. The legacy prefix and data offset never move.
+
+## Legacy prefix
+
+The packed 48-byte prefix is, in order: command, status, device address, endpoint, direction, transfer type, maximum packet size, requested length, actual length, timeout, speed, interval, the eight-byte USB setup packet, split-hub address, split-hub port, flags, and reserved word. Setup `wValue`, `wIndex`, and `wLength` remain USB little-endian; the other multi-byte values are big-endian. Persistent periodic commands use the reserved word as a device generation so a reused USB address cannot inherit an earlier endpoint.
+
+## v2 extension
+
+| Relative offset | Type | Field | Rule |
+|---|---|---|---|
+| `0` | `u16` | version | Exactly `2` |
+| `2` | `u16` | header size | Exactly `64` |
+| `4` | `u32` | request ID | Nonzero, monotonically advances within a negotiated session |
+| `8` | `u32` | controller epoch | Zero only in `QUERY_CAPS`; otherwise must match firmware |
+| `12` | `u32` | capabilities | Firmware capabilities on completion |
+
+A v2 driver ORs `ZZUSB_DOORBELL_V2` into the existing command-register write. Old firmware ignores the doorbell value and therefore returns `BADPARAM` to the appended `QUERY_CAPS` command; new firmware uses the marker to distinguish v2 from stale bytes left in the previously unused gap. An old driver never sets the marker, so new firmware always interprets it as v1 even when the gap contains old v2 data.
+
+## Negotiation and lifecycle
+
+1. A new driver sends `QUERY_CAPS` with v2 version/header, request ID 1, and epoch 0.
+2. New firmware returns its nonzero controller epoch and only implemented capabilities. The matched base capability set covers v2 framing, request IDs, epochs, validation, bounded diagnostics, persistent periodic interrupt endpoints, simple and realtime ISO transport, the USB event IRQ, and precise errors.
+3. `BADPARAM` selects constrained legacy mode. No v2 capability is advertised.
+4. Every later v2 command carries the negotiated epoch and a new request ID. Firmware rejects zero, duplicate/out-of-order, or wrong-epoch work before EHCI access.
+5. A successful controller reset advances the epoch. A completion is accepted only when its request ID matches; a non-reset response must also carry the expected epoch.
+6. A local legacy timeout quarantines the driver transport. It must not overwrite the uncertain mailbox. Later lifecycle work replaces polling with acknowledged retirement/reset semantics.
+
+Firmware snapshots the command and OUT payload before starting EHCI. It copies IN data and completion metadata back only if the shared request still matches. This is exact for v2 IDs/epochs and a best-effort immutable-field fence for v1.
+
+## Persistent interrupt transport
+
+`PERIODIC_ARM` creates or reuses one EHCI interrupt queue keyed by epoch, device generation, address, endpoint, direction, speed, maximum packet, interval, and split topology. Full/low-speed split queues encode the transaction-translator think time and multi-TT slot in legal start/complete masks. High-speed `bInterval` values use the USB 2.0 exponent rule. Firmware retains at most 16 endpoints and one unread completion per endpoint; it pauses that endpoint rather than overwrite unread data.
+
+`PERIODIC_REAP` returns one matching completion. `NAK`, a zero-length IN transaction, and an all-zero hub change report are non-terminal to the Poseidon request. A successful reap rearms the retained descriptor no sooner than its declared interval. Transfer errors are terminal and retire the endpoint. `PERIODIC_STOP`, reset, detach, epoch advance, and controller recovery retire matching queues through the fenced EHCI unlink path.
+
+Firmware raises interrupt-source bit `16` in `REG_ZZ_CONFIG` only after it queues data or a terminal error. The Amiga interrupt server acknowledges only that source by writing `8 | 256` and signals the mailbox-owning worker; it never accesses the mailbox itself. More unread completions cause firmware to reassert the coalesced source after a reap. The driver installs this shared server on INT6 by default or INT2 when `ZZ9000.CFG` selects `INT2`.
+
+## Isochronous transport
+
+`ISO_QUEUE`, `ISO_REAP`, and `ISO_STOP` use transfer type ISO and are available only in negotiated v2 mode. The firmware retains at most eight batches globally, with at most 32 packets and 15840 data bytes per batch. High-speed endpoints use iTDs; full-speed endpoints are accepted only behind a high-speed hub and use split-transaction siTDs. Low-speed ISO is invalid. High- and full-speed `bInterval` values use the USB 2.0 exponent rule.
+
+The batch header is 32 bytes:
+
+| Offset | Type | Field |
+|---|---|---|
+| `0` | `u32` | magic `0x5a49534f` (`ZISO`) |
+| `4` | `u16` | batch version `1` |
+| `6` | `u16` | flags; bit 0 requests ASAP scheduling |
+| `8` | `u32` | nonzero batch ID |
+| `12` | `u16` | starting frame, modulo 2048 |
+| `14` | `u16` | packet count, 1-32 |
+| `16` | `u32` | total packet data extent |
+| `20` | `u8` | starting microframe, 0-7 |
+| `21` | 11 bytes | reserved, zero |
+
+Each 16-byte packet entry contains requested length at offset 0, actual length at 2, status at 4, completed frame at 6, payload-relative data offset at 8, and completed microframe at 12. Remaining bytes are reserved. Packet status values are OK `0`, pending `1`, short `2`, missed `3`, underrun `4`, overrun `5`, cancelled `6`, offline `7`, transaction error `8`, and babble `9`.
+
+An OUT queue contains header, packet entries, then the complete data extent. An IN queue contains metadata only. A successful reap returns metadata plus the complete data extent for IN and metadata only for OUT. Packet offsets describe the requested layout, so a short packet does not change later packet offsets. The driver accepts a reap only when its endpoint identity and batch ID are still outstanding.
+
+Explicit scheduling preserves the requested frame and microframe. ASAP scheduling chooses a wrap-safe lead of at least four frames; later ASAP batches for the same endpoint chain after the last queued packet instead of choosing overlapping starts. Firmware raises the shared USB event source only for a reapable batch or actionable terminal condition. Pumping and harvesting are bounded in the main loop.
+
+`ISO_STOP`, reset, detach, and epoch invalidation unlink active descriptors, wait for the asynchronous schedule to retire, release bandwidth reservations, and discard both active and completed-but-unreaped batches before their storage can be reused.
+
+## Diagnostic snapshot page
+
+`ZZUSB_CAP_DIAGNOSTICS` makes the final 4096 bytes directly readable while the command mailbox is pending. The page is big-endian and starts with:
+
+| Offset | Type | Field |
+|---|---|---|
+| `0` | `u32` | magic `0x5a554447` |
+| `4` | `u32` | seqlock generation; odd while publishing |
+| `8` | `u16` | snapshot version `1` |
+| `10` | `u16` | header size `128` |
+| `12` | `u32` | total page size |
+| `16` | `u32` | firmware capabilities |
+| `20` | `u32` | controller epoch |
+| `24` | `u32` | last request ID |
+| `28` | `u32` | next event sequence |
+| `32` | `u32` | retained event count |
+| `36` | `u32` | overwritten/lost event count |
+| `40` | `u32` | queue state: mailbox in bits 0-7, periodic ready depth in bits 8-15, active periodic endpoints in bits 16-23 |
+| `44` | `u32` | EHCI command/status bits in the low half, aggregate periodic S/C masks in the high half |
+| `48` | 16 × `u32` | fixed counters |
+| `128` | 64 × 32 bytes | oldest-to-newest retained events |
+
+Each event contains sequence, request ID, epoch, detail, timestamp, type, status, address, topology, endpoint, direction, and schedule bits. A reader copies only when the generation is even and unchanged before and after the copy. Firmware flushes the odd generation, page body, and final even generation in that order. A legacy peer neither advertises the capability nor has its aperture tail interpreted as a snapshot.
+
+## Validation
+
+Firmware rejects malformed values before controller access: device address above 127, endpoint above 15, invalid direction or speed, payload beyond the negotiated extent, inconsistent setup length, illegal transfer type or interval, invalid maximum packet size, high-speed split use, or incomplete split hub/port topology. Split hub address and port are 1-127. TT mode and think time are meaningful only when the split flag is present.
+
+## Append-only commands
+
+Commands `0x01`-`0x0c` retain their legacy values. v2 appends capability query, endpoint retire/cancel, diagnostic snapshot, periodic arm/reap/stop, and ISO queue/reap/stop commands at `0x0d`-`0x16`. Periodic and ISO commands are capability-gated and implemented by the matched firmware/driver release.
+
+## Append-only statuses
+
+Legacy status values through `BADPARAM` (`0xf6`) remain unchanged. v2 appends `UNSUPPORTED`, `STALE`, `CANCELLED`, `HOSTERROR`, `BUSY`, and `NOMEM` down through `0xf0`. Unknown appended statuses are host errors to legacy drivers. Actual length is valid only for the matching completion and never exceeds the negotiated staging extent.

--- a/docs/usb-proxy-protocol.md
+++ b/docs/usb-proxy-protocol.md
@@ -89,15 +89,15 @@ Explicit scheduling preserves the requested frame and microframe. ASAP schedulin
 | `16` | `u32` | firmware capabilities |
 | `20` | `u32` | controller epoch |
 | `24` | `u32` | last request ID |
-| `28` | `u32` | next event sequence |
+| `28` | `u32` | next physical event-ring slot (`0`-`63`); when the ring is full this is also the oldest retained slot |
 | `32` | `u32` | retained event count |
 | `36` | `u32` | overwritten/lost event count |
 | `40` | `u32` | queue state: mailbox in bits 0-7, periodic ready depth in bits 8-15, active periodic endpoints in bits 16-23 |
 | `44` | `u32` | EHCI command/status bits in the low half, aggregate periodic S/C masks in the high half |
 | `48` | 16 × `u32` | fixed counters |
-| `128` | 64 × 32 bytes | oldest-to-newest retained events |
+| `128` | 64 × 32 bytes | events in physical ring slots |
 
-Each event contains sequence, request ID, epoch, detail, timestamp, type, status, address, topology, endpoint, direction, and schedule bits. A reader copies only when the generation is even and unchanged before and after the copy. Firmware flushes the odd generation, page body, and final even generation in that order. A legacy peer neither advertises the capability nor has its aperture tail interpreted as a snapshot.
+Each event contains sequence, request ID, epoch, detail, timestamp, type, status, address, topology, endpoint, direction, and schedule bits. Before the first wrap, the retained events occupy slots zero through `count - 1`. Once `count` is 64, readers start at the slot from offset 28 and wrap modulo 64 to traverse oldest-to-newest. The sequence stored in each event is the authoritative monotonic identity and lets readers detect overwritten or concurrently replaced slots. A reader copies only when the generation is even and unchanged before and after the copy. Firmware flushes the odd generation, page body, and final even generation in that order. A legacy peer neither advertises the capability nor has its aperture tail interpreted as a snapshot.
 
 ## Validation
 

--- a/test/usb/Makefile
+++ b/test/usb/Makefile
@@ -1,0 +1,61 @@
+CC ?= cc
+CFLAGS ?= -O2 -g -Wall -Wextra -Werror -std=c11
+
+SRC_DIR := ../../ZZ9000_proto.sdk/ZZ9000OS/src
+BUILD_DIR := build
+TARGETS := $(BUILD_DIR)/usb_proxy_protocol_test $(BUILD_DIR)/usb_proxy_recovery_test \
+	$(BUILD_DIR)/ehci_lifecycle_test $(BUILD_DIR)/usb_proxy_diag_test \
+	$(BUILD_DIR)/ehci_periodic_test $(BUILD_DIR)/usb_event_irq_test \
+	$(BUILD_DIR)/ehci_iso_test $(BUILD_DIR)/usb_proxy_iso_test
+
+CPPFLAGS += -Istubs -I$(SRC_DIR)
+
+.PHONY: test clean
+
+test: $(TARGETS)
+	$(BUILD_DIR)/usb_proxy_protocol_test
+	$(BUILD_DIR)/usb_proxy_recovery_test
+	$(BUILD_DIR)/ehci_lifecycle_test
+	$(BUILD_DIR)/usb_proxy_diag_test
+	$(BUILD_DIR)/ehci_periodic_test
+	$(BUILD_DIR)/usb_event_irq_test
+	$(BUILD_DIR)/ehci_iso_test
+	$(BUILD_DIR)/usb_proxy_iso_test
+
+$(BUILD_DIR)/usb_proxy_protocol_test: usb_proxy_protocol_test.c $(SRC_DIR)/usb_proxy.h stubs/xil_types.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ usb_proxy_protocol_test.c
+
+$(BUILD_DIR)/usb_proxy_recovery_test: usb_proxy_recovery_test.c $(SRC_DIR)/usb_proxy.h stubs/xil_types.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ usb_proxy_recovery_test.c
+
+$(BUILD_DIR)/ehci_lifecycle_test: ehci_lifecycle_test.c $(SRC_DIR)/usb/ehci_lifecycle.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ ehci_lifecycle_test.c
+
+$(BUILD_DIR)/usb_proxy_diag_test: usb_proxy_diag_test.c $(SRC_DIR)/usb_proxy_diag.c $(SRC_DIR)/usb_proxy_diag.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ usb_proxy_diag_test.c $(SRC_DIR)/usb_proxy_diag.c
+
+$(BUILD_DIR)/ehci_periodic_test: ehci_periodic_test.c $(SRC_DIR)/usb/ehci_periodic.h $(SRC_DIR)/usb_proxy_periodic_ring.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ ehci_periodic_test.c
+
+$(BUILD_DIR)/usb_event_irq_test: usb_event_irq_test.c $(SRC_DIR)/usb_event_irq.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ usb_event_irq_test.c
+
+$(BUILD_DIR)/ehci_iso_test: ehci_iso_test.c $(SRC_DIR)/usb/ehci-iso.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ ehci_iso_test.c
+
+$(BUILD_DIR)/usb_proxy_iso_test: usb_proxy_iso_test.c $(SRC_DIR)/usb_proxy_iso.c \
+		$(SRC_DIR)/usb_proxy_iso.h $(SRC_DIR)/usb/ehci-iso.h \
+		stubs/xil_cache.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ usb_proxy_iso_test.c \
+		$(SRC_DIR)/usb_proxy_iso.c
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/test/usb/ehci_iso_test.c
+++ b/test/usb/ehci_iso_test.c
@@ -11,6 +11,16 @@ static void test_frame_wrap(void)
     assert(ehci_iso_frame_distance(2, 2046) == 4);
     assert(ehci_iso_frame_distance(2046, 2) == 2044);
     assert(ehci_iso_frame_distance(0, 0) == 0);
+    assert(ehci_iso_frame_schedulable(2, 2046));
+    assert(!ehci_iso_frame_schedulable(1, 2046));
+    assert(!ehci_iso_frame_schedulable(1024, 0));
+}
+
+static void test_itd_completion_length(void)
+{
+    assert(ehci_iso_itd_actual(1024U << 16, 1024) == 1024);
+    assert(ehci_iso_itd_actual(64U << 16, 1024) == 64);
+    assert(ehci_iso_itd_actual(1025U << 16, 1024) == 0);
 }
 
 static void test_split_masks(void)
@@ -106,6 +116,7 @@ static void test_sitd_builder(void)
 int main(void)
 {
     test_frame_wrap();
+    test_itd_completion_length();
     test_split_masks();
     test_itd_builder();
     test_sitd_builder();

--- a/test/usb/ehci_iso_test.c
+++ b/test/usb/ehci_iso_test.c
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "usb/ehci-iso.h"
+
+static void test_frame_wrap(void)
+{
+    assert(ehci_iso_frame_distance(2, 2046) == 4);
+    assert(ehci_iso_frame_distance(2046, 2) == 2044);
+    assert(ehci_iso_frame_distance(0, 0) == 0);
+}
+
+static void test_split_masks(void)
+{
+    uint8_t smask;
+    uint8_t cmask;
+
+    assert(ehci_iso_split_masks(188, 1, 0, 0, 0, &smask, &cmask));
+    assert(smask == 0x01);
+    assert(cmask == 0x1c);
+
+    assert(ehci_iso_split_masks(376, 0, 0, 1, 1, &smask, &cmask));
+    assert(smask == 0x06);
+    assert(cmask == 0);
+
+    assert(ehci_iso_split_masks(1023, 1, 0, 0, 0, &smask, &cmask));
+    assert(smask == 0x01);
+    assert(cmask == 0xfc);
+
+    assert(!ehci_iso_split_masks(1024, 0, 0, 0, 0, &smask, &cmask));
+    assert(!ehci_iso_split_masks(1, 1, 4, 0, 0, &smask, &cmask));
+}
+
+static void test_itd_builder(void)
+{
+    struct ehci_iso_config config;
+    struct ehci_iso_itd itd;
+
+    memset(&config, 0, sizeof(config));
+    config.address = 5;
+    config.endpoint = 3;
+    config.direction_in = 1;
+    config.max_packet = 0x13ff;
+
+    assert(ehci_iso_build_itd(&itd, &config, 0x12345f80,
+                              3069, 7, 0xdead0002));
+    assert(itd.next == 0xdead0002);
+    for (unsigned index = 0; index < 7; index++)
+        assert(itd.transaction[index] == 0);
+    assert(itd.transaction[7] ==
+           (EHCI_ITD_ACTIVE | EHCI_ITD_IOC | (3069U << 16) | 0x0f80U));
+    assert(itd.buffer[0] == 0x12345305);
+    assert(itd.buffer[1] == 0x123463ff);
+    assert(itd.buffer[2] == 0x12347803);
+    assert(itd.buffer[6] == 0x1234b000);
+
+    assert(!ehci_iso_build_itd(&itd, &config, 0x12345f80,
+                               3070, 0, EHCI_ISO_LINK_TERMINATE));
+    assert(!ehci_iso_build_itd(&itd, &config, 0x12345f80,
+                               1, 8, EHCI_ISO_LINK_TERMINATE));
+
+    config.max_packet = 64;
+    assert(ehci_iso_build_itd(&itd, &config, 0x10000000,
+                              0, 0, EHCI_ISO_LINK_TERMINATE));
+    assert(itd.transaction[0] == (EHCI_ITD_ACTIVE | EHCI_ITD_IOC));
+}
+
+static void test_sitd_builder(void)
+{
+    struct ehci_iso_config config;
+    struct ehci_iso_sitd sitd;
+
+    memset(&config, 0, sizeof(config));
+    config.address = 9;
+    config.endpoint = 4;
+    config.direction_in = 1;
+    config.hub_address = 2;
+    config.hub_port = 3;
+
+    assert(ehci_iso_build_sitd(&sitd, &config, 0x20000ff0,
+                               1000, 0x01, 0x1c, 0x12340002));
+    assert(sitd.next == 0x12340002);
+    assert(sitd.endpoint == 0x83020409);
+    assert(sitd.uframe == 0x00001c01);
+    assert(sitd.results ==
+           (EHCI_SITD_IOC | EHCI_SITD_ACTIVE | (1000U << 16)));
+    assert(sitd.buffer[0] == 0x20000ff0);
+    assert(sitd.buffer[1] == 0x20001000);
+    assert(sitd.back == EHCI_ISO_LINK_TERMINATE);
+
+    config.direction_in = 0;
+    assert(ehci_iso_build_sitd(&sitd, &config, 0x20000ff0,
+                               376, 0x03, 0, EHCI_ISO_LINK_TERMINATE));
+    assert(sitd.endpoint == 0x03020409);
+    assert(sitd.buffer[1] == 0x2000100a);
+
+    assert(!ehci_iso_build_sitd(&sitd, &config, 0x20000ff0,
+                                1024, 1, 0, EHCI_ISO_LINK_TERMINATE));
+    assert(!ehci_iso_build_sitd(&sitd, &config, 0x20000ff0,
+                                1, 0, 0, EHCI_ISO_LINK_TERMINATE));
+}
+
+int main(void)
+{
+    test_frame_wrap();
+    test_split_masks();
+    test_itd_builder();
+    test_sitd_builder();
+    puts("ehci_iso_test: ok");
+    return 0;
+}

--- a/test/usb/ehci_lifecycle_test.c
+++ b/test/usb/ehci_lifecycle_test.c
@@ -28,6 +28,11 @@ int main(void)
     CHECK(ehci_deadline_expired_u32(12u, start, 20u));
     CHECK(ehci_deadline_expired_u32(200u, start, 20u));
 
+    CHECK(!ehci_deadline_reached_u32(UINT32_MAX - 4u, 20u));
+    CHECK(!ehci_deadline_reached_u32(19u, 20u));
+    CHECK(ehci_deadline_reached_u32(20u, 20u));
+    CHECK(ehci_deadline_reached_u32(21u, 20u));
+
     puts("EHCI lifetime and wrap-safe deadline contract satisfied");
     return EXIT_SUCCESS;
 }

--- a/test/usb/ehci_lifecycle_test.c
+++ b/test/usb/ehci_lifecycle_test.c
@@ -1,0 +1,33 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "usb/ehci_lifecycle.h"
+
+#define CHECK(expr) do {     if (!(expr)) {         fprintf(stderr, "%s:%d: check failed: %s\n",                 __FILE__, __LINE__, #expr);         return EXIT_FAILURE;     } } while (0)
+
+static int descriptors_are_freed(int unlink_acknowledged,
+                                 int schedule_stopped,
+                                 int controller_reset)
+{
+    return ehci_dma_reclaimable(unlink_acknowledged, schedule_stopped,
+                                controller_reset);
+}
+
+int main(void)
+{
+    uint32_t start = UINT32_MAX - 7u;
+
+    CHECK(!descriptors_are_freed(0, 0, 0));
+    CHECK(descriptors_are_freed(1, 0, 0));
+    CHECK(descriptors_are_freed(0, 1, 0));
+    CHECK(descriptors_are_freed(0, 0, 1));
+
+    CHECK(!ehci_deadline_expired_u32(start + 4u, start, 20u));
+    CHECK(!ehci_deadline_expired_u32(3u, start, 20u));
+    CHECK(ehci_deadline_expired_u32(12u, start, 20u));
+    CHECK(ehci_deadline_expired_u32(200u, start, 20u));
+
+    puts("EHCI lifetime and wrap-safe deadline contract satisfied");
+    return EXIT_SUCCESS;
+}

--- a/test/usb/ehci_periodic_test.c
+++ b/test/usb/ehci_periodic_test.c
@@ -27,6 +27,13 @@ static void test_high_speed_cadence(void)
     assert(plan.interval_microframes == 32768);
     assert(plan.frame_interval == 4096);
     assert(ehci_periodic_hardware_frame_interval(&plan) == 1024);
+    assert(ehci_periodic_frame_list_cycles(&plan) == 4);
+    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 15, 0,
+                                    0, 0, 0, &plan));
+    assert(plan.frame_interval == 2048);
+    assert(ehci_periodic_frame_list_cycles(&plan) == 2);
+    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 16, 0,
+                                    0, 0, 0, &plan));
     assert(ehci_periodic_frame_due(&plan, 0));
     assert(!ehci_periodic_frame_due(&plan, 1));
     assert(plan.start_mask == 0x01);

--- a/test/usb/ehci_periodic_test.c
+++ b/test/usb/ehci_periodic_test.c
@@ -1,0 +1,91 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "usb/ehci_periodic.h"
+#include "usb_proxy_periodic_ring.h"
+
+static void test_high_speed_cadence(void)
+{
+    struct ehci_periodic_plan plan;
+
+    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 1, 0,
+                                    0, 0, 0, &plan));
+    assert(plan.interval_microframes == 1);
+    assert(plan.frame_interval == 1);
+    assert(plan.start_mask == 0xff);
+    assert(plan.complete_mask == 0);
+
+    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 3, 0,
+                                    0, 0, 0, &plan));
+    assert(plan.interval_microframes == 4);
+    assert(plan.start_mask == 0x11);
+
+    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 16, 0,
+                                    0, 0, 0, &plan));
+    assert(plan.interval_microframes == 32768);
+    assert(plan.frame_interval == 4096);
+    assert(plan.start_mask == 0x01);
+    assert(!ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 17, 0,
+                                     0, 0, 0, &plan));
+}
+
+static void test_split_masks(void)
+{
+    struct ehci_periodic_plan plan;
+
+    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_FULL, 8, 1,
+                                    0, 0, 0, &plan));
+    assert(plan.interval_microframes == 64);
+    assert(plan.frame_interval == 8);
+    assert(plan.start_mask == 0x01);
+    assert(plan.complete_mask == 0x1c);
+
+    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_LOW, 10, 1,
+                                    2, 1, 3, &plan));
+    assert(plan.start_mask == 0x02);
+    assert(plan.complete_mask == 0xe0);
+
+    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_FULL, 1, 1,
+                                    3, 1, 1, &plan));
+    assert(plan.start_mask == 0x01);
+    assert(plan.complete_mask == 0xe0);
+    assert(!ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_FULL, 1, 1,
+                                     4, 0, 0, &plan));
+}
+
+static void test_ready_ring_wrap_and_no_overwrite(void)
+{
+    uint8_t entries[ZZUSB_PERIODIC_RING_CAPACITY];
+    uint8_t head = 0;
+    uint8_t count = 0;
+    unsigned value;
+
+    memset(entries, 0, sizeof(entries));
+    for (value = 0; value < ZZUSB_PERIODIC_RING_CAPACITY; value++)
+        assert(zzusb_periodic_ring_push(entries, head, &count,
+                                        (uint8_t)value));
+    assert(count == ZZUSB_PERIODIC_RING_CAPACITY);
+    assert(!zzusb_periodic_ring_push(entries, head, &count, 17));
+    assert(!zzusb_periodic_ring_push(entries, head, &count, 3));
+
+    assert(zzusb_periodic_ring_remove(entries, &head, &count, 5));
+    assert(count == ZZUSB_PERIODIC_RING_CAPACITY - 1);
+    assert(entries[5] == 6);
+    assert(zzusb_periodic_ring_push(entries, head, &count, 17));
+    assert(entries[ZZUSB_PERIODIC_RING_CAPACITY - 1] == 17);
+
+    while (count)
+        assert(zzusb_periodic_ring_remove(entries, &head, &count, 0));
+    assert(head == 0);
+}
+
+int main(void)
+{
+    test_high_speed_cadence();
+    test_split_masks();
+    test_ready_ring_wrap_and_no_overwrite();
+    puts("EHCI periodic cadence, split masks, and bounded ring contract satisfied");
+    return 0;
+}

--- a/test/usb/ehci_periodic_test.c
+++ b/test/usb/ehci_periodic_test.c
@@ -27,13 +27,6 @@ static void test_high_speed_cadence(void)
     assert(plan.interval_microframes == 32768);
     assert(plan.frame_interval == 4096);
     assert(ehci_periodic_hardware_frame_interval(&plan) == 1024);
-    assert(ehci_periodic_frame_list_cycles(&plan) == 4);
-    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 15, 0,
-                                    0, 0, 0, &plan));
-    assert(plan.frame_interval == 2048);
-    assert(ehci_periodic_frame_list_cycles(&plan) == 2);
-    assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 16, 0,
-                                    0, 0, 0, &plan));
     assert(ehci_periodic_frame_due(&plan, 0));
     assert(!ehci_periodic_frame_due(&plan, 1));
     assert(plan.start_mask == 0x01);

--- a/test/usb/ehci_periodic_test.c
+++ b/test/usb/ehci_periodic_test.c
@@ -26,6 +26,9 @@ static void test_high_speed_cadence(void)
                                     0, 0, 0, &plan));
     assert(plan.interval_microframes == 32768);
     assert(plan.frame_interval == 4096);
+    assert(ehci_periodic_hardware_frame_interval(&plan) == 1024);
+    assert(ehci_periodic_frame_due(&plan, 0));
+    assert(!ehci_periodic_frame_due(&plan, 1));
     assert(plan.start_mask == 0x01);
     assert(!ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 17, 0,
                                      0, 0, 0, &plan));
@@ -44,6 +47,10 @@ static void test_split_masks(void)
 
     assert(ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_LOW, 10, 1,
                                     2, 1, 3, &plan));
+    assert(plan.interval_microframes == 64);
+    assert(plan.frame_interval == 8);
+    assert(ehci_periodic_frame_due(&plan, 8));
+    assert(!ehci_periodic_frame_due(&plan, 10));
     assert(plan.start_mask == 0x02);
     assert(plan.complete_mask == 0xe0);
 

--- a/test/usb/ehci_periodic_test.c
+++ b/test/usb/ehci_periodic_test.c
@@ -27,11 +27,17 @@ static void test_high_speed_cadence(void)
     assert(plan.interval_microframes == 32768);
     assert(plan.frame_interval == 4096);
     assert(ehci_periodic_hardware_frame_interval(&plan) == 1024);
+    assert(plan.frame_phase == 0);
     assert(ehci_periodic_frame_due(&plan, 0));
     assert(!ehci_periodic_frame_due(&plan, 1));
     assert(plan.start_mask == 0x01);
     assert(!ehci_periodic_build_plan(EHCI_PERIODIC_SPEED_HIGH, 17, 0,
                                      0, 0, 0, &plan));
+
+    plan.frame_interval = 1024;
+    plan.frame_phase = 1023;
+    assert(ehci_periodic_frame_due(&plan, 1023));
+    assert(!ehci_periodic_frame_due(&plan, 0));
 }
 
 static void test_split_masks(void)

--- a/test/usb/ehci_periodic_test.c
+++ b/test/usb/ehci_periodic_test.c
@@ -68,6 +68,12 @@ static void test_split_masks(void)
                                      4, 0, 0, &plan));
 }
 
+static void test_transient_buffer_retirement(void)
+{
+    assert(ehci_periodic_buffer_reclaimable(0));
+    assert(!ehci_periodic_buffer_reclaimable(1));
+}
+
 static void test_ready_ring_wrap_and_no_overwrite(void)
 {
     uint8_t entries[ZZUSB_PERIODIC_RING_CAPACITY];
@@ -98,6 +104,7 @@ int main(void)
 {
     test_high_speed_cadence();
     test_split_masks();
+    test_transient_buffer_retirement();
     test_ready_ring_wrap_and_no_overwrite();
     puts("EHCI periodic cadence, split masks, and bounded ring contract satisfied");
     return 0;

--- a/test/usb/stubs/xil_cache.h
+++ b/test/usb/stubs/xil_cache.h
@@ -1,0 +1,18 @@
+#ifndef TEST_XIL_CACHE_H
+#define TEST_XIL_CACHE_H
+
+#include "xil_types.h"
+
+static inline void Xil_DCacheFlushRange(u32 address, u32 length)
+{
+    (void)address;
+    (void)length;
+}
+
+static inline void Xil_DCacheInvalidateRange(u32 address, u32 length)
+{
+    (void)address;
+    (void)length;
+}
+
+#endif

--- a/test/usb/stubs/xil_types.h
+++ b/test/usb/stubs/xil_types.h
@@ -1,0 +1,11 @@
+#ifndef TEST_USB_XIL_TYPES_H
+#define TEST_USB_XIL_TYPES_H
+
+#include <stdint.h>
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+#endif

--- a/test/usb/usb_event_irq_test.c
+++ b/test/usb/usb_event_irq_test.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "usb_event_irq.h"
+
+static uint32_t acknowledge(uint32_t pending, uint16_t value)
+{
+    return pending & ~zzusb_event_ack_mask(value);
+}
+
+int main(void)
+{
+    uint32_t shared = 1U | 2U | 4U | ZZUSB_EVENT_INTERRUPT_BIT;
+
+    assert(zzusb_event_ack_mask(ZZUSB_EVENT_ACK_USB) == 0);
+    assert(zzusb_event_ack_mask(ZZUSB_EVENT_ACK_GATE) == 0);
+    assert(zzusb_event_ack_mask(ZZUSB_EVENT_ACK_GATE |
+                                ZZUSB_EVENT_ACK_USB) ==
+           ZZUSB_EVENT_INTERRUPT_BIT);
+    assert(acknowledge(shared, ZZUSB_EVENT_ACK_GATE |
+                      ZZUSB_EVENT_ACK_USB) == (1U | 2U | 4U));
+    assert(acknowledge(shared, ZZUSB_EVENT_ACK_GATE | 16U) == shared);
+    assert((shared | ZZUSB_EVENT_INTERRUPT_BIT) == shared);
+
+    puts("USB event IRQ acknowledge and shared-source coexistence satisfied");
+    return 0;
+}

--- a/test/usb/usb_proxy_diag_test.c
+++ b/test/usb/usb_proxy_diag_test.c
@@ -69,7 +69,7 @@ int main(void)
     CHECK(read_be32(page + ZZUSB_DIAG_OFF_MAGIC) == ZZUSB_DIAG_MAGIC);
     CHECK((read_be32(page + ZZUSB_DIAG_OFF_GENERATION) & 1u) == 0u);
     CHECK(read_be16(page + ZZUSB_DIAG_OFF_VERSION) == ZZUSB_DIAG_VERSION);
-    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENT_NEXT) == 201u);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENT_NEXT) == 9u);
     CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENT_COUNT) == 64u);
     CHECK(read_be32(page + ZZUSB_DIAG_OFF_LOST_EVENTS) == 137u);
     CHECK(read_be32(page + ZZUSB_DIAG_OFF_COUNTERS +
@@ -77,9 +77,10 @@ int main(void)
     CHECK(read_be32(page + ZZUSB_DIAG_OFF_COUNTERS +
                     ZZUSB_DIAG_COUNT_QUEUE_HIGH_WATER * 4u) == 9u);
     CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENTS +
+                    9u * ZZUSB_DIAG_EVENT_SIZE +
                     ZZUSB_DIAG_EVT_OFF_SEQUENCE) == 138u);
     CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENTS +
-                    63u * ZZUSB_DIAG_EVENT_SIZE +
+                    8u * ZZUSB_DIAG_EVENT_SIZE +
                     ZZUSB_DIAG_EVT_OFF_SEQUENCE) == 201u);
 
     CHECK(zzusb_diag_read_coherent(page, snapshot,
@@ -93,9 +94,9 @@ int main(void)
 
     zzusb_diag_publish(page, sizeof(page), 0x1fu, 7u, 201u,
                        0u, 0u, NULL);
-    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENT_NEXT) == 201u);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENT_NEXT) == 9u);
     CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENTS +
-                    63u * ZZUSB_DIAG_EVENT_SIZE +
+                    8u * ZZUSB_DIAG_EVENT_SIZE +
                     ZZUSB_DIAG_EVT_OFF_SEQUENCE) == 201u);
 
     puts("USB diagnostic ring and seqlock snapshot contract satisfied");

--- a/test/usb/usb_proxy_diag_test.c
+++ b/test/usb/usb_proxy_diag_test.c
@@ -1,0 +1,103 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "usb_proxy_diag.h"
+
+#define CHECK(expr) do { \
+    if (!(expr)) { \
+        fprintf(stderr, "%s:%d: check failed: %s\n", \
+                __FILE__, __LINE__, #expr); \
+        return EXIT_FAILURE; \
+    } \
+} while (0)
+
+static uint8_t page[ZZUSB_DIAG_PAGE_SIZE];
+static uint8_t snapshot[ZZUSB_DIAG_PAGE_SIZE];
+static uint8_t mailbox[128];
+static int inject_during_publish;
+
+static uint16_t read_be16(const uint8_t *src)
+{
+    return (uint16_t)(((uint16_t)src[0] << 8) | src[1]);
+}
+
+static uint32_t read_be32(const uint8_t *src)
+{
+    return ((uint32_t)src[0] << 24) |
+           ((uint32_t)src[1] << 16) |
+           ((uint32_t)src[2] << 8) |
+           src[3];
+}
+
+static void publish_flush(volatile void *address, size_t length)
+{
+    (void)address;
+    (void)length;
+    if (inject_during_publish) {
+        inject_during_publish = 0;
+        zzusb_diag_record(ZZUSB_DIAG_EVENT_LATE_COMPLETION, 0xf4,
+                          999u, 7u, 3u, 2u, 1u, 0u, 0u,
+                          0xfeedu, 123u);
+    }
+}
+
+int main(void)
+{
+    zzusb_diag_reset();
+    memset(page, 0xa5, sizeof(page));
+    memset(mailbox, 0x01, sizeof(mailbox));
+
+    for (uint32_t i = 1; i <= 200u; i++) {
+        zzusb_diag_count(ZZUSB_DIAG_COUNT_REQUEST);
+        zzusb_diag_record((uint16_t)((i % 12u) + 1u),
+                          (uint16_t)(i & 0xffu), i, 7u,
+                          (uint16_t)(i & 0x7fu),
+                          (uint8_t)(i & 0x0fu), (uint8_t)(i & 1u),
+                          (uint16_t)(i >> 4), (uint16_t)(i & 7u),
+                          i * 3u, i * 5u);
+    }
+    zzusb_diag_high_water(4u);
+    zzusb_diag_high_water(2u);
+    zzusb_diag_high_water(9u);
+
+    inject_during_publish = 1;
+    zzusb_diag_publish(page, sizeof(page), 0x1fu, 7u, 200u,
+                       4u, 0x55u, publish_flush);
+
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_MAGIC) == ZZUSB_DIAG_MAGIC);
+    CHECK((read_be32(page + ZZUSB_DIAG_OFF_GENERATION) & 1u) == 0u);
+    CHECK(read_be16(page + ZZUSB_DIAG_OFF_VERSION) == ZZUSB_DIAG_VERSION);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENT_NEXT) == 201u);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENT_COUNT) == 64u);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_LOST_EVENTS) == 137u);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_COUNTERS +
+                    ZZUSB_DIAG_COUNT_REQUEST * 4u) == 200u);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_COUNTERS +
+                    ZZUSB_DIAG_COUNT_QUEUE_HIGH_WATER * 4u) == 9u);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENTS +
+                    ZZUSB_DIAG_EVT_OFF_SEQUENCE) == 138u);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENTS +
+                    63u * ZZUSB_DIAG_EVENT_SIZE +
+                    ZZUSB_DIAG_EVT_OFF_SEQUENCE) == 201u);
+
+    CHECK(zzusb_diag_read_coherent(page, snapshot,
+                                   sizeof(snapshot), 4u));
+    CHECK(memcmp(page, snapshot, sizeof(page)) == 0);
+    CHECK(mailbox[0] == 0x01u && mailbox[sizeof(mailbox) - 1u] == 0x01u);
+
+    page[ZZUSB_DIAG_OFF_GENERATION + 3u] |= 1u;
+    CHECK(!zzusb_diag_read_coherent(page, snapshot,
+                                    sizeof(snapshot), 2u));
+
+    zzusb_diag_publish(page, sizeof(page), 0x1fu, 7u, 201u,
+                       0u, 0u, NULL);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENT_NEXT) == 201u);
+    CHECK(read_be32(page + ZZUSB_DIAG_OFF_EVENTS +
+                    63u * ZZUSB_DIAG_EVENT_SIZE +
+                    ZZUSB_DIAG_EVT_OFF_SEQUENCE) == 201u);
+
+    puts("USB diagnostic ring and seqlock snapshot contract satisfied");
+    return EXIT_SUCCESS;
+}

--- a/test/usb/usb_proxy_iso_test.c
+++ b/test/usb/usb_proxy_iso_test.c
@@ -20,6 +20,7 @@ static int fake_retire_failure;
 static unsigned fake_retire_count;
 static unsigned fake_bandwidth_reset_count;
 static unsigned fake_refresh_count;
+static uint16_t fake_current_frame = 100;
 static uint8_t *fake_buffer;
 static unsigned fake_schedule_count;
 static uint16_t fake_start_frame[ZZUSB_ISO_MAX_BATCHES];
@@ -50,7 +51,7 @@ void zzusb_diag_count(enum zzusb_diag_counter counter)
 uint16_t ehci_iso_current_frame(struct ehci_ctrl *ctrl)
 {
     assert(ctrl == &fake_ctrl);
-    return 100;
+    return fake_current_frame;
 }
 
 int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
@@ -174,6 +175,7 @@ static void reset_fixture(void)
     fake_retire_failure = 0;
     fake_retire_count = 0;
     fake_refresh_count = 0;
+    fake_current_frame = 100;
     fake_schedule_count = 0;
     memset(fake_start_frame, 0, sizeof(fake_start_frame));
     memset(fake_start_microframe, 0, sizeof(fake_start_microframe));
@@ -237,6 +239,29 @@ static void test_asap_batches_chain(void)
     assert(fake_start_microframe[0] == 0);
     assert(fake_start_frame[1] == 104);
     assert(fake_start_microframe[1] == 2);
+    assert(usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED) == 0);
+}
+
+static void test_completed_batch_does_not_delay_asap(void)
+{
+    struct ZZUSBCommand cmd;
+    uint8_t wire[ZZUSB_V2_DATA_MAX];
+    unsigned metadata_size;
+
+    reset_fixture();
+    metadata_size = make_batch(wire, 12, 0, 100);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+    fake_complete = 1;
+    usb_proxy_iso_pump();
+    assert(usb_proxy_iso_queue_state() == 0x11000000);
+
+    fake_current_frame = 1200;
+    metadata_size = make_batch(wire, 13, ZZUSB_ISO_FLAG_ASAP, 0);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+    assert(fake_start_frame[1] == 1204);
+    assert(fake_start_microframe[1] == 0);
     assert(usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED) == 0);
 }
 
@@ -352,11 +377,12 @@ int main(void)
 {
     test_queue_complete_reap();
     test_asap_batches_chain();
+    test_completed_batch_does_not_delay_asap();
     test_full_speed_asap_batches_use_exponential_interval();
     test_missed_frame_status();
     test_linked_failure_is_quarantined();
     test_ring_backpressure_and_retirement();
-    assert(fake_bandwidth_reset_count == 6);
+    assert(fake_bandwidth_reset_count == 7);
     puts("usb_proxy_iso_test: ok");
     return 0;
 }

--- a/test/usb/usb_proxy_iso_test.c
+++ b/test/usb/usb_proxy_iso_test.c
@@ -265,6 +265,29 @@ static void test_completed_batch_does_not_delay_asap(void)
     assert(usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED) == 0);
 }
 
+static void test_explicit_batches_reject_overlap(void)
+{
+    struct ZZUSBCommand cmd;
+    uint8_t wire[ZZUSB_V2_DATA_MAX];
+    unsigned metadata_size;
+
+    reset_fixture();
+    metadata_size = make_batch(wire, 14, 0, 104);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+
+    metadata_size = make_batch(wire, 15, 0, 104);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_BUSY);
+    assert(fake_schedule_count == 1);
+
+    metadata_size = make_batch(wire, 16, 0, 105);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+    assert(fake_schedule_count == 2);
+    assert(usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED) == 0);
+}
+
 static void test_full_speed_asap_batches_use_exponential_interval(void)
 {
     struct ZZUSBCommand cmd;
@@ -378,11 +401,12 @@ int main(void)
     test_queue_complete_reap();
     test_asap_batches_chain();
     test_completed_batch_does_not_delay_asap();
+    test_explicit_batches_reject_overlap();
     test_full_speed_asap_batches_use_exponential_interval();
     test_missed_frame_status();
     test_linked_failure_is_quarantined();
     test_ring_backpressure_and_retirement();
-    assert(fake_bandwidth_reset_count == 7);
+    assert(fake_bandwidth_reset_count == 8);
     puts("usb_proxy_iso_test: ok");
     return 0;
 }

--- a/test/usb/usb_proxy_iso_test.c
+++ b/test/usb/usb_proxy_iso_test.c
@@ -1,0 +1,362 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "usb_proxy.h"
+#include "usb_proxy_diag.h"
+#include "usb_proxy_iso.h"
+#include "usb/ehci-iso.h"
+
+struct ehci_ctrl {
+    int unused;
+};
+
+static struct ehci_ctrl fake_ctrl;
+static int fake_schedule_result;
+static int fake_complete;
+static int fake_retire_failure;
+static unsigned fake_retire_count;
+static unsigned fake_bandwidth_reset_count;
+static unsigned fake_refresh_count;
+static uint8_t *fake_buffer;
+static unsigned fake_schedule_count;
+static uint16_t fake_start_frame[ZZUSB_ISO_MAX_BATCHES];
+static uint8_t fake_start_microframe[ZZUSB_ISO_MAX_BATCHES];
+
+struct ehci_ctrl *usb_proxy_get_ehci_controller(void)
+{
+    return &fake_ctrl;
+}
+
+uint32_t usb_proxy_get_controller_epoch(void)
+{
+    return 77;
+}
+
+void usb_proxy_refresh_event_irq(void)
+{
+    fake_refresh_count++;
+}
+
+
+void zzusb_diag_count(enum zzusb_diag_counter counter)
+{
+    assert(counter == ZZUSB_DIAG_COUNT_ISO_QUEUE ||
+           counter == ZZUSB_DIAG_COUNT_ISO_REAP);
+}
+
+uint16_t ehci_iso_current_frame(struct ehci_ctrl *ctrl)
+{
+    assert(ctrl == &fake_ctrl);
+    return 100;
+}
+
+int ehci_iso_schedule(struct ehci_iso_transfer *transfer,
+                      struct ehci_ctrl *ctrl,
+                      const struct ehci_iso_config *config,
+                      struct ehci_iso_packet *packets,
+                      unsigned packet_count, uint8_t *buffer)
+{
+    uint32_t absolute_uframe;
+    uint32_t step;
+
+    assert(ctrl == &fake_ctrl);
+    assert(packet_count <= EHCI_ISO_MAX_PACKETS);
+    memset(transfer, 0, sizeof(*transfer));
+    transfer->ctrl = ctrl;
+    transfer->config = *config;
+    transfer->packet_count = (uint8_t)packet_count;
+    absolute_uframe = (uint32_t)packets[0].frame * 8U +
+                      packets[0].microframe;
+    step = config->speed == 3U ? 1U << (config->interval - 1U) :
+           (uint32_t)(1U << (config->interval - 1U)) * 8U;
+    assert(fake_schedule_count < ZZUSB_ISO_MAX_BATCHES);
+    fake_start_frame[fake_schedule_count] = packets[0].frame;
+    fake_start_microframe[fake_schedule_count] = packets[0].microframe;
+    fake_schedule_count++;
+    for (unsigned index = 0; index < packet_count; index++) {
+        transfer->packets[index] = packets[index];
+        transfer->packets[index].frame =
+            (uint16_t)((absolute_uframe >> 3) & EHCI_ISO_FRAME_MASK);
+        transfer->packets[index].microframe =
+            (uint8_t)(absolute_uframe & 7U);
+        transfer->packets[index].status = EHCI_ISO_PACKET_PENDING;
+        absolute_uframe += step;
+    }
+    fake_buffer = buffer;
+    if (fake_schedule_result) {
+        if (fake_schedule_result == EHCI_ISO_ERR_TIMEOUT)
+            transfer->linked = 1;
+        return fake_schedule_result;
+    }
+    transfer->linked = 1;
+    return 0;
+}
+
+int ehci_iso_poll(struct ehci_iso_transfer *transfer)
+{
+    if (!fake_complete)
+        return 0;
+    for (unsigned index = 0; index < transfer->packet_count; index++) {
+        struct ehci_iso_packet *packet = &transfer->packets[index];
+
+        packet->actual = packet->requested;
+        packet->status = EHCI_ISO_PACKET_OK;
+    }
+    for (unsigned index = 0; index < 16; index++)
+        fake_buffer[index] = (uint8_t)(0xa0U + index);
+    transfer->complete = 1;
+    return 1;
+}
+
+int ehci_iso_retire(struct ehci_iso_transfer *transfer,
+                    uint8_t unfinished_status)
+{
+    (void)unfinished_status;
+    fake_retire_count++;
+    if (fake_retire_failure)
+        return EHCI_ISO_ERR_TIMEOUT;
+    transfer->linked = 0;
+    return 0;
+}
+
+void ehci_iso_reset_bandwidth(void)
+{
+    fake_bandwidth_reset_count++;
+}
+
+static void make_command(struct ZZUSBCommand *cmd, uint16_t command,
+                         uint32_t data_length)
+{
+    memset(cmd, 0, sizeof(*cmd));
+    put_be16(&cmd->cmd, command);
+    put_be32(&cmd->dev_addr, 4);
+    put_be16(&cmd->endpoint, 2);
+    put_be16(&cmd->direction, 0x80);
+    put_be16(&cmd->speed, ZZUSB_SPEED_HIGH);
+    put_be16(&cmd->max_pkt_size, 1024);
+    put_be16(&cmd->interval, 1);
+    put_be16(&cmd->reserved, 9);
+    put_be32(&cmd->data_length, data_length);
+}
+
+static unsigned make_batch(uint8_t *wire, uint32_t batch_id,
+                           uint16_t flags, uint16_t start_frame)
+{
+    unsigned metadata_size = ZZUSB_ISO_HEADER_SIZE +
+                             2U * ZZUSB_ISO_PACKET_SIZE;
+
+    memset(wire, 0, ZZUSB_V2_DATA_MAX);
+    put_be32(wire + ZZUSB_ISO_HDR_OFF_MAGIC, ZZUSB_ISO_MAGIC);
+    put_be16(wire + ZZUSB_ISO_HDR_OFF_VERSION, ZZUSB_ISO_VERSION);
+    put_be16(wire + ZZUSB_ISO_HDR_OFF_FLAGS, flags);
+    put_be32(wire + ZZUSB_ISO_HDR_OFF_BATCH_ID, batch_id);
+    put_be16(wire + ZZUSB_ISO_HDR_OFF_START, start_frame);
+    put_be16(wire + ZZUSB_ISO_HDR_OFF_COUNT, 2);
+    put_be32(wire + ZZUSB_ISO_HDR_OFF_DATA_LEN, 16);
+    put_be16(wire + ZZUSB_ISO_HEADER_SIZE +
+             ZZUSB_ISO_PKT_OFF_REQUESTED, 8);
+    put_be32(wire + ZZUSB_ISO_HEADER_SIZE +
+             ZZUSB_ISO_PKT_OFF_DATA, 0);
+    put_be16(wire + ZZUSB_ISO_HEADER_SIZE + ZZUSB_ISO_PACKET_SIZE +
+             ZZUSB_ISO_PKT_OFF_REQUESTED, 8);
+    put_be32(wire + ZZUSB_ISO_HEADER_SIZE + ZZUSB_ISO_PACKET_SIZE +
+             ZZUSB_ISO_PKT_OFF_DATA, 8);
+    return metadata_size;
+}
+
+static void reset_fixture(void)
+{
+    fake_schedule_result = 0;
+    fake_complete = 0;
+    fake_retire_failure = 0;
+    fake_retire_count = 0;
+    fake_refresh_count = 0;
+    fake_schedule_count = 0;
+    memset(fake_start_frame, 0, sizeof(fake_start_frame));
+    memset(fake_start_microframe, 0, sizeof(fake_start_microframe));
+    fake_buffer = NULL;
+    usb_proxy_iso_after_controller_reset();
+}
+
+static void test_queue_complete_reap(void)
+{
+    struct ZZUSBCommand cmd;
+    uint8_t wire[ZZUSB_V2_DATA_MAX];
+    unsigned metadata_size;
+
+    reset_fixture();
+    metadata_size = make_batch(wire, 0x11223344,
+                               ZZUSB_ISO_FLAG_ASAP, 0);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+    assert(usb_proxy_iso_queue_state() == 0x01000000);
+    assert(usb_proxy_iso_schedule_bits() == 1);
+
+    fake_complete = 1;
+    usb_proxy_iso_pump();
+    assert(usb_proxy_iso_queue_state() == 0x11000000);
+    assert(fake_refresh_count == 1);
+
+    make_command(&cmd, ZZUSB_CMD_ISO_REAP, sizeof(wire));
+    assert(usb_proxy_iso_handle_reap(&cmd, wire) == ZZUSB_STATUS_OK);
+    assert(be32(&cmd.actual_length) == metadata_size + 16U);
+    assert(be32(wire + ZZUSB_ISO_HDR_OFF_BATCH_ID) == 0x11223344);
+    assert(be16(wire + ZZUSB_ISO_HEADER_SIZE +
+                ZZUSB_ISO_PKT_OFF_STATUS) == EHCI_ISO_PACKET_OK);
+    assert(be16(wire + ZZUSB_ISO_HEADER_SIZE +
+                ZZUSB_ISO_PKT_OFF_FRAME) == 104);
+    assert(wire[ZZUSB_ISO_HEADER_SIZE +
+                ZZUSB_ISO_PKT_OFF_UFRAME] == 0);
+    assert(wire[ZZUSB_ISO_HEADER_SIZE + ZZUSB_ISO_PACKET_SIZE +
+                ZZUSB_ISO_PKT_OFF_UFRAME] == 1);
+    for (unsigned index = 0; index < 16; index++)
+        assert(wire[metadata_size + index] == (uint8_t)(0xa0U + index));
+    assert(fake_retire_count == 1);
+    assert(fake_refresh_count == 2);
+    assert(usb_proxy_iso_queue_state() == 0);
+}
+
+static void test_asap_batches_chain(void)
+{
+    struct ZZUSBCommand cmd;
+    uint8_t wire[ZZUSB_V2_DATA_MAX];
+    unsigned metadata_size;
+
+    reset_fixture();
+    metadata_size = make_batch(wire, 10, ZZUSB_ISO_FLAG_ASAP, 0);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+    metadata_size = make_batch(wire, 11, ZZUSB_ISO_FLAG_ASAP, 0);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+    assert(fake_schedule_count == 2);
+    assert(fake_start_frame[0] == 104);
+    assert(fake_start_microframe[0] == 0);
+    assert(fake_start_frame[1] == 104);
+    assert(fake_start_microframe[1] == 2);
+    assert(usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED) == 0);
+}
+
+static void test_full_speed_asap_batches_use_exponential_interval(void)
+{
+    struct ZZUSBCommand cmd;
+    uint8_t wire[ZZUSB_V2_DATA_MAX];
+    unsigned metadata_size;
+
+    reset_fixture();
+    metadata_size = make_batch(wire, 20, ZZUSB_ISO_FLAG_ASAP, 0);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    put_be16(&cmd.speed, ZZUSB_SPEED_FULL);
+    put_be16(&cmd.max_pkt_size, 64);
+    put_be16(&cmd.interval, 3);
+    put_be16(&cmd.flags, ZZUSB_FLAG_SPLIT);
+    put_be16(&cmd.split_hub_addr, 1);
+    put_be16(&cmd.split_hub_port, 2);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+
+    metadata_size = make_batch(wire, 21, ZZUSB_ISO_FLAG_ASAP, 0);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    put_be16(&cmd.speed, ZZUSB_SPEED_FULL);
+    put_be16(&cmd.max_pkt_size, 64);
+    put_be16(&cmd.interval, 3);
+    put_be16(&cmd.flags, ZZUSB_FLAG_SPLIT);
+    put_be16(&cmd.split_hub_addr, 1);
+    put_be16(&cmd.split_hub_port, 2);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+
+    assert(fake_schedule_count == 2);
+    assert(fake_start_frame[0] == 104);
+    assert(fake_start_microframe[0] == 0);
+    assert(fake_start_frame[1] == 112);
+    assert(fake_start_microframe[1] == 0);
+    assert(usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED) == 0);
+}
+
+static void test_missed_frame_status(void)
+{
+    struct ZZUSBCommand cmd;
+    uint8_t wire[ZZUSB_V2_DATA_MAX];
+    unsigned metadata_size;
+
+    reset_fixture();
+    fake_schedule_result = EHCI_ISO_ERR_MISSED;
+    metadata_size = make_batch(wire, 2, 0, 98);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+    assert(usb_proxy_iso_queue_state() == 0x11000000);
+
+    make_command(&cmd, ZZUSB_CMD_ISO_REAP, sizeof(wire));
+    assert(usb_proxy_iso_handle_reap(&cmd, wire) == ZZUSB_STATUS_OK);
+    assert(be16(wire + ZZUSB_ISO_HEADER_SIZE +
+                ZZUSB_ISO_PKT_OFF_STATUS) == EHCI_ISO_PACKET_MISSED);
+    assert(be16(wire + ZZUSB_ISO_HEADER_SIZE +
+                ZZUSB_ISO_PKT_OFF_FRAME) == 98);
+    assert(be16(wire + ZZUSB_ISO_HEADER_SIZE + ZZUSB_ISO_PACKET_SIZE +
+                ZZUSB_ISO_PKT_OFF_FRAME) == 98);
+}
+
+static void test_linked_failure_is_quarantined(void)
+{
+    struct ZZUSBCommand cmd;
+    uint8_t wire[ZZUSB_V2_DATA_MAX];
+    unsigned metadata_size;
+
+    reset_fixture();
+    fake_schedule_result = EHCI_ISO_ERR_TIMEOUT;
+    metadata_size = make_batch(wire, 3, ZZUSB_ISO_FLAG_ASAP, 0);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) ==
+           ZZUSB_STATUS_HOSTERROR);
+    assert(usb_proxy_iso_queue_state() == 0x11000000);
+
+    make_command(&cmd, ZZUSB_CMD_ISO_REAP, sizeof(wire));
+    assert(usb_proxy_iso_handle_reap(&cmd, wire) == ZZUSB_STATUS_OK);
+    assert(be16(wire + ZZUSB_ISO_HEADER_SIZE +
+                ZZUSB_ISO_PKT_OFF_STATUS) == EHCI_ISO_PACKET_OFFLINE);
+    assert(fake_retire_count == 1);
+    assert(usb_proxy_iso_queue_state() == 0);
+}
+
+static void test_ring_backpressure_and_retirement(void)
+{
+    struct ZZUSBCommand cmd;
+    uint8_t wire[ZZUSB_V2_DATA_MAX];
+    unsigned metadata_size;
+
+    reset_fixture();
+    for (unsigned batch = 1; batch <= ZZUSB_ISO_MAX_BATCHES; batch++) {
+        metadata_size = make_batch(wire, batch,
+                                   ZZUSB_ISO_FLAG_ASAP, 0);
+        make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+        assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_OK);
+    }
+    metadata_size = make_batch(wire, 99, ZZUSB_ISO_FLAG_ASAP, 0);
+    make_command(&cmd, ZZUSB_CMD_ISO_QUEUE, metadata_size);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_BUSY);
+
+    fake_retire_failure = 1;
+    assert(usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED) < 0);
+    assert(usb_proxy_iso_queue_state() == 0x08000000);
+    assert(usb_proxy_iso_handle_queue(&cmd, wire) == ZZUSB_STATUS_BUSY);
+
+    fake_retire_failure = 0;
+    assert(usb_proxy_iso_stop_all(EHCI_ISO_PACKET_CANCELLED) == 0);
+    assert(fake_retire_count == 16);
+    assert(usb_proxy_iso_queue_state() == 0);
+}
+
+int main(void)
+{
+    test_queue_complete_reap();
+    test_asap_batches_chain();
+    test_full_speed_asap_batches_use_exponential_interval();
+    test_missed_frame_status();
+    test_linked_failure_is_quarantined();
+    test_ring_backpressure_and_retirement();
+    assert(fake_bandwidth_reset_count == 6);
+    puts("usb_proxy_iso_test: ok");
+    return 0;
+}

--- a/test/usb/usb_proxy_protocol_test.c
+++ b/test/usb/usb_proxy_protocol_test.c
@@ -113,6 +113,11 @@ int main(void)
     make_valid_control(&cmd, &ext);
     CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
           ZZUSB_STATUS_OK);
+    cmd.setup_bRequestType = 0;
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+
+    make_valid_control(&cmd, &ext);
 
     put_be32(&cmd.dev_addr, 128);
     CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
@@ -142,6 +147,14 @@ int main(void)
           ZZUSB_STATUS_OK);
     CHECK(zzusb_validate_command(&cmd, &ext, 0, 7) ==
           ZZUSB_STATUS_BADPARAM);
+    put_be16(&cmd.max_pkt_size, 0x1400);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_OK);
+    put_be16(&cmd.max_pkt_size, 0x1401);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+    put_be16(&cmd.max_pkt_size, 1024);
+
 
     put_be32(&cmd.data_length, 31);
     CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==

--- a/test/usb/usb_proxy_protocol_test.c
+++ b/test/usb/usb_proxy_protocol_test.c
@@ -1,0 +1,184 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "usb_proxy.h"
+
+#define CHECK(expr) do {     if (!(expr)) {         fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #expr);         return EXIT_FAILURE;     } } while (0)
+
+static void put_le16_test(void *p, uint16_t value)
+{
+    uint8_t *bytes = p;
+    bytes[0] = value & 0xffu;
+    bytes[1] = value >> 8;
+}
+
+static void make_valid_control(struct ZZUSBCommand *cmd,
+                               struct ZZUSBProtocolExtension *ext)
+{
+    memset(cmd, 0, sizeof(*cmd));
+    memset(ext, 0, sizeof(*ext));
+    put_be16(&cmd->cmd, ZZUSB_CMD_CONTROL_XFER);
+    put_be32(&cmd->dev_addr, 1);
+    put_be16(&cmd->direction, 0x80);
+    put_be16(&cmd->xfer_type, ZZUSB_XFER_CONTROL);
+    put_be16(&cmd->max_pkt_size, 64);
+    put_be32(&cmd->data_length, 4);
+    put_be16(&cmd->speed, ZZUSB_SPEED_HIGH);
+    cmd->setup_bRequestType = 0x80;
+    put_le16_test(&cmd->setup_wLength, 4);
+    put_be16(&ext->version, ZZUSB_PROTOCOL_VERSION);
+    put_be16(&ext->header_size, ZZUSB_V2_HEADER_SIZE);
+    put_be32(&ext->request_id, 1);
+    put_be32(&ext->controller_epoch, 7);
+}
+
+static void make_valid_iso(struct ZZUSBCommand *cmd,
+                           struct ZZUSBProtocolExtension *ext,
+                           uint16_t command, uint32_t data_length)
+{
+    memset(cmd, 0, sizeof(*cmd));
+    memset(ext, 0, sizeof(*ext));
+    put_be16(&cmd->cmd, command);
+    put_be32(&cmd->dev_addr, 1);
+    put_be16(&cmd->endpoint, 1);
+    put_be16(&cmd->direction, 0x80);
+    put_be16(&cmd->xfer_type, ZZUSB_XFER_ISO);
+    put_be16(&cmd->max_pkt_size, 1024);
+    put_be32(&cmd->data_length, data_length);
+    put_be16(&cmd->interval, 1);
+    put_be16(&cmd->speed, ZZUSB_SPEED_HIGH);
+    put_be16(&ext->version, ZZUSB_PROTOCOL_VERSION);
+    put_be16(&ext->header_size, ZZUSB_V2_HEADER_SIZE);
+    put_be32(&ext->request_id, 2);
+    put_be32(&ext->controller_epoch, 7);
+}
+
+int main(void)
+{
+    struct ZZUSBCommand cmd;
+    struct ZZUSBProtocolExtension ext;
+
+    CHECK(ZZUSB_CMD_SIZE == 48u);
+    CHECK(ZZUSB_V2_HEADER_SIZE == 64u);
+    CHECK(ZZUSB_DATA_OFFSET == 64u);
+    CHECK(ZZUSB_APERTURE_SIZE == 24576u);
+    CHECK(ZZUSB_MAX_XFER == 24512u);
+    CHECK(ZZUSB_V2_DATA_MAX == 16384u);
+    CHECK(ZZUSB_DIAG_OFFSET == 20480u);
+    CHECK(ZZUSB_DIAG_SIZE == 4096u);
+    CHECK(sizeof(struct ZZUSBCommand) == ZZUSB_CMD_SIZE);
+    CHECK(sizeof(struct ZZUSBProtocolExtension) == 16u);
+
+    CHECK(offsetof(struct ZZUSBCommand, cmd) == 0u);
+    CHECK(offsetof(struct ZZUSBCommand, status) == 2u);
+    CHECK(offsetof(struct ZZUSBCommand, dev_addr) == 4u);
+    CHECK(offsetof(struct ZZUSBCommand, data_length) == 16u);
+    CHECK(offsetof(struct ZZUSBCommand, actual_length) == 20u);
+    CHECK(offsetof(struct ZZUSBCommand, timeout_ms) == 24u);
+    CHECK(offsetof(struct ZZUSBCommand, setup_bRequestType) == 32u);
+    CHECK(offsetof(struct ZZUSBCommand, split_hub_addr) == 40u);
+    CHECK(offsetof(struct ZZUSBCommand, flags) == 44u);
+    CHECK(offsetof(struct ZZUSBCommand, reserved) == 46u);
+    CHECK(offsetof(struct ZZUSBProtocolExtension, version) == 0u);
+    CHECK(offsetof(struct ZZUSBProtocolExtension, header_size) == 2u);
+    CHECK(offsetof(struct ZZUSBProtocolExtension, request_id) == 4u);
+    CHECK(offsetof(struct ZZUSBProtocolExtension, controller_epoch) == 8u);
+    CHECK(offsetof(struct ZZUSBProtocolExtension, capabilities) == 12u);
+
+    CHECK(ZZUSB_CMD_CONTROL_XFER == 0x01u);
+    CHECK(ZZUSB_CMD_BULK_XFER == 0x02u);
+    CHECK(ZZUSB_CMD_INT_XFER == 0x03u);
+    CHECK(ZZUSB_CMD_ISO_XFER == 0x04u);
+    CHECK(ZZUSB_CMD_CHECK_PORT == 0x0cu);
+    CHECK(ZZUSB_CMD_QUERY_CAPS == 0x0du);
+    CHECK(ZZUSB_CMD_ISO_STOP == 0x16u);
+
+    CHECK(ZZUSB_STATUS_OK == 0x00u);
+    CHECK(ZZUSB_STATUS_PENDING == 0x01u);
+    CHECK(ZZUSB_STATUS_ERROR == 0xffu);
+    CHECK(ZZUSB_STATUS_BADPARAM == 0xf6u);
+    CHECK(ZZUSB_STATUS_UNSUPPORTED == 0xf5u);
+    CHECK(ZZUSB_STATUS_STALE == 0xf4u);
+    CHECK(ZZUSB_STATUS_NOMEM == 0xf0u);
+    CHECK((ZZUSB_CAP_BASE & ZZUSB_CAP_PROTOCOL_V2) != 0);
+    CHECK((ZZUSB_CAP_BASE & ZZUSB_CAP_PRECISE_ERRORS) != 0);
+    CHECK((ZZUSB_CAP_BASE & ZZUSB_CAP_PERIODIC) != 0);
+    CHECK((ZZUSB_CAP_BASE & ZZUSB_CAP_EVENT_IRQ) != 0);
+    CHECK((ZZUSB_CAP_BASE & ZZUSB_CAP_ISO_SIMPLE) != 0);
+    CHECK((ZZUSB_CAP_BASE & ZZUSB_CAP_ISO_REALTIME) != 0);
+
+    make_valid_control(&cmd, &ext);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_OK);
+
+    put_be32(&cmd.dev_addr, 128);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+
+    make_valid_control(&cmd, &ext);
+    put_be32(&ext.controller_epoch, 6);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_STALE);
+
+    make_valid_control(&cmd, &ext);
+    put_be32(&cmd.data_length, ZZUSB_V2_DATA_MAX + 1u);
+    put_le16_test(&cmd.setup_wLength, 0);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+
+    make_valid_control(&cmd, &ext);
+    put_be16(&cmd.flags, ZZUSB_FLAG_SPLIT);
+    put_be16(&cmd.speed, ZZUSB_SPEED_HIGH);
+    put_be16(&cmd.split_hub_addr, 2);
+    put_be16(&cmd.split_hub_port, 1);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+
+    make_valid_iso(&cmd, &ext, ZZUSB_CMD_ISO_QUEUE, 32);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_OK);
+    CHECK(zzusb_validate_command(&cmd, &ext, 0, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+
+    put_be32(&cmd.data_length, 31);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+
+    make_valid_iso(&cmd, &ext, ZZUSB_CMD_ISO_REAP, ZZUSB_V2_DATA_MAX);
+    put_be16(&cmd.interval, 17);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+
+    make_valid_iso(&cmd, &ext, ZZUSB_CMD_ISO_QUEUE, 32);
+    put_be16(&cmd.speed, ZZUSB_SPEED_FULL);
+    put_be16(&cmd.max_pkt_size, 1023);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+    put_be16(&cmd.flags, ZZUSB_FLAG_SPLIT);
+    put_be16(&cmd.split_hub_addr, 2);
+    put_be16(&cmd.split_hub_port, 1);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_OK);
+    put_be16(&cmd.interval, 17);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_BADPARAM);
+
+    make_valid_iso(&cmd, &ext, ZZUSB_CMD_ISO_STOP, 0);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_OK);
+
+    memset(&cmd, 0, sizeof(cmd));
+    memset(&ext, 0, sizeof(ext));
+    put_be16(&cmd.cmd, ZZUSB_CMD_QUERY_CAPS);
+    put_be16(&ext.version, ZZUSB_PROTOCOL_VERSION);
+    put_be16(&ext.header_size, ZZUSB_V2_HEADER_SIZE);
+    put_be32(&ext.request_id, 9);
+    CHECK(zzusb_validate_command(&cmd, &ext, 1, 7) ==
+          ZZUSB_STATUS_OK);
+
+    puts("USB proxy v1/v2 wire and validation contract satisfied");
+    return EXIT_SUCCESS;
+}

--- a/test/usb/usb_proxy_recovery_test.c
+++ b/test/usb/usb_proxy_recovery_test.c
@@ -1,0 +1,37 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "usb_proxy.h"
+
+#ifndef ZZUSB_PROTOCOL_VERSION
+#define ZZUSB_PROTOCOL_VERSION 1u
+#endif
+#ifndef ZZUSB_V2_HEADER_SIZE
+#define ZZUSB_V2_HEADER_SIZE ZZUSB_CMD_SIZE
+#endif
+
+#define CHECK(expr) do {     if (!(expr)) {         fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #expr);         return EXIT_FAILURE;     } } while (0)
+
+static int completion_matches(uint32_t active_id, uint32_t active_epoch,
+                              uint32_t completion_id, uint32_t completion_epoch)
+{
+    return ZZUSB_PROTOCOL_VERSION >= 2u &&
+           active_id != 0u &&
+           active_id == completion_id &&
+           active_epoch == completion_epoch;
+}
+
+int main(void)
+{
+    CHECK(ZZUSB_PROTOCOL_VERSION == 2u);
+    CHECK(ZZUSB_V2_HEADER_SIZE == ZZUSB_DATA_OFFSET);
+
+    CHECK(completion_matches(7u, 3u, 7u, 3u));
+    CHECK(!completion_matches(7u, 3u, 6u, 3u));
+    CHECK(!completion_matches(7u, 3u, 7u, 2u));
+    CHECK(!completion_matches(0u, 3u, 0u, 3u));
+
+    puts("USB proxy completion identity contract satisfied");
+    return EXIT_SUCCESS;
+}

--- a/test/video/videocap_control_test.c
+++ b/test/video/videocap_control_test.c
@@ -145,7 +145,7 @@ static int main_source_contract(void)
 	fclose(source);
 
 	if (revision_major_defines != 1U || revision_minor_defines != 1U ||
-	    ((revision_major << 8) | revision_minor) != 0x0208U) {
+	    ((revision_major << 8) | revision_minor) != 0x0209U) {
 		printf("firmware revision contract mismatch: defines=%u/%u revision=0x%04x\n",
 		       revision_major_defines, revision_minor_defines,
 		       (revision_major << 8) | revision_minor);


### PR DESCRIPTION
## Summary

Firmware 2.9 makes USB host requests attributable, bounded, and recoverable across completion, timeout, reset, and detach. It also adds persistent interrupt scheduling plus high-speed and split full-speed isochronous transport for the matched `zzusbhw.device` 2.2 driver, while preserving the existing mailbox prefix and data offset for legacy peers.

This is the firmware half of the matched USB reliability release. Companion driver branch: https://github.com/BlitterStudio/zz9000-drivers/tree/usb-host-reliability

Related: BlitterStudio/zz9000-drivers#23

## Design decisions

| Decision | Result |
|---|---|
| Append-only protocol v2 | Request IDs, controller epochs, capabilities, and validation fence late or mixed-version completions without moving legacy fields. |
| Retirement before reuse | Async QH/qTD, periodic queues, iTD/siTD descriptors, endpoint state, and mailbox data remain owned until retirement or controller recovery. |
| Bounded periodic work | Persistent interrupt endpoints and an eight-batch ISO queue use fixed storage, fair pump budgets, and the existing firmware-managed Amiga interrupt source. |
| Production diagnostics | Binary counters and a bounded event ring retain request, topology, schedule, error, reset, and queue evidence without hot-path UART output. |

Session-settled decisions carried from planning: firmware and driver are the only implementation targets (user-directed); the Poseidon 4.5 source remains an immutable reference (user-directed); production diagnostics remain bounded and enabled (user-approved).

## Validation

- [x] Firmware USB proxy/EHCI host models: protocol, identity, lifecycle, diagnostics, periodic cadence, shared IRQ, iTD/siTD, and ISO batching.
- [x] Full ARM build with Arm GNU Toolchain 13.2.Rel1: current and legacy-bitstream ELFs plus `BOOT-sdk-docker.bin`.
- [x] Seven release profile archives assembled with `--require-all`.
- [x] Firmware/driver command, status, capability, diagnostic, and ISO constants matched by the companion contract checker.
- [ ] Physical Amiga, Poseidon 4.5, target USB devices, hubs, and sustained mixed traffic were not available.

The README and protocol guide state the matched 2.9/2.2 requirement and do not promote host-model evidence into a hardware qualification claim.