### PR TITLE
fix(video): heal the centered capture scanout origin on NTSC

### DIFF
--- a/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
@@ -458,18 +458,18 @@ void isr_video(void *dummy) {
 		if (vblank && overlay_scanout_active()) {
 			/* Same geometry discipline as the mode-change trigger:
 			 * a driver pan write that landed inside the capture area
-			 * must not become the scanout stride (any profile) or the
-			 * scanout base (non-centered; centered keeps its
-			 * driver-provided canvas base). */
+			 * must not become the scanout stride or the scanout base
+			 * for any profile. The origin helper already encodes the
+			 * per-standard centered contract — centered profiles keep
+			 * base mode ZZVMODE_800x600, so PAL centered retains the
+			 * tuned origin and NTSC centered takes the capture row
+			 * base instead of the stale PAL constant (#84). */
 			if (vs.framebuffer_pan_offset >= 0x00dff000) {
 				vs.framebuffer_pan_width = 0;
-				if (!video_videocap_output_profile_centered(
-						(uint32_t)videocap_output_profile)) {
-					vs.framebuffer_pan_offset =
-						videocap_scanout_pan_offset(
-							videocap_ntsc,
-							videocap_full_width);
-				}
+				vs.framebuffer_pan_offset =
+					videocap_scanout_pan_offset(
+						videocap_ntsc,
+						videocap_full_width);
 			}
 			init_vdma(vs.vmode_hsize, vs.vmode_vsize, vs.vmode_hdiv,
 					vs.vmode_vdiv,
@@ -568,16 +568,15 @@ void isr_video(void *dummy) {
 					 * into this VDMA restart. The stride width is
 					 * firmware-owned for every profile (the trigger
 					 * clears it unconditionally); the origin is
-					 * re-derived for non-centered profiles only —
-					 * centered keeps its driver-provided base. */
+					 * re-derived for every profile too — the helper
+					 * returns the tuned PAL constant for centered
+					 * (base mode stays ZZVMODE_800x600) and the
+					 * capture row base for NTSC centered (#84). */
 					vs.framebuffer_pan_width = 0;
-					if (!video_videocap_output_profile_centered(
-							(uint32_t)videocap_output_profile)) {
-						vs.framebuffer_pan_offset =
-							videocap_scanout_pan_offset(
-								videocap_ntsc,
-								videocap_full_width);
-					}
+					vs.framebuffer_pan_offset =
+						videocap_scanout_pan_offset(
+							videocap_ntsc,
+							videocap_full_width);
 					videocap_area_clear();
 					video_formatter_write(video_formatter_scale_control(videocap_scalemode),
 					                      MNTVF_OP_SCALE);

--- a/test/video/video_vdma_test.c
+++ b/test/video/video_vdma_test.c
@@ -140,6 +140,23 @@ static int test_native_scanout_pan_base(void)
 	                ZZVMODE_800x600), 0x00dff2f8U)) {
 		return 6;
 	}
+	/* Centered profiles route through this same contract: their runtime
+	 * request keeps the default base mode ZZVMODE_800x600
+	 * (video_videocap_sanitize_runtime_mode), so the VDMA-restart heal
+	 * must derive NTSC centered from the capture row base — not the
+	 * stale PAL constant the driver writes — while PAL centered keeps
+	 * the tuned origin. These pins guard the base-mode default the
+	 * centered scanout origin depends on (the #84 centered residual). */
+	if (!expect_u32("ntsc centered origin",
+	                video_videocap_scanout_pan_base(1U, 0U,
+	                ZZVMODE_800x600), 0x00e00000U)) {
+		return 7;
+	}
+	if (!expect_u32("pal centered origin",
+	                video_videocap_scanout_pan_base(0U, 0U,
+	                ZZVMODE_800x600), 0x00dff2f8U)) {
+		return 8;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
## Summary

NTSC no longer wraps the left edge of the centered 1080p scandoubler profiles: every capture-area VDMA restart now re-derives the scanout origin for centered profiles too, instead of letting the RTG driver's legacy PAL-tuned pan write survive on them.

## Root cause

#102's heal re-derived the origin at each capture VDMA restart but deliberately skipped centered profiles. The driver still writes `0x00dff2f8` — the PAL 800x600 tuned constant, 190 words *before* the capture rows — for every centered mode at native-screen activation. On NTSC, each centered 1280-pixel content row therefore started 190 words early and wrapped the previous row's tail across the left edge: the same mechanism as the original #84 wrap, surviving only in the centered family (reported as "not 100% fixed" at 1920x1080 centered).

The correct value was already computed and discarded: centered profiles keep the default base mode `ZZVMODE_800x600`, so `video_videocap_scanout_pan_base()` returns the tuned constant for PAL centered (byte-identical to what the driver writes — no PAL change) and the capture row base for NTSC centered. The fix drops the two `!centered` guards; the pan-width reset was already unconditional, and the mode-change trigger site already derived unconditionally.

## Verification

- `test/video` host suite green, with new pins documenting the centered origin contract (NTSC centered → `0x00e00000`, PAL centered → `0x00dff2f8`).
- ARM cross-compile of the modified `video.c` clean.
- The ISR guard wiring itself has no host seam (ISR-internal state); that missing seam is recorded here — on-hardware confirmation is the reporter's retest of 1920x1080 centered on NTSC Hires/Hires Laced.

Related: BlitterStudio/zz9000-drivers#84
