### PR TITLE
fix(video): prevent NTSC capture wrap from stale native pan write

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
@@ -458,15 +458,18 @@ void isr_video(void *dummy) {
 		if (vblank && overlay_scanout_active()) {
 			/* Same geometry discipline as the mode-change trigger:
 			 * a driver pan write that landed inside the capture area
-			 * must not become the scanout base or stride here; both
-			 * are firmware-owned in this region. */
-			if (vs.framebuffer_pan_offset >= 0x00dff000 &&
-			    !video_videocap_output_profile_centered(
-					(uint32_t)videocap_output_profile)) {
+			 * must not become the scanout stride (any profile) or the
+			 * scanout base (non-centered; centered keeps its
+			 * driver-provided canvas base). */
+			if (vs.framebuffer_pan_offset >= 0x00dff000) {
 				vs.framebuffer_pan_width = 0;
-				vs.framebuffer_pan_offset =
-					videocap_scanout_pan_offset(videocap_ntsc,
-						videocap_full_width);
+				if (!video_videocap_output_profile_centered(
+						(uint32_t)videocap_output_profile)) {
+					vs.framebuffer_pan_offset =
+						videocap_scanout_pan_offset(
+							videocap_ntsc,
+							videocap_full_width);
+				}
 			}
 			init_vdma(vs.vmode_hsize, vs.vmode_vsize, vs.vmode_hdiv,
 					vs.vmode_vdiv,
@@ -562,13 +565,14 @@ void isr_video(void *dummy) {
 					/* The mode-change trigger above may have run
 					 * several vblanks earlier; a host driver pan
 					 * write that landed since then must not leak
-					 * into this VDMA restart — neither its origin
-					 * nor the RTG stride width. Re-derive both (the
-					 * centered profiles keep the driver-provided
-					 * canvas base). */
+					 * into this VDMA restart. The stride width is
+					 * firmware-owned for every profile (the trigger
+					 * clears it unconditionally); the origin is
+					 * re-derived for non-centered profiles only —
+					 * centered keeps its driver-provided base. */
+					vs.framebuffer_pan_width = 0;
 					if (!video_videocap_output_profile_centered(
 							(uint32_t)videocap_output_profile)) {
-						vs.framebuffer_pan_width = 0;
 						vs.framebuffer_pan_offset =
 							videocap_scanout_pan_offset(
 								videocap_ntsc,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
@@ -456,12 +456,14 @@ void isr_video(void *dummy) {
 		// can proceed (the overlay present hook does not run in this
 		// branch and would otherwise stay latched as presenting)
 		if (vblank && overlay_scanout_active()) {
-			/* Same origin discipline as the mode-change trigger: a
-			 * stale driver native-pan write inside the capture area
-			 * must not become the scanout base here either. */
+			/* Same geometry discipline as the mode-change trigger:
+			 * a driver pan write that landed inside the capture area
+			 * must not become the scanout base or stride here; both
+			 * are firmware-owned in this region. */
 			if (vs.framebuffer_pan_offset >= 0x00dff000 &&
 			    !video_videocap_output_profile_centered(
 					(uint32_t)videocap_output_profile)) {
+				vs.framebuffer_pan_width = 0;
 				vs.framebuffer_pan_offset =
 					videocap_scanout_pan_offset(videocap_ntsc,
 						videocap_full_width);
@@ -558,13 +560,15 @@ void isr_video(void *dummy) {
 					vs.scalemode = (int)videocap_scalemode;
 					vs.vmode_vdiv = (int)video_vertical_scale_factor(videocap_scalemode);
 					/* The mode-change trigger above may have run
-					 * several vblanks earlier; a host driver native-pan
-					 * write that landed since then must not leak into
-					 * this VDMA restart. Re-derive the origin (the
+					 * several vblanks earlier; a host driver pan
+					 * write that landed since then must not leak
+					 * into this VDMA restart — neither its origin
+					 * nor the RTG stride width. Re-derive both (the
 					 * centered profiles keep the driver-provided
 					 * canvas base). */
 					if (!video_videocap_output_profile_centered(
 							(uint32_t)videocap_output_profile)) {
+						vs.framebuffer_pan_width = 0;
 						vs.framebuffer_pan_offset =
 							videocap_scanout_pan_offset(
 								videocap_ntsc,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
@@ -50,10 +50,15 @@ void _clip_hw_sprite(int16_t offset_x, int16_t offset_y);
 static void video_mode_init_internal(int mode, int scalemode, int colormode,
 		int skip_vdma, int output_profile);
 
-// FIXME integrate with memory map
-static int default_pan_offset_pal = 0x00e00000;
-static int default_pan_offset_ntsc = 0x00e00000;
-static int default_pan_offset_pal_800x600 = 0x00dff2f8;
+/* Capture-area scanout origin for the detected standard and requested
+ * base mode. One derivation for every capture-area VDMA start, so a
+ * stale legacy native-pan write from the host driver (its constant is
+ * tuned for PAL 800x600 only) can never wrap NTSC lines (#84). */
+static uint32_t videocap_scanout_pan_offset(int ntsc, int full_width)
+{
+	return video_videocap_scanout_pan_base((uint32_t)ntsc,
+		(uint32_t)full_width, (uint32_t)vs.videocap_video_mode);
+}
 
 static int isr_flush_count = 0;
 int vblank_count = 0;
@@ -140,7 +145,7 @@ void video_reset() {
 	vs.videocap_enabled_old = 0;
 	videocap_detection_reset();
 	vs.framebuffer_pan_width = 0;
-	vs.framebuffer_pan_offset = default_pan_offset_pal_800x600;
+	vs.framebuffer_pan_offset = VIDEO_VDMA_CAPTURE_PAN_PAL_800X600;
 	vs.split_request_pos = 0;
 
 	vs.sprite_colors[0] = 0x00ff00ff;
@@ -451,6 +456,16 @@ void isr_video(void *dummy) {
 		// can proceed (the overlay present hook does not run in this
 		// branch and would otherwise stay latched as presenting)
 		if (vblank && overlay_scanout_active()) {
+			/* Same origin discipline as the mode-change trigger: a
+			 * stale driver native-pan write inside the capture area
+			 * must not become the scanout base here either. */
+			if (vs.framebuffer_pan_offset >= 0x00dff000 &&
+			    !video_videocap_output_profile_centered(
+					(uint32_t)videocap_output_profile)) {
+				vs.framebuffer_pan_offset =
+					videocap_scanout_pan_offset(videocap_ntsc,
+						videocap_full_width);
+			}
 			init_vdma(vs.vmode_hsize, vs.vmode_vsize, vs.vmode_hdiv,
 					vs.vmode_vdiv,
 					(u32)vs.framebuffer + vs.framebuffer_pan_offset);
@@ -510,27 +525,17 @@ void isr_video(void *dummy) {
 						vs.videocap_full_width_applied = videocap_full_width;
 					}
 
+					vs.framebuffer_pan_width = 0;
+					vs.framebuffer_pan_offset = videocap_scanout_pan_offset(
+						videocap_ntsc, videocap_full_width);
 					if (videocap_ntsc) {
 						// NTSC
 						printf("videocap: ntsc\n");
-						vs.framebuffer_pan_width = 0;
-						vs.framebuffer_pan_offset = videocap_full_width ?
-							video_vdma_native_row_start(default_pan_offset_ntsc) :
-							default_pan_offset_ntsc;
 						init_videocap_video_mode(1, videocap_full_width,
 							videocap_output_profile);
 					} else {
 						// PAL
 						printf("videocap: pal\n");
-						vs.framebuffer_pan_width = 0;
-						if (videocap_full_width) {
-							vs.framebuffer_pan_offset =
-								video_vdma_native_row_start(default_pan_offset_pal);
-						} else if (vs.videocap_video_mode == ZZVMODE_800x600) {
-							vs.framebuffer_pan_offset = default_pan_offset_pal_800x600;
-						} else {
-							vs.framebuffer_pan_offset = default_pan_offset_pal;
-						}
 						init_videocap_video_mode(0, videocap_full_width,
 							videocap_output_profile);
 					}
@@ -552,6 +557,19 @@ void isr_video(void *dummy) {
 							(uint32_t)interlace);
 					vs.scalemode = (int)videocap_scalemode;
 					vs.vmode_vdiv = (int)video_vertical_scale_factor(videocap_scalemode);
+					/* The mode-change trigger above may have run
+					 * several vblanks earlier; a host driver native-pan
+					 * write that landed since then must not leak into
+					 * this VDMA restart. Re-derive the origin (the
+					 * centered profiles keep the driver-provided
+					 * canvas base). */
+					if (!video_videocap_output_profile_centered(
+							(uint32_t)videocap_output_profile)) {
+						vs.framebuffer_pan_offset =
+							videocap_scanout_pan_offset(
+								videocap_ntsc,
+								videocap_full_width);
+					}
 					videocap_area_clear();
 					video_formatter_write(video_formatter_scale_control(videocap_scalemode),
 					                      MNTVF_OP_SCALE);

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/video_vdma.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/video_vdma.h
@@ -2,6 +2,14 @@
 #define VIDEO_VDMA_H
 
 #include <stdint.h>
+#include "zz_video_modes.h"
+
+/* Framebuffer-relative base of the native capture area (matches the
+ * RTL's VIDEOCAP_ADDR write base) and the one legacy exception: the
+ * hand-tuned PAL 800x600 filtered scanout origin, which starts 0x2f8
+ * bytes (190 words) before the capture rows. */
+#define VIDEO_VDMA_CAPTURE_PAN_BASE          0x00e00000U
+#define VIDEO_VDMA_CAPTURE_PAN_PAL_800X600   0x00dff2f8U
 
 #define VIDEO_VDMA_WORD_BYTES 4U
 
@@ -20,6 +28,23 @@ static inline uint32_t video_vdma_line_bytes(uint32_t hsize, uint32_t hdiv)
 static inline uint32_t video_vdma_native_row_start(uint32_t capture_offset)
 {
 	return capture_offset;
+}
+
+/* Native-scanout origin inside the capture area. The pre-row constant is
+ * the tuned centering for the PAL 800x600 filtered profile ONLY. Every
+ * other combination must start at the capture row base: a driver's
+ * legacy native-pan write of the PAL constant with NTSC detected makes
+ * each fetched line begin 190 words before its capture row, wrapping the
+ * preceding row's tail across the left edge (zz9000-drivers #84). */
+static inline uint32_t video_videocap_scanout_pan_base(uint32_t ntsc,
+		uint32_t full_width, uint32_t base_mode)
+{
+	if (ntsc != 0U || full_width != 0U ||
+	    base_mode != ZZVMODE_800x600)
+		return video_vdma_native_row_start(
+			VIDEO_VDMA_CAPTURE_PAN_BASE);
+
+	return VIDEO_VDMA_CAPTURE_PAN_PAL_800X600;
 }
 
 static inline uint32_t video_vdma_stride_bytes(uint32_t hsize, uint32_t hdiv,

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
@@ -193,6 +193,7 @@ enum zz_reg_offsets {
 #define ZZ_FW_CAP_Z2_APERTURE_LAYOUT (1U << 2)
 #define ZZ_FW_CAP_VIDEOCAP_CENTERED_1080P (1U << 3)
 #define ZZ_FW_CAP_VIDEOCAP_CENTERED_1080P_50 (1U << 4)
+#define ZZ_FW_CAP_VIDEOCAP_SOURCE_SYNC (1U << 5)
 #define ZZ_FW_CAP_VIDEOCAP_SCANOUT_ORIGIN (1U << 6)
 /* The centered 1080p profiles are intentionally excluded here: firmware
  * advertises them dynamically only when the loaded bitstream exposes both

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/zz_regs.h
@@ -193,16 +193,22 @@ enum zz_reg_offsets {
 #define ZZ_FW_CAP_Z2_APERTURE_LAYOUT (1U << 2)
 #define ZZ_FW_CAP_VIDEOCAP_CENTERED_1080P (1U << 3)
 #define ZZ_FW_CAP_VIDEOCAP_CENTERED_1080P_50 (1U << 4)
-#define ZZ_FW_CAP_VIDEOCAP_SOURCE_SYNC (1U << 5)
+#define ZZ_FW_CAP_VIDEOCAP_SCANOUT_ORIGIN (1U << 6)
 /* The centered 1080p profiles are intentionally excluded here: firmware
  * advertises them dynamically only when the loaded bitstream exposes both
  * required paths (viewport layout AND full-rate capture). Bit 3 stays the
  * 60 Hz variant; bit 4 is the 50 Hz variant on the same eligibility. Bit 5
  * (the source-locked match pair: profile + virtual mode 0x100) additionally
- * requires the source-sync controller (REG3 bit 14) on top of bits 3/4. */
+ * requires the source-sync controller (REG3 bit 14) on top of bits 3/4.
+ *
+ * Bit 6 is static: the ISR re-derives the capture-area scanout origin and
+ * clears the RTG pan width at every capture VDMA restart, so a driver's
+ * legacy native-pan write can no longer displace or skew the picture
+ * (zz9000-drivers #84). Drivers gate the raw 0x00e00000 native pan on
+ * this bit; without it they keep writing the legacy tuned constant. */
 #define ZZ_FW_CAPABILITIES \
   (ZZ_FW_CAP_VIDEOCAP_PROFILE | ZZ_FW_CAP_VIDEOCAP_LIVE | \
-   ZZ_FW_CAP_Z2_APERTURE_LAYOUT)
+   ZZ_FW_CAP_Z2_APERTURE_LAYOUT | ZZ_FW_CAP_VIDEOCAP_SCANOUT_ORIGIN)
 
 enum zz9k_card_features {
   CARD_FEATURE_NONE,

--- a/test/video/video_vdma_test.c
+++ b/test/video/video_vdma_test.c
@@ -102,6 +102,48 @@ static int test_native_scanout_starts_at_capture_row(void)
 	return 0;
 }
 
+static int test_native_scanout_pan_base(void)
+{
+	/* The 0x00dff2f8 origin is the tuned exception for PAL 800x600
+	 * filtered only. Every other combination must start at the capture
+	 * row base 0x00e00000: the host driver's legacy native-pan write
+	 * carries the PAL constant unconditionally, and scanning 720x480
+	 * lines from 190 words before their capture rows wraps the left
+	 * edge of every line (zz9000-drivers #84). */
+	if (!expect_u32("ntsc filtered 800x600 base",
+	                video_videocap_scanout_pan_base(1U, 0U,
+	                ZZVMODE_800x600), 0x00e00000U)) {
+		return 1;
+	}
+	if (!expect_u32("ntsc filtered 720x576 base",
+	                video_videocap_scanout_pan_base(1U, 0U,
+	                ZZVMODE_720x576), 0x00e00000U)) {
+		return 2;
+	}
+	if (!expect_u32("ntsc full width",
+	                video_videocap_scanout_pan_base(1U, 1U,
+	                ZZVMODE_800x600), 0x00e00000U)) {
+		return 3;
+	}
+	if (!expect_u32("pal full width",
+	                video_videocap_scanout_pan_base(0U, 1U,
+	                ZZVMODE_800x600), 0x00e00000U)) {
+		return 4;
+	}
+	if (!expect_u32("pal filtered 720x576 base",
+	                video_videocap_scanout_pan_base(0U, 0U,
+	                ZZVMODE_720x576), 0x00e00000U)) {
+		return 5;
+	}
+	if (!expect_u32("pal filtered 800x600 tuned origin preserved",
+	                video_videocap_scanout_pan_base(0U, 0U,
+	                ZZVMODE_800x600), 0x00dff2f8U)) {
+		return 6;
+	}
+
+	return 0;
+}
+
 static int test_centered_output_keeps_native_content_geometry(uint32_t profile)
 {
 	struct video_videocap_geometry full =
@@ -161,6 +203,10 @@ int main(void)
 	result = test_native_scanout_starts_at_capture_row();
 	if (result)
 		return 70 + result;
+
+	result = test_native_scanout_pan_base();
+	if (result)
+		return 80 + result;
 
 	result = test_centered_output_keeps_native_content_geometry(
 		ZZ_VIDEOCAP_OUTPUT_CENTERED_1080P_60);


### PR DESCRIPTION
NTSC native screens no longer wrap horizontally when the RTG driver is loaded: the firmware now re-derives the capture-area scanout origin at every capture-area VDMA restart, so a stale pan write from the driver can no longer reach the scanout.

The driver writes pan `0x00dff2f8` at every native-screen switch for 800x600-family scandoubler modes — a constant hand-tuned for PAL 800x600 filtered output that points 190 words before the capture rows at `0x00e00000`. On NTSC the scandoubler scans 720x480 from 720-word capture rows. The firmware corrected that origin only inside the mode-change trigger; at a normal boot the trigger fires during the boot screen, the driver overwrites the pan when Workbench opens the laced NTSC screen, and the interlace 0->1 VDMA restart then scans each line 190 words early, wrapping the previous row's tail across the left edge. An RTG/native cycle re-arms the trigger and heals it — exactly what the reporter observed.

- The origin choice is centralized in `video_videocap_scanout_pan_base()`; the mode-change trigger, the interlace reconfiguration, and the overlay-scanout release all share one derivation. PAL 800x600 keeps its tuned origin; centered profiles keep the driver-provided canvas base.
- Driver versions as far back as 2.2 carried the same write (behind an ENV var); this fix makes the firmware correct against every released driver, so no matched-stack constraint is introduced.

## Validation

- Full `test/video` host suite green, including six new cases in `video_vdma_test.c` pinning the per-standard origin contract (NTSC / full-width / 720x576 -> capture base; PAL 800x600 -> tuned origin).
- `video.c` passes `-Wall -Wextra -fsyntax-only` against the in-repo BSP headers.
- Hardware confirmation on NTSC Hires/Laced with default `filtered_60` pending with the reporter.

## Related

- Related: BlitterStudio/zz9000-drivers#84 (horizontal wrap; reporter retest pending before close)
