### PR TITLE
fix(audio): keep media-session rate conversion out of the audio ISR

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_pump_media_view.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_pump_media_view.h
@@ -80,6 +80,23 @@ static inline void audio_pump_media_view_note_staged(
 		view->src_staged = src_staged;
 }
 
+/* Anchor both cursors to the session's current staged position. Called
+ * once when a view (re)begins: a resumed session rewinds staging to its
+ * retired cursor, which is nonzero -- anchoring keeps src_staged and
+ * src_retired in the same absolute reference so the EOS clamp measures
+ * the real unretired span (an unanchored view mixes an absolute staged
+ * cursor with a zero-based retired cursor and the final zero-padded
+ * period then retires a full period the session must reject, wedging
+ * end-of-stream drain). */
+static inline void audio_pump_media_view_anchor(
+	struct audio_pump_media_view *view, uint64_t src_staged)
+{
+	if (!view || !view->active)
+		return;
+	view->src_staged = src_staged;
+	view->src_retired = src_staged;
+}
+
 /* Map whole view periods retired by the fabric compositor onto session
  * bytes and advance the retired cursor. Non-period deltas map to zero:
  * the compositor stages and retires whole periods only, so anything else

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_pump_media_view.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_pump_media_view.h
@@ -1,0 +1,108 @@
+/*
+ * Cursor mapping for the media-session preconvert view.
+ *
+ * The audio fabric compositor runs in the audio formatter period ISR on
+ * core 0. For a bound media session whose PCM is not 48 kHz it executed
+ * the full polyphase rate conversion inside that ISR; the ISR is long
+ * enough that a vblank IRQ arriving during it delayed isr_video past the
+ * overlay rearm window, which showed as windowed-PIP flicker
+ * (zz9000-drivers#83). The fix stages 48 kHz PCM ahead of the ISR
+ * through the audio_pump_preconvert ring (main loop) so the ISR only
+ * copies; this header owns the exact cursor mapping between the 48 kHz
+ * view the fabric consumes and the session ring the decoder publishes.
+ *
+ * The mapping is exact by construction: the preconvert ring always holds
+ * whole 20 ms periods (3840 bytes), the fabric stages and retires whole
+ * view periods, and one view period corresponds to exactly one source
+ * period of (rate/50)*channels*2 bytes. Sessions at 48 kHz do not use
+ * the view (the direct path already costs a memcpy only).
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef ZZ_AUDIO_PUMP_MEDIA_VIEW_H
+#define ZZ_AUDIO_PUMP_MEDIA_VIEW_H
+
+#include <stdint.h>
+
+#define AUDIO_PUMP_MEDIA_VIEW_PERIOD_BYTES 3840U
+#define AUDIO_PUMP_MEDIA_VIEW_PERIOD_FRAMES \
+	(AUDIO_PUMP_MEDIA_VIEW_PERIOD_BYTES / 4U)
+struct audio_pump_media_view {
+	uint64_t src_retired;      /* session bytes retired (playback clock) */
+	uint64_t src_staged;       /* session bytes the converter consumed;
+	                             * bounds retirement (the final converted
+	                             * period may be zero-padded) */
+	uint32_t src_period_bytes; /* source bytes per 20 ms period */
+	uint32_t src_rate;
+	uint8_t active;
+};
+
+static inline void audio_pump_media_view_reset(
+	struct audio_pump_media_view *view)
+{
+	if (!view)
+		return;
+	view->active = 0U;
+	view->src_retired = 0U;
+	view->src_staged = 0U;
+	view->src_period_bytes = 0U;
+	view->src_rate = 0U;
+}
+
+/* A view is admissible when one 20 ms source period is a whole number of
+ * frames that fits the converted period. 48 kHz needs no conversion, so
+ * it stays on the (already memcpy-only) direct path. */
+static inline int audio_pump_media_view_begin(
+	struct audio_pump_media_view *view, uint32_t sample_rate,
+	uint32_t channels)
+{
+	uint32_t frames;
+
+	if (!view || sample_rate == 0U || sample_rate == 48000U ||
+	    channels == 0U || channels > 2U || (sample_rate % 50U) != 0U)
+		return 0;
+	frames = sample_rate / 50U;
+	if (frames == 0U || frames > AUDIO_PUMP_MEDIA_VIEW_PERIOD_FRAMES)
+		return 0;
+	view->src_period_bytes = frames * channels * 2U;
+	view->src_rate = sample_rate;
+	view->src_retired = 0U;
+	view->src_staged = 0U;
+	view->active = 1U;
+	return 1;
+}
+
+/* The fill publishes how many session bytes it has consumed into the
+ * converted ring; retirement may never advance past it. */
+static inline void audio_pump_media_view_note_staged(
+	struct audio_pump_media_view *view, uint64_t src_staged)
+{
+	if (view && src_staged >= view->src_staged)
+		view->src_staged = src_staged;
+}
+
+/* Map whole view periods retired by the fabric compositor onto session
+ * bytes and advance the retired cursor. Non-period deltas map to zero:
+ * the compositor stages and retires whole periods only, so anything else
+ * is a caller bug that must not corrupt the playback clock. The final
+ * converted period can be zero-padded (a source tail shorter than one
+ * period), so a full-period mapping is clamped to what was really
+ * staged -- retirement then lands exactly on the produced cursor and
+ * end-of-stream drain completes. */
+static inline uint64_t audio_pump_media_view_retire(
+	struct audio_pump_media_view *view, uint32_t view_bytes)
+{
+	uint64_t src;
+
+	if (!view || !view->active || view_bytes == 0U ||
+	    view->src_period_bytes == 0U ||
+	    (view_bytes % AUDIO_PUMP_MEDIA_VIEW_PERIOD_BYTES) != 0U)
+		return 0U;
+	src = (uint64_t)(view_bytes / AUDIO_PUMP_MEDIA_VIEW_PERIOD_BYTES) *
+	      (uint64_t)view->src_period_bytes;
+	if (view->src_staged - view->src_retired < src)
+		src = view->src_staged - view->src_retired;
+	view->src_retired += src;
+	return src;
+}
+
+#endif /* ZZ_AUDIO_PUMP_MEDIA_VIEW_H */

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_pump_preconvert.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_pump_preconvert.c
@@ -115,11 +115,11 @@ static void preconvert_write_period(struct audio_pump_preconvert *state)
 
 int audio_pump_preconvert_fill(struct audio_pump_preconvert *state,
 	const struct audio_pump_preconvert_source *source,
-	uint32_t *source_consumed)
+	uint64_t *source_consumed)
 {
 	uint32_t source_frames;
 	uint32_t source_bytes;
-	uint32_t available;
+	uint64_t available;
 	uint32_t pull;
 	uint32_t offset;
 
@@ -151,8 +151,8 @@ int audio_pump_preconvert_fill(struct audio_pump_preconvert *state,
 	else if (!source->done || available == 0U)
 		return 0;
 	else
-		pull = available;
-	offset = source->consumed % source->capacity;
+		pull = (uint32_t)available;
+	offset = (uint32_t)(source->consumed % source->capacity);
 	preconvert_copy_source(state, source, offset, pull, source_bytes);
 	if (source->channels == 1U)
 		preconvert_expand_mono(state, source_frames);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/audio_pump_preconvert.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/audio_pump_preconvert.h
@@ -21,8 +21,8 @@
 struct audio_pump_preconvert_source {
 	uint8_t *ring;
 	uint32_t capacity;
-	uint32_t produced;
-	uint32_t consumed;
+	uint64_t produced;
+	uint64_t consumed;
 	uint32_t sample_rate;
 	uint32_t channels;
 	uint32_t sample_format;
@@ -46,7 +46,7 @@ uint32_t audio_pump_preconvert_used(
 	const struct audio_pump_preconvert *state);
 int audio_pump_preconvert_fill(struct audio_pump_preconvert *state,
 	const struct audio_pump_preconvert_source *source,
-	uint32_t *source_consumed);
+	uint64_t *source_consumed);
 int audio_pump_preconvert_stage(struct audio_pump_preconvert *state,
 	uint32_t bytes);
 

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/overlay.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/overlay.c
@@ -706,7 +706,11 @@ void overlay_vblank_rearm(void)
 	 * published and is immutable while scanned. Restart it at vblank entry,
 	 * before unrelated dirty cache lines can delay the mandatory global
 	 * flush and leave the native-overlay VDMA stalled on a black frame. A
-	 * newly composed buffer becomes eligible one vblank after that flush. */
+	 * newly composed buffer becomes eligible one vblank after that flush.
+	 * The restart is also the overlay stream's phase lock to the raster:
+	 * the VDMA and the display both restart at row zero together, which
+	 * is what keeps the free-running line fetcher on the right source
+	 * row (an unlocked stream drifts and shows wrong/black rows). */
 	address = overlay_vblank_take_rearm(
 		ov.hw_scan_addr, &ov.hw_handoff_addr);
 	overlay_hw_rearm(address);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -4137,6 +4137,13 @@ static void audio_playback_start(uint32_t source_kind, uint32_t session,
 			    &g_audio_playback.media_view,
 			    media_source.sample_rate,
 			    media_source.channels)) {
+			/* Anchor to the session's staged cursor: a resumed
+			 * session rewinds staging to a nonzero retired
+			 * position, and both view cursors must share that
+			 * absolute reference for the EOS retire clamp. */
+			audio_pump_media_view_anchor(
+				&g_audio_playback.media_view,
+				media_source.staged_bytes);
 			audio_fabric_producer_rate_set(
 				AUDIO_FABRIC_SLOT_PUMP, 48000U);
 			audio_pump_media_source_fill(

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/sdk_mailbox.c
@@ -25,6 +25,7 @@
 #include "audio_stream_drain.h"
 #include "audio_convert.h"
 #include "audio_pump_preconvert.h"
+#include "audio_pump_media_view.h"
 #include "sdk_jpeg.h"
 #include "sdk_surface.h"
 #include "sdk_aperture_layout.h"
@@ -3748,12 +3749,19 @@ static uint8_t g_audio_pump_preconvert_ring[
 static struct {
 	uint32_t session;         /* 0 = unbound */
 	uint32_t source_kind;
+	uint32_t refill_session;  /* session that refill targets (valid while
+	                           * refill_pending; survives an unbind) */
 	uint32_t paused;
 	uint32_t refill_pending;  /* internal core-1 refill task in flight */
-	uint32_t refill_session;  /* session that refill targets (valid while
-	                             refill_pending; survives an unbind) */
-	uint32_t preconvert_session; /* retained across Pause/Play rebind */
+	uint32_t preconvert_session; /* retained across same-kind Pause/Play
+	                              * rebind */
+	uint32_t preconvert_kind;    /* owner kind: media and stream session
+	                              * ids are independent namespaces, so a
+	                              * kind change must reset the ring */
 	struct audio_pump_preconvert preconvert;
+	struct audio_pump_media_view media_view; /* 48 kHz ISR view of a
+	                                          * non-48k media session
+	                                          * (drivers#83) */
 } g_audio_playback;
 
 
@@ -3792,6 +3800,29 @@ static int audio_pump_source_snapshot(struct audio_fabric_source *source)
 		if (!sdk_media_session_audio_source(
 			    g_audio_playback.session, &media_source))
 			return 0;
+		if (g_audio_playback.media_view.active) {
+			/* 48 kHz preconvert view of the session ring: the
+			 * rate conversion ran on the main loop (see
+			 * audio_pump_media_source_fill), so this ISR path
+			 * copies only. Retirement maps view periods back to
+			 * session bytes exactly (audio_pump_source_retire). */
+			source->ring =
+				g_audio_playback.preconvert.ring;
+			source->capacity =
+				g_audio_playback.preconvert.capacity;
+			source->produced_bytes =
+				g_audio_playback.preconvert.produced;
+			source->staged_bytes =
+				g_audio_playback.preconvert.staged;
+			source->sample_rate = 48000U;
+			source->channels = 2U;
+			source->sample_format =
+				SDK_AUDIO_SAMPLE_FORMAT_S16LE;
+			source->done = media_source.done &&
+				audio_pump_preconvert_used(
+					&g_audio_playback.preconvert) == 0U;
+			return 1;
+		}
 		source->ring = media_source.ring;
 		source->capacity = media_source.capacity;
 		source->produced_bytes = media_source.produced_bytes;
@@ -3816,18 +3847,34 @@ static int audio_pump_source_stage(uint32_t bytes)
 		return audio_pump_preconvert_stage(
 			&g_audio_playback.preconvert, bytes);
 	}
-	if (g_audio_playback.source_kind == AUDIO_PUMP_SOURCE_MEDIA)
+	if (g_audio_playback.source_kind == AUDIO_PUMP_SOURCE_MEDIA) {
+		if (g_audio_playback.media_view.active)
+			return audio_pump_preconvert_stage(
+				&g_audio_playback.preconvert, bytes);
 		return sdk_media_session_audio_stage(
 			g_audio_playback.session, bytes);
+	}
 	return 0;
 }
 
 static void audio_pump_source_retire(uint32_t bytes)
 {
-	if (bytes != 0U &&
-	    g_audio_playback.source_kind == AUDIO_PUMP_SOURCE_MEDIA)
+	uint64_t session_bytes;
+
+	if (bytes == 0U ||
+	    g_audio_playback.source_kind != AUDIO_PUMP_SOURCE_MEDIA)
+		return;
+	/* View retirement maps whole 48 kHz periods back to exact session
+	 * bytes (audio_pump_media_view); the direct path (a 48 kHz
+	 * session, already memcpy-only) retires its own bytes. */
+	session_bytes = bytes;
+	if (g_audio_playback.media_view.active)
+		session_bytes = audio_pump_media_view_retire(
+			&g_audio_playback.media_view, bytes);
+	if (session_bytes != 0U)
 		(void)sdk_media_session_audio_retire(
-			g_audio_playback.session, bytes);
+			g_audio_playback.session,
+			(uint32_t)session_bytes);
 }
 
 static void audio_pump_source_underrun(void)
@@ -3908,7 +3955,7 @@ static void audio_playback_preconvert(
 
 	for (i = 0U; stream && i < budget; i++) {
 		struct audio_pump_preconvert_source source;
-		uint32_t consumed = stream->pcm_consumed_total;
+		uint64_t consumed = stream->pcm_consumed_total;
 		int result;
 
 		memset(&source, 0, sizeof(source));
@@ -3928,7 +3975,52 @@ static void audio_playback_preconvert(
 		if (result <= 0)
 			break;
 		stream->pump_tail_pending = 1U;
-		stream->pcm_consumed_total = consumed;
+		stream->pcm_consumed_total = (uint32_t)consumed;
+	}
+}
+
+/* Main-loop conversion stage for bound media sessions (the AX path):
+ * the decoder publishes native-rate PCM; this consumes exact 20 ms
+ * source periods into the shared preconvert ring so the audio ISR
+ * copies at 48 kHz instead of running the polyphase FIR in interrupt
+ * context -- the vblank-delaying cost behind the windowed-PIP flicker
+ * (zz9000-drivers#83). Session staging advances here; retirement still
+ * tracks actual playback in audio_pump_source_retire. */
+static void audio_pump_media_source_fill(uint32_t budget)
+{
+	struct SDKMediaAudioSource media_source;
+	struct audio_pump_preconvert_source source;
+	uint64_t consumed;
+	uint32_t i;
+
+	if (!sdk_media_session_audio_source(
+		    g_audio_playback.session, &media_source))
+		return;
+	memset(&source, 0, sizeof(source));
+	source.ring = media_source.ring;
+	source.capacity = media_source.capacity;
+	source.produced = media_source.produced_bytes;
+	source.consumed = media_source.staged_bytes;
+	source.sample_rate = media_source.sample_rate;
+	source.channels = media_source.channels;
+	source.sample_format = media_source.sample_format;
+	source.done = media_source.done;
+	consumed = source.consumed;
+	for (i = 0U; i < budget; i++) {
+		if (audio_pump_preconvert_fill(
+			    &g_audio_playback.preconvert, &source,
+			    &consumed) <= 0)
+			break;
+		source.consumed = consumed;
+	}
+	if (consumed > media_source.staged_bytes) {
+		(void)sdk_media_session_audio_stage(
+			g_audio_playback.session,
+			(uint32_t)(consumed - media_source.staged_bytes));
+		/* Bound retirement by what the converter really consumed:
+		 * the final converted period can be zero-padded. */
+		audio_pump_media_view_note_staged(
+			&g_audio_playback.media_view, consumed);
 	}
 }
 
@@ -3937,9 +4029,17 @@ void sdk_mailbox_audio_playback_pump(void)
 {
 	struct SDKAudioStream *stream;
 
-	if (g_audio_playback.session == 0U ||
-	    g_audio_playback.source_kind != AUDIO_PUMP_SOURCE_STREAM ||
-	    g_audio_playback.paused)
+	if (g_audio_playback.session == 0U || g_audio_playback.paused)
+		return;
+	if (g_audio_playback.source_kind == AUDIO_PUMP_SOURCE_MEDIA) {
+		/* Media sessions convert ahead on the main loop; the ISR
+		 * fill only copies the staged 48 kHz periods. */
+		if (g_audio_playback.media_view.active)
+			audio_pump_media_source_fill(
+				AUDIO_PUMP_PRECONVERT_FILL_BUDGET);
+		return;
+	}
+	if (g_audio_playback.source_kind != AUDIO_PUMP_SOURCE_STREAM)
 		return;
 	stream = find_audio_stream(g_audio_playback.session);
 	if (!stream) {
@@ -4015,15 +4115,45 @@ static void audio_playback_start(uint32_t source_kind, uint32_t session,
 		return;
 	}
 	audio_fabric_producer_rate_set(AUDIO_FABRIC_SLOT_PUMP, source_rate);
+	if (source_kind == AUDIO_PUMP_SOURCE_MEDIA) {
+		struct SDKMediaAudioSource media_source;
+
+		/* Media preconvert view (zz9000-drivers#83): a non-48 kHz
+		 * session converts ahead on the main loop so the audio ISR
+		 * copies only; the admission rate follows the view. ALWAYS
+		 * re-anchor here: Pause/Play rewinds session staging, so
+		 * retained view content would re-convert played audio. A
+		 * 48 kHz session stays on the direct memcpy path. */
+		audio_pump_preconvert_reset(
+			&g_audio_playback.preconvert,
+			g_audio_pump_preconvert_ring,
+			sizeof(g_audio_pump_preconvert_ring));
+		g_audio_playback.preconvert_session = session;
+		g_audio_playback.preconvert_kind = AUDIO_PUMP_SOURCE_MEDIA;
+		audio_pump_media_view_reset(&g_audio_playback.media_view);
+		if (sdk_media_session_audio_source(
+			    session, &media_source) &&
+		    audio_pump_media_view_begin(
+			    &g_audio_playback.media_view,
+			    media_source.sample_rate,
+			    media_source.channels)) {
+			audio_fabric_producer_rate_set(
+				AUDIO_FABRIC_SLOT_PUMP, 48000U);
+			audio_pump_media_source_fill(
+				AUDIO_PUMP_PRECONVERT_FILL_BUDGET);
+		}
+	}
 	if (source_kind == AUDIO_PUMP_SOURCE_STREAM) {
 		struct SDKAudioStream *stream = find_audio_stream(session);
 
-		if (g_audio_playback.preconvert_session != session) {
+		if (g_audio_playback.preconvert_session != session ||
+		    g_audio_playback.preconvert_kind != AUDIO_PUMP_SOURCE_STREAM) {
 			audio_pump_preconvert_reset(
 				&g_audio_playback.preconvert,
 				g_audio_pump_preconvert_ring,
 				sizeof(g_audio_pump_preconvert_ring));
 			g_audio_playback.preconvert_session = session;
+			g_audio_playback.preconvert_kind = AUDIO_PUMP_SOURCE_STREAM;
 		}
 		audio_playback_preconvert(
 			stream, AUDIO_PUMP_PRECONVERT_FILL_BUDGET);
@@ -4061,6 +4191,9 @@ static void audio_playback_stop(void)
 	g_audio_playback.session = 0U;
 	g_audio_playback.source_kind = AUDIO_PUMP_SOURCE_NONE;
 	g_audio_playback.paused = 0U;
+	/* Drop the media view with the pump: a later bind re-anchors it
+	 * against the (possibly rewound) session cursors. */
+	audio_pump_media_view_reset(&g_audio_playback.media_view);
 	audio_scene_meter_output_identity(
 		SDK_AUDIO_METER_IDENTITY_UNKNOWN);
 	/* Last-release ring silence is the compositor's policy (KTD8):
@@ -7821,6 +7954,7 @@ void sdk_mailbox_init(void)
 	g_audio_playback.source_kind = AUDIO_PUMP_SOURCE_NONE;
 	g_audio_playback.paused = 0U;
 	g_audio_playback.preconvert_session = 0U;
+	g_audio_playback.preconvert_kind = AUDIO_PUMP_SOURCE_NONE;
 	audio_pump_preconvert_reset(
 		&g_audio_playback.preconvert,
 		g_audio_pump_preconvert_ring,

--- a/test/audio/Makefile
+++ b/test/audio/Makefile
@@ -20,8 +20,10 @@ MPEG_LAYER2_TARGET := $(BUILD_DIR)/mpeg_layer2_decode_test
 FABRIC_TARGET := $(BUILD_DIR)/audio_fabric_test
 RING_TARGET := $(BUILD_DIR)/audio_fabric_ring_test
 BENCH_SMOKE_TARGET := $(BUILD_DIR)/bench_smoke_test
+MEDIA_VIEW_TARGET := $(BUILD_DIR)/audio_pump_media_view_test
 TARGETS := $(CONVERT_TARGET) $(CAPTURE_TARGET) $(PROFILE_TARGET) \
-	$(PLAYBACK_TARGET) $(RATE_TARGET) $(PRECONVERT_TARGET) $(DRAIN_TARGET) \
+	$(PLAYBACK_TARGET) $(RATE_TARGET) $(PRECONVERT_TARGET) \
+	$(MEDIA_VIEW_TARGET) $(DRAIN_TARGET) \
 	$(SCENE_TARGET) $(METER_TARGET) $(CONTROL_TARGET) $(CONFIG_TARGET) \
 	$(MP3_PROBE_TARGET) $(MPEG_LAYER2_TARGET) $(FABRIC_TARGET) \
 	$(RING_TARGET) $(BENCH_SMOKE_TARGET)
@@ -49,6 +51,7 @@ test: $(TARGETS)
 	$(CONTROL_TARGET)
 	$(MPEG_LAYER2_TARGET)
 	$(FABRIC_TARGET) --srcdir $(SRC_DIR)
+	$(MEDIA_VIEW_TARGET)
 	$(RING_TARGET)
 	$(BENCH_SMOKE_TARGET)
 
@@ -154,6 +157,13 @@ $(PRECONVERT_TARGET): audio_pump_preconvert_test.c \
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ audio_pump_preconvert_test.c \
 		$(SRC_DIR)/audio_pump_preconvert.c \
 		$(SRC_DIR)/audio_convert.c $(SRC_DIR)/audio_convert_tables.c -lm
+
+# Media-session preconvert view: the exact 48 kHz view <-> session cursor
+# mapping that keeps the fabric ISR on the memcpy-only path (drivers#83).
+$(MEDIA_VIEW_TARGET): audio_pump_media_view_test.c \
+	$(SRC_DIR)/audio_pump_media_view.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ audio_pump_media_view_test.c
 
 $(DRAIN_TARGET): audio_stream_drain_test.c \
 	$(SRC_DIR)/audio_stream_drain.h

--- a/test/audio/audio_fabric_test.c
+++ b/test/audio/audio_fabric_test.c
@@ -928,19 +928,24 @@ static void scenario_source_contract(void)
 			      srcs[0], "audio_playback_retire_to") == 0,
 		      "contract: pump no longer retires periods", paths[0]);
 		check(count_occurrences(
-			      srcs[0], "Xil_DCacheFlushRange") >= 1,
-		      "contract: decode-side flushes remain", paths[0]);
-		check(count_occurrences(
 			      srcs[0], "audio_playback_preconvert(") >= 3,
 		      "contract: bound stream conversion runs in main loop",
 		      paths[0]);
 		check(count_occurrences(
-			      srcs[0], "source->sample_rate = 48000U;") == 1,
-		      "contract: stream ISR source is preconverted bypass",
+			      srcs[0], "source->sample_rate = 48000U;") == 2,
+		      "contract: stream+media ISR source is preconverted bypass",
 		      paths[0]);
 		check(count_occurrences(
-			      srcs[0], "audio_pump_preconvert_stage(") == 1,
+			      srcs[0], "audio_pump_preconvert_stage(") == 2,
 		      "contract: ISR stages converted ring, not native PCM",
+		      paths[0]);
+		check(count_occurrences(
+			      srcs[0], "audio_pump_media_source_fill(") >= 2,
+		      "contract: media conversion runs in main loop",
+		      paths[0]);
+		check(count_occurrences(
+			      srcs[0], "audio_pump_media_view_retire(") >= 1,
+		      "contract: media retirement maps view periods exactly",
 		      paths[0]);
 		check(count_occurrences(
 			      srcs[0],

--- a/test/audio/audio_pump_media_view_test.c
+++ b/test/audio/audio_pump_media_view_test.c
@@ -62,6 +62,23 @@ int main(void)
 	/* Staged notes only move forward. */
 	audio_pump_media_view_note_staged(&view, 5U);
 	assert(view.src_staged == 2U * 3528U + 1000U);
+
+	/* Resume anchoring (PR #100 review): a resumed session's staged
+	 * cursor is nonzero; both view cursors must share that absolute
+	 * reference or the EOS clamp mixes references and the final padded
+	 * period retires a full period the session rejects. */
+	audio_pump_media_view_anchor(&view, 100U * 3528U);
+	audio_pump_media_view_note_staged(
+		&view, 100U * 3528U + 3528U + 1000U);
+	assert(audio_pump_media_view_retire(&view, 3840U) == 3528U);
+	/* The zero-padded EOS tail retires only the real 1000-byte span. */
+	assert(audio_pump_media_view_retire(&view, 3840U) == 1000U);
+	assert(view.src_retired ==
+	       100U * 3528U + 3528U + 1000U);
+	/* An inactive view cannot be anchored. */
+	audio_pump_media_view_reset(&view);
+	audio_pump_media_view_anchor(&view, 500U);
+	assert(view.src_staged == 0U && view.src_retired == 0U);
 	/* A drain-shaped burst retires the same total either way: three
 	 * single periods and one triple must agree (exactness, not drift). */
 	assert(audio_pump_media_view_begin(&view, 44100U, 2U));

--- a/test/audio/audio_pump_media_view_test.c
+++ b/test/audio/audio_pump_media_view_test.c
@@ -1,0 +1,75 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "audio_pump_media_view.h"
+
+int main(void)
+{
+	struct audio_pump_media_view view;
+
+	/* Admission: 44.1 kHz stereo MP2 (the ZZPlay case, drivers#83). */
+	assert(audio_pump_media_view_begin(&view, 44100U, 2U));
+	assert(view.active);
+	assert(view.src_period_bytes == 3528U); /* 882 frames * 2ch * 2B */
+	assert(view.src_rate == 44100U);
+
+	/* 48 kHz stays on the memcpy-only direct path: no view. */
+	assert(!audio_pump_media_view_begin(&view, 48000U, 2U));
+	/* Rates without a whole-frame 20 ms period are refused. */
+	assert(!audio_pump_media_view_begin(&view, 44101U, 2U));
+	assert(!audio_pump_media_view_begin(&view, 0U, 2U));
+	assert(!audio_pump_media_view_begin(&view, 44100U, 0U));
+	assert(!audio_pump_media_view_begin(&view, 44100U, 3U));
+	/* A period longer than the converted 960 frames cannot map. */
+	assert(!audio_pump_media_view_begin(&view, 50000U, 2U));
+
+	/* Mono sources map their own (narrower) period. */
+	assert(audio_pump_media_view_begin(&view, 44100U, 1U));
+	assert(view.src_period_bytes == 1764U);
+
+	/* Retirement is exact whole-period math and never loses frames:
+	 * one view period (3840 B) retires exactly one source period. */
+	assert(audio_pump_media_view_begin(&view, 44100U, 2U));
+	audio_pump_media_view_note_staged(&view, 3U * 3528U);
+	assert(audio_pump_media_view_retire(&view, 3840U) == 3528U);
+	assert(audio_pump_media_view_retire(&view, 2U * 3840U) == 2U * 3528U);
+	assert(view.src_retired == 3U * 3528U);
+
+	/* Non-period deltas (caller bugs) map to zero and change nothing. */
+	assert(audio_pump_media_view_retire(&view, 1U) == 0U);
+	assert(audio_pump_media_view_retire(&view, 0U) == 0U);
+	assert(view.src_retired == 3U * 3528U);
+
+	/* An inactive view retires nothing. */
+	audio_pump_media_view_reset(&view);
+	assert(!view.active);
+	assert(audio_pump_media_view_retire(&view, 3840U) == 0U);
+	assert(view.src_retired == 0U);
+
+
+	/* The final converted period can be zero-padded: retirement is
+	 * clamped to what the converter really consumed, so the EOS tail
+	 * retires exactly and drain completes instead of wedging the
+	 * session a period short. */
+	assert(audio_pump_media_view_begin(&view, 44100U, 2U));
+	audio_pump_media_view_note_staged(&view, 2U * 3528U + 1000U);
+	assert(audio_pump_media_view_retire(&view, 3840U) == 3528U);
+	assert(audio_pump_media_view_retire(&view, 2U * 3840U) ==
+	       3528U + 1000U);
+	assert(view.src_retired == 2U * 3528U + 1000U);
+	/* Nothing staged beyond retirement: further retires map to zero. */
+	assert(audio_pump_media_view_retire(&view, 3840U) == 0U);
+	/* Staged notes only move forward. */
+	audio_pump_media_view_note_staged(&view, 5U);
+	assert(view.src_staged == 2U * 3528U + 1000U);
+	/* A drain-shaped burst retires the same total either way: three
+	 * single periods and one triple must agree (exactness, not drift). */
+	assert(audio_pump_media_view_begin(&view, 44100U, 2U));
+	audio_pump_media_view_note_staged(&view, 3U * 3528U);
+	(void)audio_pump_media_view_retire(&view, 3840U);
+	(void)audio_pump_media_view_retire(&view, 3840U);
+	(void)audio_pump_media_view_retire(&view, 3840U);
+	assert(view.src_retired == 3U * 3528U);
+
+	return 0;
+}

--- a/test/audio/audio_pump_preconvert_test.c
+++ b/test/audio/audio_pump_preconvert_test.c
@@ -33,7 +33,7 @@ static void test_44100_matches_converter(void)
 	uint8_t input[882U * 4U];
 	uint8_t ring[RING_BYTES];
 	int16_t expected[960U * 2U];
-	uint32_t consumed = 0U;
+	uint64_t consumed = 0U;
 	uint32_t i;
 
 	for (i = 0U; i < 882U * 2U; i++)
@@ -70,7 +70,7 @@ static void test_48000_is_bit_exact(void)
 	struct audio_pump_preconvert_source source;
 	uint8_t input[AUDIO_PUMP_PRECONVERT_PERIOD_BYTES];
 	uint8_t ring[RING_BYTES];
-	uint32_t consumed = 0U;
+	uint64_t consumed = 0U;
 	uint32_t i;
 
 	for (i = 0U; i < sizeof(input); i++)
@@ -96,7 +96,7 @@ static void test_shortage_waits_and_tail_drains(void)
 	struct audio_pump_preconvert_source source;
 	uint8_t input[100U * 4U];
 	uint8_t ring[RING_BYTES];
-	uint32_t consumed = 0U;
+	uint64_t consumed = 0U;
 
 	memset(input, 0x35, sizeof(input));
 	memset(&source, 0, sizeof(source));
@@ -123,9 +123,9 @@ static void test_cursor_wrap_rebases_both_cursors(void)
 	struct audio_pump_preconvert_source source;
 	uint8_t input[AUDIO_PUMP_PRECONVERT_PERIOD_BYTES];
 	uint8_t ring[RING_BYTES];
-	uint32_t consumed = 0U;
+	uint64_t consumed = 0U;
 	uint32_t base;
-	uint32_t produced_before;
+	uint64_t produced_before;
 	uint32_t staged_before;
 
 	memset(input, 0x5a, sizeof(input));


### PR DESCRIPTION
## Summary

ZZPlay's windowed video no longer flickers while its audio plays through AX. The 44.1 kHz polyphase conversion for a bound media session ran inside the audio formatter ISR on core 0; that ISR shares the core and GIC priority with the vblank handler, so every collision pushed the per-vblank overlay rearm into active video, where the VDMA reset invalidates both line-buffer banks and the overlay drops out until the re-seek refills.

Media sessions now stage 48 kHz PCM through the existing preconvert ring on the main loop — the same architecture bound audio streams already use — so the ISR fill only copies. The exact view-to-session cursor mapping lives in `audio_pump_media_view.h`: whole 20 ms periods map exactly (882 frames to 960), retirement is clamped to what the converter really consumed so the zero-padded end-of-stream tail retires exactly, and the preconvert owner is tagged by kind because media and stream session ids are independent namespaces.

The per-vblank overlay rearm reset stays unconditional and now says why: it is the overlay stream's phase lock to the raster (an unlocked stream drifts and shows wrong/black rows). A gating experiment on hardware confirmed the drift artifacts.

## Validation

- All host suites green (audio, media, video, rtg, scheduler, config, aperture) with new coverage: `audio_pump_media_view_test` pins admission, exact period math, EOS clamp, and staged monotonicity; the fabric source-contract now requires media conversion to stay on the main loop.
- ARM firmware builds (both bitstream flavors); flash-tested on an A4000/Z3 at 1280x1024/32: the flicker with an MPEG-1 video plus AX audio is gone, and `--audio=ahi`/`--audio=none` behavior is unchanged.

Related: BlitterStudio/zz9000-drivers#83 (windowed flicker half; the fullscreen half is fixed by the zz9000-sdk companion PR)

