### PR TITLE
fix(video): speed up same-timing RTG/native switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,14 @@ fallback also applies when another configuration window saves a stored
 unsupported profile. Older firmware ignores an unknown profile token,
 which is not a guaranteed `full_60` fallback for hand-edited old stacks.
 
+RTG/native switches keep the HDMI signal running when the complete output
+timing is unchanged; framebuffer layout, scaling and pixel format still update.
+For example, centered native 60 Hz and 1920x1080 RTG using the same preset
+do not need transmitter or pixel-clock retraining. Matching resolution alone
+is not enough: different refresh rates or sync timings still require an output
+mode change. Entering `centered_1080p_match` also retains its safe source-phase
+acquisition described below.
+
 The existing `full_exact` profile selects fixed PAL/NTSC timing
 approximations (about 49.93/59.95 Hz); it does not phase-lock to the input.
 The experimental `centered_1080p_match` profile instead tracks the captured

--- a/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
+++ b/ZZ9000_proto.sdk/ZZ9000OS/src/video.c
@@ -762,6 +762,10 @@ void pixelclock_init_2(struct zz_video_mode *mode) {
 
 static void video_mode_init_internal(int mode, int scalemode, int colormode,
 		int skip_vdma, int output_profile) {
+	/* Keep a value snapshot: custom mode slots can be edited in place, and
+	 * RTG/native layouts can share output timing despite different mode IDs. */
+	static struct zz_video_mode output_mode;
+	static int output_mode_valid;
 	printf("video_mode_init: %d color: %d scale: %d\n", mode, colormode, scalemode);
 
 	// reset interlace tracking
@@ -787,6 +791,22 @@ static void video_mode_init_internal(int mode, int scalemode, int colormode,
 		hdiv *= 2;
 
 	struct zz_video_mode *vmode = &preset_video_modes[mode];
+	int clock_unchanged = output_mode_valid &&
+		output_mode.mul == vmode->mul && output_mode.div == vmode->div &&
+		output_mode.div2 == vmode->div2 &&
+		(XClk_Wiz_ReadReg(XPAR_CLK_WIZ_0_BASEADDR,
+			CLK_WIZ_STATUS_OFFSET) & CLK_WIZ_STATUS_LOCKED) &&
+		!(XClk_Wiz_ReadReg(XPAR_CLK_WIZ_0_BASEADDR,
+			CLK_WIZ_RECONFIG_OFFSET) & CLK_WIZ_RECONFIG_LOAD);
+	int output_unchanged = clock_unchanged &&
+		output_mode.hres == vmode->hres && output_mode.vres == vmode->vres &&
+		output_mode.hstart == vmode->hstart && output_mode.hend == vmode->hend &&
+		output_mode.hmax == vmode->hmax &&
+		output_mode.vstart == vmode->vstart && output_mode.vend == vmode->vend &&
+		output_mode.vmax == vmode->vmax &&
+		output_mode.polarity == vmode->polarity &&
+		output_mode.phz == vmode->phz && output_mode.vhz == vmode->vhz &&
+		output_mode.hdmi == vmode->hdmi;
 	uint32_t content_hres = (uint32_t)vmode->hres;
 	uint32_t content_vres = (uint32_t)vmode->vres;
 	uint32_t dimensions_control = ((uint32_t)vmode->vres << 16) |
@@ -829,13 +849,17 @@ static void video_mode_init_internal(int mode, int scalemode, int colormode,
 	video_formatter_write(video_formatter_scale_control((uint32_t)scalemode),
 	                      MNTVF_OP_SCALE);
 	video_formatter_write(colormode, MNTVF_OP_COLORMODE);
-	/* Power down TMDS and publish the new timing metadata before changing
-	 * the live pixel clock.  This is a lightweight mode update, not the old
-	 * 16ms transmitter reset that broke native-video switching in the ISR. */
-	hdmi_ctrl_prepare_mode(vmode);
+	/* Layout/color changes must not interrupt an unchanged output signal:
+	 * a TMDS power-down forces receiver reacquisition even at the same
+	 * resolution. Real timing changes retain the established retrain path. */
+	if (!output_unchanged)
+		hdmi_ctrl_prepare_mode(vmode);
 
-	// Now safe to switch the pixel clock — VGA counters already have new geometry.
-	pixelclock_init_2(vmode);
+	/* Different timings can share a PLL (e.g. 1080p50/60). Keep it running
+	 * when already locked; otherwise the new geometry is in place before
+	 * reloading it, as required by the formatter's counter pipeline. */
+	if (!clock_unchanged)
+		pixelclock_init_2(vmode);
 
 	if (!skip_vdma) {
 		init_vdma(content_hres, content_vres, hdiv, vdiv,
@@ -848,7 +872,11 @@ static void video_mode_init_internal(int mode, int scalemode, int colormode,
 	/* A mode change is also the fail-safe wake path: never leave a display
 	 * stranded with one or both syncs suppressed after reprogramming timing. */
 	video_set_dpms(ZZ_DPMS_ON);
-	hdmi_ctrl_enable_output();
+	if (!output_unchanged)
+		hdmi_ctrl_enable_output();
+
+	output_mode = *vmode;
+	output_mode_valid = 1;
 
 	vs.vmode_hsize = content_hres;
 	vs.vmode_vsize = content_vres;

--- a/test/video/Makefile
+++ b/test/video/Makefile
@@ -1,6 +1,11 @@
 CC ?= cc
 CFLAGS ?= -O2 -g -Wall -Wextra
 PYTHON ?= python3
+ifeq ($(shell uname -s),Darwin)
+MODE_SWITCH_LDFLAGS := -Wl,-dead_strip
+else
+MODE_SWITCH_LDFLAGS := -Wl,--gc-sections
+endif
 
 SRC_DIR := ../../ZZ9000_proto.sdk/ZZ9000OS/src
 BUILD_DIR := build
@@ -10,6 +15,7 @@ TARGETS := \
 	$(BUILD_DIR)/video_scale_test \
 	$(BUILD_DIR)/videocap_control_test \
 	$(BUILD_DIR)/video_mode_pll_test \
+	$(BUILD_DIR)/video_mode_switch_test \
 	$(BUILD_DIR)/overlay_color_test \
 	$(BUILD_DIR)/overlay_schedule_test \
 	$(BUILD_DIR)/overlay_hw_test
@@ -25,6 +31,7 @@ test: $(TARGETS)
 	$(BUILD_DIR)/video_scale_test
 	$(BUILD_DIR)/videocap_control_test
 	$(BUILD_DIR)/video_mode_pll_test
+	$(BUILD_DIR)/video_mode_switch_test
 	$(BUILD_DIR)/overlay_color_test
 	$(BUILD_DIR)/overlay_schedule_test
 	$(BUILD_DIR)/overlay_hw_test
@@ -47,6 +54,20 @@ $(BUILD_DIR)/video_mode_pll_test: video_mode_pll_test.c \
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CPPFLAGS) $(CFLAGS) -o $@ \
 		video_mode_pll_test.c $(SRC_DIR)/zz_video_modes.c -lm
+
+$(BUILD_DIR)/video_mode_switch_test: video_mode_switch_test.c \
+		stubs/xil_io.h $(SRC_DIR)/video.c $(SRC_DIR)/video.h \
+		$(SRC_DIR)/video_scale.h $(SRC_DIR)/video_vdma.h \
+		$(SRC_DIR)/hdmi.c $(SRC_DIR)/hdmi.h \
+		$(SRC_DIR)/zz_video_modes.c $(SRC_DIR)/zz_video_modes.h
+	@mkdir -p $(BUILD_DIR)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -Istubs -I$(BSP_INCLUDE) \
+		-DXIL_IO_H -include stubs/xil_io.h \
+		-include xparameters.h -include xil_printf.h \
+		-ffunction-sections -fdata-sections \
+		-Wno-pointer-to-int-cast -Wno-int-to-pointer-cast \
+		-o $@ video_mode_switch_test.c $(SRC_DIR)/hdmi.c \
+		$(SRC_DIR)/zz_video_modes.c $(MODE_SWITCH_LDFLAGS)
 
 $(BUILD_DIR)/overlay_color_test: overlay_color_test.c $(SRC_DIR)/overlay_color.h
 	@mkdir -p $(BUILD_DIR)

--- a/test/video/video_mode_switch_test.c
+++ b/test/video/video_mode_switch_test.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026, Dimitris Panokostas <midwan@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Run the production mode transaction against simulated MMIO/I2C peripherals.
+ * A same-timing RTG/native switch must not remove the monitor's signal; real
+ * timing changes and a lost PLL lock must still take the retraining path.
+ */
+#include <assert.h>
+#include <string.h>
+#include "xparameters.h"
+#include "xil_printf.h"
+#include "xiicps.h"
+#include "../../ZZ9000_proto.sdk/ZZ9000OS/src/video.c"
+
+static unsigned clock_reloads, tmds_interruptions;
+static unsigned delay_us;
+static uint32_t clock_locked = 1, clock_load;
+static uint8_t transmitter[256], i2c_register;
+static uint32_t formatter_data, formatter_ops[32];
+static XAxiVdma_DmaSetup dma_setup;
+static unsigned dma_starts;
+
+void test_xil_out32(uintptr_t address, uint32_t value)
+{
+	if (address == XPAR_CLK_WIZ_0_BASEADDR + CLK_WIZ_RECONFIG_OFFSET) {
+		++clock_reloads;
+		clock_locked = 1;
+		clock_load = 0;
+	} else if (address == MNTZ_BASE_ADDR + MNTZORRO_REG3) {
+		formatter_data = value;
+	} else if (address == MNTZ_BASE_ADDR + MNTZORRO_REG2 &&
+	           (value & 0x80000000U)) {
+		formatter_ops[value & 31U] = formatter_data;
+	}
+}
+
+uint32_t test_xil_in32(uintptr_t address)
+{
+	if (address == XPAR_CLK_WIZ_0_BASEADDR + CLK_WIZ_STATUS_OFFSET)
+		return clock_locked;
+	if (address == XPAR_CLK_WIZ_0_BASEADDR + CLK_WIZ_RECONFIG_OFFSET)
+		return clock_load;
+	return 0;
+}
+
+uint32_t smp_local_irq_save(void) { return 0; }
+void smp_local_irq_restore(uint32_t state) { (void)state; }
+void usleep(unsigned long useconds) { delay_us += useconds; }
+
+u32 XClk_Wiz_CfgInitialize(XClk_Wiz *instance, XClk_Wiz_Config *config,
+		UINTPTR address)
+{
+	(void)instance; (void)config; (void)address;
+	return XST_SUCCESS;
+}
+
+XAxiVdma_Config *XAxiVdma_LookupConfig(u16 id)
+{
+	static XAxiVdma_Config config;
+	(void)id;
+	return &config;
+}
+int XAxiVdma_CfgInitialize(XAxiVdma *instance, XAxiVdma_Config *config,
+		UINTPTR address)
+{
+	(void)instance; (void)config; (void)address;
+	return XST_SUCCESS;
+}
+int XAxiVdma_DmaConfig(XAxiVdma *instance, u16 direction,
+		XAxiVdma_DmaSetup *config)
+{
+	(void)instance; (void)direction;
+	dma_setup = *config;
+	return XST_SUCCESS;
+}
+int XAxiVdma_DmaSetBufferAddr(XAxiVdma *instance, u16 direction,
+		UINTPTR *addresses)
+{
+	(void)instance; (void)direction; (void)addresses;
+	return XST_SUCCESS;
+}
+int XAxiVdma_DmaStart(XAxiVdma *instance, u16 direction)
+{
+	(void)instance; (void)direction;
+	++dma_starts;
+	return XST_SUCCESS;
+}
+
+XIicPs_Config *XIicPs_LookupConfig(u16 id)
+{
+	static XIicPs_Config config;
+	(void)id;
+	return &config;
+}
+s32 XIicPs_CfgInitialize(XIicPs *instance, XIicPs_Config *config, u32 address)
+{
+	(void)instance; (void)config; (void)address;
+	return XST_SUCCESS;
+}
+s32 XIicPs_BusIsBusy(XIicPs *instance) { (void)instance; return 0; }
+s32 XIicPs_SelfTest(XIicPs *instance) { (void)instance; return XST_SUCCESS; }
+s32 XIicPs_SetSClk(XIicPs *instance, u32 rate)
+{
+	(void)instance; (void)rate;
+	return XST_SUCCESS;
+}
+s32 XIicPs_MasterSendPolled(XIicPs *instance, u8 *data, s32 count, u16 address)
+{
+	(void)instance; (void)address;
+	i2c_register = data[0];
+	if (count == 2) {
+		transmitter[i2c_register] = data[1];
+		if (i2c_register == 0x1a && (data[1] & 0x10))
+			++tmds_interruptions;
+	}
+	return XST_SUCCESS;
+}
+s32 XIicPs_MasterRecvPolled(XIicPs *instance, u8 *data, s32 count, u16 address)
+{
+	(void)instance; (void)count; (void)address;
+	data[0] = transmitter[i2c_register];
+	return XST_SUCCESS;
+}
+
+static void clear_measurements(void)
+{
+	clock_reloads = tmds_interruptions = delay_us = dma_starts = 0;
+}
+
+int main(void)
+{
+	/* Cold start must initialize the physical output. */
+	video_mode_init(ZZVMODE_1920x1080_60, 0, MNTVA_COLOR_16BIT565);
+	assert(clock_reloads == 1 && tmds_interruptions == 1);
+
+	/* Native has the same 1080p canvas, but a centered x4 capture layout. */
+	clear_measurements();
+	init_videocap_video_mode(0, 1, ZZ_VIDEOCAP_OUTPUT_CENTERED_1080P_60);
+	printf("RTG -> native, same timing: PLL reloads=%u TMDS interruptions=%u explicit waits=%u us\n",
+		clock_reloads, tmds_interruptions, delay_us);
+	fflush(stdout);
+	assert(clock_reloads == 0 && tmds_interruptions == 0);
+	assert(vs.vmode_hsize == 1280 && vs.vmode_vsize == 1024 && vs.vmode_vdiv == 4);
+	assert(formatter_ops[MNTVF_OP_VIEWPORT_SIZE_COMMIT] == (1024U << 16 | 1280U));
+
+	/* DPMS is formatter-owned: the fast path must still restore syncs. */
+	video_set_dpms(ZZ_DPMS_OFF);
+	assert(formatter_ops[MNTVF_OP_DPMS] == ZZ_DPMS_OFF);
+	clear_measurements();
+	video_mode_init(ZZVMODE_1920x1080_60, 0, MNTVA_COLOR_16BIT565);
+	assert(clock_reloads == 0 && tmds_interruptions == 0);
+	assert(dma_starts == 1 && dma_setup.VertSizeInput == 1080 &&
+	       dma_setup.HoriSizeInput == 1920 * 2);
+	assert(formatter_ops[MNTVF_OP_COLORMODE] == MNTVA_COLOR_16BIT565);
+	assert(formatter_ops[MNTVF_OP_DPMS] == ZZ_DPMS_ON);
+
+	/* An identical custom mode is also safe, regardless of its mode ID. */
+	preset_video_modes[ZZVMODE_CUSTOM] = preset_video_modes[ZZVMODE_1920x1080_60];
+	clear_measurements();
+	video_mode_init(ZZVMODE_CUSTOM, 0, MNTVA_COLOR_32BIT);
+	assert(clock_reloads == 0 && tmds_interruptions == 0);
+
+	/* Editing a live custom slot must not mutate the applied snapshot. */
+	++preset_video_modes[ZZVMODE_CUSTOM].hstart;
+	clear_measurements();
+	video_mode_init(ZZVMODE_CUSTOM, 0, MNTVA_COLOR_32BIT);
+	assert(clock_reloads == 0 && tmds_interruptions == 1);
+
+	/* 1080p50 has the same PLL as 1080p60, but different line timing. */
+	clear_measurements();
+	video_mode_init(ZZVMODE_1920x1080_50, 0, MNTVA_COLOR_32BIT);
+	assert(clock_reloads == 0 && tmds_interruptions == 1);
+	assert(formatter_ops[MNTVF_OP_MAX] == (1125U << 16 | 2640U));
+
+	/* A failed/lost PLL must not be hidden by a matching software cache. */
+	clock_locked = 0;
+	clear_measurements();
+	video_mode_init(ZZVMODE_1920x1080_50, 0, MNTVA_COLOR_32BIT);
+	assert(clock_reloads == 1 && tmds_interruptions == 1);
+	clock_load = CLK_WIZ_RECONFIG_LOAD;
+	clear_measurements();
+	video_mode_init(ZZVMODE_1920x1080_50, 0, MNTVA_COLOR_32BIT);
+	assert(clock_reloads == 1 && tmds_interruptions == 1);
+
+	clear_measurements();
+	video_mode_init(ZZVMODE_800x600, 2, MNTVA_COLOR_32BIT);
+	assert(clock_reloads == 1 && tmds_interruptions == 1);
+	puts("video mode switch: PASS");
+	return 0;
+}


### PR DESCRIPTION
## Summary
RTG/native switching is now fast when both use the same output timing. Previously, even a framebuffer-layout change interrupted HDMI and reloaded the pixel-clock PLL, forcing unnecessary reacquisition.

The fast path compares a snapshot of the applied timing, not just the resolution or mode ID. Mutable custom-mode slots are handled correctly. Matching PLL settings are reused only while hardware reports LOCKED with no pending LOAD. Viewport, scaling, pixel format, DMA configuration and DPMS wake still update.

## Validation
Production `video.c` and `hdmi.c` replay with simulated MMIO/I2C, switching RTG 1080p60 to centered native 1080p60:

| Operation per switch | Before | After |
|---|---:|---:|
| HDMI power-downs | 1 | 0 |
| PLL reloads | 1 | 0 |
| Explicit firmware waits | 239 µs | 0 µs |

These are peripheral-operation counts and explicit waits, not total hardware latency.

- Regression fails before the fix and passes afterward; covers both directions, custom-mode mutation, equal timing under different mode IDs, DPMS wake, shared-clock timing changes and lost-lock recovery.
- Video and RTG host suites pass.
- Normal and legacy-bitstream ARM firmware targets build with Arm GNU 13.2.rel1; existing unrelated build warnings remain.
- Hardware testing confirms switching is **very fast with both RTG and centered native output at 1080p60**. The initially unchanged roughly two-second delay used native 50 Hz against RTG 60 Hz. Exact milliseconds were not measured.

## Scope
Matching resolution alone is insufficient: different refresh rates or sync timings retain HDMI retraining. Match Amiga source-phase acquisition and its framebuffer safety guard are unchanged. No FPGA, driver or public ABI changes are required.
